### PR TITLE
Fix undeclared var "br" in Search bindings and function callbacks

### DIFF
--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -2932,6 +2932,7 @@ BookReader.prototype.getPageWidth2UP = function(index) {
 //______________________________________________________________________________
 BookReader.prototype.search = function(term, options) {
     options = options !== undefined ? options : {};
+    var br = this;
     var defaultOptions = {
         // {bool} (default=false) goToFirstResult - jump to the first result
         goToFirstResult: false,
@@ -2980,6 +2981,7 @@ BookReader.prototype.search = function(term, options) {
 // BRSearchCallback()
 //______________________________________________________________________________
 BookReader.prototype.BRSearchCallback = function(results, options) {
+    var br = this;
     br.searchResults = results;
     $('#BRnavpos .search').remove();
     $('#mobileSearchResultWrapper').empty(); // Empty mobile results
@@ -3005,6 +3007,7 @@ BookReader.prototype.BRSearchCallback = function(results, options) {
 // BRSearchCallbackErrorDesktop()
 //______________________________________________________________________________
 BookReader.prototype.BRSearchCallbackErrorDesktop = function(results, options) {
+    var br = this;
     var $el = $(br.popup);
     this._BRSearchCallbackError(results, $el, true);
 };
@@ -3018,7 +3021,7 @@ BookReader.prototype.BRSearchCallbackErrorMobile = function(results, options) {
 BookReader.prototype._BRSearchCallbackError = function(results, $el, fade, options) {
     $('#BRnavpos .search').remove();
     $('#mobileSearchResultWrapper').empty(); // Empty mobile results
-
+    var br = this;
     br.searchResults = results;
     var timeout = 2000;
     if (results.error) {
@@ -3690,6 +3693,7 @@ BookReader.prototype.updateNavIndexThrottled = BookReader.prototype.throttle(Boo
 
 
 BookReader.prototype.addSearchResult = function(queryString, pageIndex) {
+    var br = this;
     var pageNumber = this.getPageNum(pageIndex);
     var uiStringSearch = "Search result"; // i18n
     var uiStringPage = "Page"; // i18n
@@ -4227,7 +4231,8 @@ BookReader.prototype.initToolbar = function(mode, ui) {
       self.switchMode(self.constModeThumb);
     });
 
-
+    var br = this;
+    
     // Bind search form
     if (this.enableSearch) {
         $('.booksearch.desktop').submit(function(e) {


### PR DESCRIPTION
Same as pull: https://github.com/internetarchive/bookreader/pull/49 but for master branch after merge with V 2.x

There are a number of places where variable ```br``` is called (used as a local context alias to ```this```) without being declared or assumed as a global without being such. This  breaks the binding between Search form and their callbacks. The only other workaround without this patch is to copy the affected methods and reimplement them in your own extension.

Seems like this is because of some left overs/partial update from an upstream merge.

at #49 there where some concerns:

> 1. I think it would be better to change the br. to just this.

Probably in some places. The reason i did not go for that is that the current coding style( legacy but still present after the big merge) was to copy this context to a local scope var to ensure context separation and correct reference in case the overriding functions and build in callback scopes (even if partial) If ```br``` should be changed by this completely,  some extra testing and a global find and replace could be needed but also a few are not removable at all ( all the ones refered by (https://github.com/internetarchive/bookreader/pull/49/files#diff-4817873ad739c71edef8536417a6c04dR4234)

> 2. I am worried that this might not be correctly bound in some of these functions. Some of them appear to be callbacks, and might not have the right this.

Local tests passed: That is where the decision on keeping 1. as it is right now makes more sense: ```br``` is bound to this before the callbacks are defined. In that way, when used it is accessed as a local global with the correct parent context already saved as in https://github.com/internetarchive/bookreader/pull/49/files#diff-4817873ad739c71edef8536417a6c04dR4242 there the binding happens before the callback so br refers to the parent this. 

Interested parties:
@rchrd2 