### PR TITLE
Fix for failure when retrying book covers

### DIFF
--- a/BookReaderIA/datanode/BookReaderImages.inc.php
+++ b/BookReaderIA/datanode/BookReaderImages.inc.php
@@ -821,6 +821,7 @@ class BookReaderImages
     }
     
     function createOutputImage($cmd, $tempFile, &$errorMessage) {
+        unlink($tempFile);
         $fullCmd = $cmd . " > " . $tempFile;
         system($fullCmd); // $$$ better error handling
         return file_exists($tempFile) && filesize($tempFile) > 0;


### PR DESCRIPTION
Book covers failed for Magic-Mouse-2010-12. The book reader preview tries with '-reduce 6', which fails. The retry failed due to reusing the same temp file. I added a call to 'unlink' to delete the temp file before the retry, now it works.
