### PR TITLE
WEBDEV-1992: Fix Rapid Reload Bug in archive.org `/stream` View

### DIFF
--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -1654,7 +1654,7 @@ BookReader.prototype.switchMode = function(mode, suppressFragmentChange) {
     }
 
     if (!suppressFragmentChange) {
-        this.trigger(BookReader.eventNames.fragmentChange);
+      this.trigger(BookReader.eventNames.fragmentChange);
     }
 };
 
@@ -2250,7 +2250,7 @@ BookReader.prototype.currentIndex = function() {
 BookReader.prototype.updateFirstIndex = function(index, suppressFragmentChange) {
     this.firstIndex = index;
     if (!suppressFragmentChange) {
-        this.trigger(BookReader.eventNames.fragmentChange);
+      this.trigger(BookReader.eventNames.fragmentChange);
     }
     this.updateNavIndexThrottled(index);
 };

--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -1000,13 +1000,14 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
                 link = document.createElement("a");
                 $(link).data('leaf', leaf);
                 link.addEventListener('mouseup', function(event) {
-                  self.updateFirstIndex($(this).data('leaf'));
+                  self.updateFirstIndex($(this).data('leaf'), true);
                   if (self.prevReadMode === self.constMode1up
                         || self.prevReadMode === self.constMode2up) {
-                    self.switchMode(self.prevReadMode);
+                    self.switchMode(self.prevReadMode, true);
                   } else {
-                    self.switchMode(self.constMode1up);
+                    self.switchMode(self.constMode1up, true);
                   }
+                  self.trigger(BookReader.eventNames.fragmentChange);
                   event.preventDefault();
                   event.stopPropagation();
                 }, true);
@@ -1609,7 +1610,7 @@ BookReader.prototype.jumpToIndex = function(index, pageX, pageY, noAnimate) {
  * Switches the mode (eg 1up 2up thumb)
  * @param {number}
  */
-BookReader.prototype.switchMode = function(mode) {
+BookReader.prototype.switchMode = function(mode, suppressFragmentChange) {
     if (mode === this.mode) {
         return;
     }
@@ -1652,7 +1653,9 @@ BookReader.prototype.switchMode = function(mode) {
         this.twoPageCenterView(0.5, 0.5); // $$$ TODO preserve center
     }
 
-    this.trigger(BookReader.eventNames.fragmentChange);
+    if (!suppressFragmentChange) {
+        this.trigger(BookReader.eventNames.fragmentChange);
+    }
 };
 
 BookReader.prototype.updateBrClasses = function() {
@@ -2244,9 +2247,11 @@ BookReader.prototype.currentIndex = function() {
  * Also triggers an event and updates the navbar slider position
  * @param {number}
  */
-BookReader.prototype.updateFirstIndex = function(index) {
+BookReader.prototype.updateFirstIndex = function(index, suppressFragmentChange) {
     this.firstIndex = index;
-    this.trigger(BookReader.eventNames.fragmentChange);
+    if (!suppressFragmentChange) {
+        this.trigger(BookReader.eventNames.fragmentChange);
+    }
     this.updateNavIndexThrottled(index);
 };
 

--- a/tests/qunit.html
+++ b/tests/qunit.html
@@ -4,6 +4,19 @@
     <meta charset="utf-8">
     <title>QUnit Tests</title>
     <link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css">
+
+    <script src="../BookReader/jquery-1.10.1.js"></script>
+    <script src="../BookReader/jquery-ui-1.12.0.min.js"></script>
+    <script src="../BookReader/jquery.browser.min.js"></script>
+    <script src="../BookReader/dragscrollable-br.js"></script>
+    <script src="../BookReader/jquery.colorbox-min.js"></script>
+    <script src="../BookReader/jquery.bt.min.js"></script>
+
+    <script src="../BookReader/BookReader.js"></script>
+
+    <!-- Plugins -->
+    <script src="../BookReader/plugins/plugin.iframe.js"></script>
+    <script src="../BookReader/plugins/plugin.url.js"></script>
   </head>
   <body>
     <div id="qunit"></div>
@@ -15,6 +28,6 @@
 
     <!-- Test file -->
     <script src="test-plugin-iframe.js"></script>
-
+    <script src="test-bookreader.js"></script>
   </body>
 </html>

--- a/tests/test-bookreader.js
+++ b/tests/test-bookreader.js
@@ -1,0 +1,78 @@
+QUnit.module('BookReader', function() {
+    QUnit.module('switchMode() fragmentChange tests', function() {
+        var triggerCalled = false;
+        var br = new BookReader();
+        br.trigger = function(message) {
+            if (message === BookReader.eventNames.fragmentChange) {
+                triggerCalled = true;
+            }
+        }
+
+        // `updateFirstIndex()` also triggers the `fragmentChange` message so we want to stub that out
+        br.updateFirstIndex = function() {}
+        br.canSwitchToMode = function() { return true; }
+        br.init()
+
+        QUnit.test(
+            'BookReader.switchMode() posts a bookReaderFragmentChange message',
+            function(assert) {
+                // first switch to 1up mode to make sure that we can change to 2up mode
+                // if it's already in 2up mode, it won't change
+                br.switchMode(BookReader.constMode1up);
+                // reset our triggerCalled so we can make sure nothing else has set it unintentionally
+                triggerCalled = false;
+                br.switchMode(BookReader.constMode2up);
+                assert.ok(triggerCalled)
+            }
+        );
+
+        QUnit.test(
+            'BookReader.switchMode() can suppress the bookReaderFragmentChange message',
+            function(assert) {
+                // we need to reset `triggerCalled` to false right before calling `switchMode` because there are
+                // other calls that trigger `fragmentChange` before we get to this point in the test
+                triggerCalled = false;
+                br.switchMode(BookReader.constMode1up, true);
+                assert.notOk(triggerCalled);
+            }
+        );
+    });
+
+    QUnit.module('updateFirstIndex() fragmentChange tests', function() {
+        var triggerCalled = false;
+        var br = new BookReader();
+        br.trigger = function(message) {
+            if (message === BookReader.eventNames.fragmentChange) {
+                triggerCalled = true;
+            }
+        }
+
+        // `switchMode()` also triggers the `fragmentChange` message so we want to stub that out
+        br.switchMode = function(message) {}
+        br.currentIndex = function() { return 1; }
+        br.init();
+
+        QUnit.test(
+            'BookReader.updateFirstIndex() posts a bookReaderFragmentChange message',
+            function(assert) {
+                // we need to reset `triggerCalled` to false right before calling `updateFirstIndex` because there are
+                // other calls that trigger `fragmentChange` before we get to this point in the test
+                triggerCalled = false;
+                br.updateFirstIndex(1);
+                assert.ok(triggerCalled)
+            }
+        );
+
+        QUnit.test(
+            'BookReader.updateFirstIndex() can suppress the bookReaderFragmentChange message',
+            function(assert) {
+                // we need to reset `triggerCalled` to false right before calling `updateFirstIndex` because there are
+                // other calls that trigger `fragmentChange` before we get to this point in the test
+                triggerCalled = false;
+                br.updateFirstIndex(1, true);
+                assert.notOk(triggerCalled);
+            }
+        );
+    });
+
+})

--- a/tests/test-bookreader.js
+++ b/tests/test-bookreader.js
@@ -32,7 +32,7 @@ QUnit.module('BookReader', function () {
         // we need to reset `triggerCalled` to false right before calling `switchMode` because there are
         // other calls that trigger `fragmentChange` before we get to this point in the test
         triggerCalled = false;
-        br.switchMode(BookReader.constMode1up, true);
+        br.switchMode(BookReader.constMode1up, { suppressFragmentChange: true });
         assert.notOk(triggerCalled);
       }
     );
@@ -69,7 +69,7 @@ QUnit.module('BookReader', function () {
         // we need to reset `triggerCalled` to false right before calling `updateFirstIndex` because there are
         // other calls that trigger `fragmentChange` before we get to this point in the test
         triggerCalled = false;
-        br.updateFirstIndex(1, true);
+        br.updateFirstIndex(1, { suppressFragmentChange: true });
         assert.notOk(triggerCalled);
       }
     );

--- a/tests/test-bookreader.js
+++ b/tests/test-bookreader.js
@@ -1,78 +1,77 @@
-QUnit.module('BookReader', function() {
-    QUnit.module('switchMode() fragmentChange tests', function() {
-        var triggerCalled = false;
-        var br = new BookReader();
-        br.trigger = function(message) {
-            if (message === BookReader.eventNames.fragmentChange) {
-                triggerCalled = true;
-            }
-        }
+QUnit.module('BookReader', function () {
+  QUnit.module('switchMode() fragmentChange tests', function () {
+    var triggerCalled = false;
+    var br = new BookReader();
+    br.trigger = function (message) {
+      if (message === BookReader.eventNames.fragmentChange) {
+        triggerCalled = true;
+      }
+    }
 
-        // `updateFirstIndex()` also triggers the `fragmentChange` message so we want to stub that out
-        br.updateFirstIndex = function() {}
-        br.canSwitchToMode = function() { return true; }
-        br.init()
+    // `updateFirstIndex()` also triggers the `fragmentChange` message so we want to stub that out
+    br.updateFirstIndex = function () { }
+    br.canSwitchToMode = function () { return true; }
+    br.init()
 
-        QUnit.test(
-            'BookReader.switchMode() posts a bookReaderFragmentChange message',
-            function(assert) {
-                // first switch to 1up mode to make sure that we can change to 2up mode
-                // if it's already in 2up mode, it won't change
-                br.switchMode(BookReader.constMode1up);
-                // reset our triggerCalled so we can make sure nothing else has set it unintentionally
-                triggerCalled = false;
-                br.switchMode(BookReader.constMode2up);
-                assert.ok(triggerCalled)
-            }
-        );
+    QUnit.test(
+      'BookReader.switchMode() posts a bookReaderFragmentChange message',
+      function (assert) {
+        // first switch to 1up mode to make sure that we can change to 2up mode
+        // if it's already in 2up mode, it won't change
+        br.switchMode(BookReader.constMode1up);
+        // reset our triggerCalled so we can make sure nothing else has set it unintentionally
+        triggerCalled = false;
+        br.switchMode(BookReader.constMode2up);
+        assert.ok(triggerCalled)
+      }
+    );
 
-        QUnit.test(
-            'BookReader.switchMode() can suppress the bookReaderFragmentChange message',
-            function(assert) {
-                // we need to reset `triggerCalled` to false right before calling `switchMode` because there are
-                // other calls that trigger `fragmentChange` before we get to this point in the test
-                triggerCalled = false;
-                br.switchMode(BookReader.constMode1up, true);
-                assert.notOk(triggerCalled);
-            }
-        );
-    });
+    QUnit.test(
+      'BookReader.switchMode() can suppress the bookReaderFragmentChange message',
+      function (assert) {
+        // we need to reset `triggerCalled` to false right before calling `switchMode` because there are
+        // other calls that trigger `fragmentChange` before we get to this point in the test
+        triggerCalled = false;
+        br.switchMode(BookReader.constMode1up, true);
+        assert.notOk(triggerCalled);
+      }
+    );
+  });
 
-    QUnit.module('updateFirstIndex() fragmentChange tests', function() {
-        var triggerCalled = false;
-        var br = new BookReader();
-        br.trigger = function(message) {
-            if (message === BookReader.eventNames.fragmentChange) {
-                triggerCalled = true;
-            }
-        }
+  QUnit.module('updateFirstIndex() fragmentChange tests', function () {
+    var triggerCalled = false;
+    var br = new BookReader();
+    br.trigger = function (message) {
+      if (message === BookReader.eventNames.fragmentChange) {
+        triggerCalled = true;
+      }
+    }
 
-        // `switchMode()` also triggers the `fragmentChange` message so we want to stub that out
-        br.switchMode = function(message) {}
-        br.currentIndex = function() { return 1; }
-        br.init();
+    // `switchMode()` also triggers the `fragmentChange` message so we want to stub that out
+    br.switchMode = function () { }
+    br.currentIndex = function () { return 1; }
+    br.init();
 
-        QUnit.test(
-            'BookReader.updateFirstIndex() posts a bookReaderFragmentChange message',
-            function(assert) {
-                // we need to reset `triggerCalled` to false right before calling `updateFirstIndex` because there are
-                // other calls that trigger `fragmentChange` before we get to this point in the test
-                triggerCalled = false;
-                br.updateFirstIndex(1);
-                assert.ok(triggerCalled)
-            }
-        );
+    QUnit.test(
+      'BookReader.updateFirstIndex() posts a bookReaderFragmentChange message',
+      function (assert) {
+        // we need to reset `triggerCalled` to false right before calling `updateFirstIndex` because there are
+        // other calls that trigger `fragmentChange` before we get to this point in the test
+        triggerCalled = false;
+        br.updateFirstIndex(1);
+        assert.ok(triggerCalled)
+      }
+    );
 
-        QUnit.test(
-            'BookReader.updateFirstIndex() can suppress the bookReaderFragmentChange message',
-            function(assert) {
-                // we need to reset `triggerCalled` to false right before calling `updateFirstIndex` because there are
-                // other calls that trigger `fragmentChange` before we get to this point in the test
-                triggerCalled = false;
-                br.updateFirstIndex(1, true);
-                assert.notOk(triggerCalled);
-            }
-        );
-    });
-
+    QUnit.test(
+      'BookReader.updateFirstIndex() can suppress the bookReaderFragmentChange message',
+      function (assert) {
+        // we need to reset `triggerCalled` to false right before calling `updateFirstIndex` because there are
+        // other calls that trigger `fragmentChange` before we get to this point in the test
+        triggerCalled = false;
+        br.updateFirstIndex(1, true);
+        assert.notOk(triggerCalled);
+      }
+    );
+  });
 })


### PR DESCRIPTION
### Background
There is a bug in the archive.org `/stream` view where after a user selects a page from the thumbnail view, the page starts rapidly switching between the thumbnail view and the full page view, causing the browser to freeze.

### Demo
Click on a thumbnail to reproduce
Bug: https://archive.org/stream/goodytwoshoes00newyiala#mode/thumb
Fix: https://ia-petabox-review-jasonb-boo-u4y32j.archive.org/stream/goodytwoshoes00newyiala#page/n8/mode/thumb

### Cause
There were two calls being made `trigger(BookReader.eventNames.fragmentChange)`, one in `updateFirstIndex()` and another in `switchMode()`. This was triggering other listeners that kept calling back into `switchMode()` and we'd get caught in the loop.

### Solution
This adds a parameter to suppress the `trigger` calls so we can make both of the calls first, then call `trigger` when they're done.