### PR TITLE
Demo BookReaderJSSimple.js change to return correct pages sides for RTL books

### DIFF
--- a/BookReaderDemo/BookReaderJSSimple.js
+++ b/BookReaderDemo/BookReaderJSSimple.js
@@ -31,10 +31,20 @@ br.getPageURI = function(index, reduce, rotate) {
 
 // Return which side, left or right, that a given page should be displayed on
 br.getPageSide = function(index) {
-    if (0 == (index & 0x1)) {
-        return 'R';
+    if ('rl' == this.pageProgression) {
+        // Right to Left
+        if (0 == (index & 0x1)) {
+            return 'L';
+        } else {
+            return 'R';
+        }
     } else {
-        return 'L';
+        // Left to right
+        if (0 == (index & 0x1)) {
+            return 'R';
+        } else {
+            return 'L';
+        }
     }
 }
 


### PR DESCRIPTION
The demo script `BookReaderDemo/BookReaderJSSimple.js` has code to handle 2-up index spreads for RTL books, but 2-up pages display incorrectly because `getPageSide()` always returns `L` for odd pages and `R` for odd pages. This commit corrects this, reversing the behavior when `br.pageProgression == 'rl'`.
