### PR TITLE
Add additional tracking event when view changes.

### DIFF
--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -37,7 +37,7 @@ function BookReader(options) {
     this.setup(options);
 }
 
-BookReader.version = "3.0.7";
+BookReader.version = "3.0.8";
 
 // Mode constants
 BookReader.constMode1up = 1;

--- a/BookReader/plugins/plugin.url.js
+++ b/BookReader/plugins/plugin.url.js
@@ -113,7 +113,7 @@ BookReader.prototype.updateLocationHash = function(skipAnalytics) {
                 kind: 'event',
                 ec: 'BookReader',
                 ea: 'UserChangedView',
-                el: location.pathname,
+                el: window.location.pathname,
                 cache_bust: Math.random()
             });
         }

--- a/BookReader/plugins/plugin.url.js
+++ b/BookReader/plugins/plugin.url.js
@@ -88,7 +88,7 @@ BookReader.prototype.updateLocationHash = function(skipAnalytics) {
     // Send analytics events if the location hash is changed (page flip or mode change),
     // which indicates that the user is actively reading the book. This will cause the
     // archive.org download count for this book to increment (via setting the `bookreader` value),
-    // and also send a tracking event (via settig the `kind` attribute to `event`).
+    // and also send a tracking event (via setting the `kind` attribute to `event`).
     // Note that users with Adblock Plus will not send data to analytics.archive.org
     if (!skipAnalytics && typeof(archive_analytics) != 'undefined') {
         if (this.oldLocationHash != newHash) {

--- a/BookReader/plugins/plugin.url.js
+++ b/BookReader/plugins/plugin.url.js
@@ -85,9 +85,10 @@ BookReader.prototype.updateLocationHash = function(skipAnalytics) {
         window.location.replace(newHash);
     }
 
-    // Send an analytics event if the location hash is changed (page flip or mode change),
+    // Send analytics events if the location hash is changed (page flip or mode change),
     // which indicates that the user is actively reading the book. This will cause the
-    // archive.org download count for this book to increment.
+    // archive.org download count for this book to increment (via setting the `bookreader` value),
+    // and also send a tracking event (via settig the `kind` attribute to `event`).
     // Note that users with Adblock Plus will not send data to analytics.archive.org
     if (!skipAnalytics && typeof(archive_analytics) != 'undefined') {
         if (this.oldLocationHash != newHash) {
@@ -104,7 +105,17 @@ BookReader.prototype.updateLocationHash = function(skipAnalytics) {
               values.details=(!values.offsite  &&  window.top.location.pathname.match(/^\/details\//)   ? 1 : 0);
             } catch (e){} //avoids embed cross site exceptions -- but on (+) side, means it is and keeps marked offite!
 
+            // Send bookreader ping
             archive_analytics.send_ping(values, null, 'augment_for_ao_site');
+
+            // Also send tracking event ping
+            archive_analytics.send_ping({
+                kind: 'event',
+                ec: 'BookReader',
+                ea: 'UserChangedView',
+                el: location.pathname,
+                cache_bust: Math.random()
+            });
         }
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.0.8
+- Add additional tracking event when view changes
+
 # 3.0.7
 - Fix: Assign options.titleLeaf to this.titleLeaf
 
@@ -11,12 +14,12 @@
 - Hotfix for plugin.search.js. Fixes fulltext search for some books on Archive.org
 
 # 3.0.3
-- Add more options: showToolbar, showLogo  
-- Add this.options field, which stores the options last used in setup call  
-- Improve `_getDataFlattened` to have simple cache breaker  
-- Fix: don't show search UI if this.enableSearch is false  
+- Add more options: showToolbar, showLogo
+- Add this.options field, which stores the options last used in setup call
+- Improve `_getDataFlattened` to have simple cache breaker
+- Fix: don't show search UI if this.enableSearch is false
 - Fix: add missing 'defaults' option to search plugin
-- Move constants out of instance, and into class (eg BookReader.constMode1up)  
+- Move constants out of instance, and into class (eg BookReader.constMode1up)
 
 # 3.0.2
 In the process of upgrading IA, to use the new BookReader API, more changes/fixes were made.
@@ -36,32 +39,32 @@ Version 3.0.0 is an effort to make BookReader more modular, extensible, and easi
 Changes include:
 
 - Make BookReader easier to use, by adding `options` to the constructor, and adding new `options.data` option. The old way of overriding properties should still work, but it is deprecated. With `options.data`, all BookReader needs is the image URLs and dimensions. To have dynamic image URLs (eg for scaling), omit the URL from `options.data`, and include `options.getPageURI`.
-- Factor out extra features into plugins. See `plugins` directory. Example plugins include:  
-    - plugins.chapters.js - render chapter markers  
-    - plugins.search.js - add search ui, and callbacks  
-    - plugins.tts.js - add tts (read aloud) ui, sound library, and callbacks  
-    - plugins.url.js - automatically updates the browser url  
-    - plugins.resume.js - uses cookies to remember the current page  
-    - plugins.mobile_nav.js - adds responsive mobile nav to BookReader  
+- Factor out extra features into plugins. See `plugins` directory. Example plugins include:
+    - plugins.chapters.js - render chapter markers
+    - plugins.search.js - add search ui, and callbacks
+    - plugins.tts.js - add tts (read aloud) ui, sound library, and callbacks
+    - plugins.url.js - automatically updates the browser url
+    - plugins.resume.js - uses cookies to remember the current page
+    - plugins.mobile_nav.js - adds responsive mobile nav to BookReader
 Note that there is minor overhead added when loading multiple script tags. If this is a concern, a build step, can be used to concatenate the files into a single JS file.
-- Clean up code: Remove a lot of commented-out code. Remove some unused methods.  
-- Change some, but not all, CSS ids to classes.  
+- Clean up code: Remove a lot of commented-out code. Remove some unused methods.
+- Change some, but not all, CSS ids to classes.
 - DEPRECATED: Use options to configure BookReader. It is now deprecated to change properties directly.
 - DEPRECATED: CSS ids are being removed, (eg #BookReader is now .BookReader), with the goal to entirely use classes instead. This is in progress, but it is considered deprecated to use the ids directly. We would like to remove all ids for the next major release.
 - BREAKING: If features that are now in plugins were used, the plugin's JS file will need to be included as well. Note, we would also like to separate the CSS into a separate file for the next major release.
 
 # 2.1.0
-- Add auto mode to 1up autosize (in addition to height and width)  
-- Remove the old responsiveAutofit (which is not needed anymore)  
+- Add auto mode to 1up autosize (in addition to height and width)
+- Remove the old responsiveAutofit (which is not needed anymore)
 
 # 2.0.2
-- Fix regex issue when searching  
-- Make the search api endpoint configurable  
+- Fix regex issue when searching
+- Make the search api endpoint configurable
 
 # 2.0.1
-- Add package.json and CHANGELOG  
-- Remove more IA-specific code  
+- Add package.json and CHANGELOG
+- Remove more IA-specific code
 
 # 2.0.0
-- Major release  
-- Many changes from updated Archive.org bookreader brought back to this open source project.  
+- Major release
+- Many changes from updated Archive.org bookreader brought back to this open source project.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookreader",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "The Internet Archive BookReader.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
When the view changes, a bookreader event fires which tracks download counts for the book. We'd also like to track view changes as a separate analytics "event". This PR adds the additional call.