### PR TITLE
Enhance Contrast: increase brightness filter from 120% to 200%

### DIFF
--- a/BookReader/BookReader.css
+++ b/BookReader/BookReader.css
@@ -1131,8 +1131,8 @@ div.share-social button.email-share-button { background-color: #c1c1c1; }
 
 body.high-contrast #BRpageview img,
 body.high-contrast #BRtwopageview img {
-  -webkit-filter: grayscale(100%) brightness(120%);
-  filter: grayscale(100%) brightness(120%);
+  -webkit-filter: grayscale(100%) brightness(200%);
+  filter: grayscale(100%) brightness(200%);
 }
 
 /* Forked from Bootstrap */


### PR DESCRIPTION
The default of 120% brightness gives a gray background instead of white in some books, for example,
https://archive.org/stream/bookofenchantmen00wred

Changing the brightness to 200% gives a high-quality white background for that book.

---

@rchrd2: Is there a reason why it's set to 120% before? Should I add a toggle to switch the amount of brightness enhancement?