### PR TITLE
Allow query string parameters besides 'ui' in URL

### DIFF
--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -3358,7 +3358,7 @@ BookReader.prototype.initNavbar = function() {
     .bind('slidechange', function(event, ui) {
         self.updateNavPageNum(ui.value); // hiding now but will show later
         $("#pagenum").hide();
-        
+
         // recursion prevention for jumpToIndex
         if ( $(this).data('swallowchange') ) {
             $(this).data('swallowchange', false);


### PR DESCRIPTION
The current hack to allow the embedded navbar does not behave well when
there are other parameters passed through the URL.

This fix allows for there to be other parameters passed through the
query string.

For example of usage see any of the links at
http://yugntruf.org/arkhiv/ale-numern/
