### PR TITLE
Add options for loading tiles via AJAX and custom AJAX request headers

### DIFF
--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -663,6 +663,11 @@ BookReader.prototype.setupTooltips = function() {
     ;
 }
 
+// loadImage()
+//______________________________________________________________________________
+BookReader.prototype.loadImage = function(src, index, img) {
+    img.src = src;
+}
 
 // drawLeafs()
 //______________________________________________________________________________
@@ -789,11 +794,11 @@ BookReader.prototype.drawLeafsOnePage = function() {
             BRpageViewEl.appendChild(div);
 
             var img = document.createElement('img');
-            img.src = this._getPageURI(index, this.reduce, 0);
             img.className = 'BRnoselect BRonePageImage';
             img.style.width = width + 'px';
             img.style.height = height + 'px';
             div.appendChild(img);
+            this.loadImage(this._getPageURI(index, this.reduce, 0), index, img);
         }
 
         leafTop += height +10;
@@ -988,6 +993,7 @@ BookReader.prototype.drawLeafsThumbnail = function( seekIndex ) {
                     .addClass('BRlazyload')
                     // Store the URL of the image that will replace this one
                     .data('srcURL',  this._getPageURI(leaf, thumbReduce));
+                    .data('index', leaf);
                 $(link).append(img);
             }
         }
@@ -1084,11 +1090,11 @@ BookReader.prototype.lazyLoadImage = function (dummyImage) {
         })
         .attr({
             'width': $(dummyImage).width(),
-            'height': $(dummyImage).height(),
-            'src': $(dummyImage).data('srcURL')
+            'height': $(dummyImage).height()
         });
 
     // replace with the new img
+    this.loadImage($(dummyImage).data('srcURL'), $(dummyImage).data('index'), img);
     $(dummyImage).before(img).remove();
 
     img = null; // tidy up closure
@@ -2695,7 +2701,7 @@ BookReader.prototype.prefetchImg = function(index) {
             // Facing page at beginning or end, or beyond
             $(img).addClass('BRemptypage');
         }
-        img.src = pageURI;
+        this.loadImage(pageURI, index, img);
         img.uri = pageURI; // browser may rewrite src so we stash raw URI here
         this.prefetchedImgs[index] = img;
     }


### PR DESCRIPTION
## Overview

This PR is based in spirit on https://github.com/openseadragon/openseadragon/pull/1055. It adds the option to load book pages using AJAX and sending custom request headers. This feature is very useful when using token-based authentication for your pages.

When the option not set then tiles should load as they did before.

## New Options

### property: `loadWithAjax` (Boolean)
When this option is set on the `BookReader` all of the images are loaded in with AJAX.

### function: `getAjaxHeaders(index)`
When this function is provided on the `BookReader` it will be called with the index of the page and returns a  `String -> String` mapping of headers to be sent with the book page. This allows us to send different headers for every page if desired.

## Potential Issues

Setting the `loadWithAjax` option will limit browser support to IE 10+ due to the use of responseType = 'arraybuffer' and [createObjectURL](http://caniuse.com/#feat=bloburls). However if this option isn't used, then the behaviour is the same as it was before. 

## Feedback

Any feedback on the PR is welcome. I'd love to see it get merged.