### PR TITLE
improvement for single page items so that they will center vertically on...

### DIFF
--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -469,6 +469,16 @@ BookReader.prototype.drawLeafsOnePage = function() {
         leafTop += parseInt(this._getPageHeight(i)/this.reduce) +10;
     }
 
+    //center the page vertically
+    if (this.numLeafs == 1)
+    {
+        var containerHeight = $('#BRcontainer').height();
+        var zoomedHeight = parseInt((this._getPageHeight(i)/this.reduce));
+        if (zoomedHeight < containerHeight)
+            leafTop = parseInt(containerHeight/2 - zoomedHeight/2);
+         //alert("center image debug viewHeight " +viewHeight + " zoomedHedight " + zoomedHeight);
+    }
+
     //var viewWidth = $('#BRpageview').width(); //includes scroll bar width
     var viewWidth = $('#BRcontainer').attr('scrollWidth');
 


### PR DESCRIPTION
... the container when being zoomed out. makes it more useful for image viewing as well as book reading

I'm not sure if you're interested in this change, but I'm using the bookreader for single page images (just for zoom+pan) as well as long books and found that this change for centering the image vertically in the container when zooming out was useful, since the top alignment gives it an odd look.
