### PR TITLE
Replaces hamburger image icon with CSS

### DIFF
--- a/BookReader/BookReader.css
+++ b/BookReader/BookReader.css
@@ -1747,16 +1747,31 @@ html.mm-background .BookReader {
 }
 
 .BRmobileHamburger {
-  background: center center no-repeat transparent;
-  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABsAAAATCAYAAABhh3Y4AAAAAXNSR0IArs4c6QAAAFZJREFUSA1jrKmpafv//38xELMx0AgwMjL+AuJeFqAlubS0COR+qPm5TED2FJDNNPIU2FiozybT0o5Rs4dBCDCO5jNKYnE0n1ESeiNI72g+oyiyYfkMAKCpRQemMsj0AAAAAElFTkSuQmCC");
   display: block;
-  width: 40px;
-  height: 40px;
   position: absolute;
   top: 0;
-  left: 10px;
-  border: none;
+  left: 17px;
+  width: 26px;
+  height: 3px;
+  margin: 18px 0;
   outline: none;
+  border: none;
+  border-radius: 3px;
+  background: #7a7a7a;
+}
+.BRmobileHamburger:before, .BRmobileHamburger:after {
+  position: absolute;
+  top: -8px;
+  right: 0;
+  left: 0;
+  height: 3px;
+  content: "";
+  border-radius: 3px;
+  background: #7a7a7a;
+}
+.BRmobileHamburger:after {
+  top: auto;
+  bottom: -8px;
 }
 
 .DrawerIconWrapper {

--- a/src/css/_MobileNav.scss
+++ b/src/css/_MobileNav.scss
@@ -45,19 +45,32 @@ html.mm-background .BookReader {
 }
 
 .BRmobileHamburger {
-	background: center center no-repeat transparent;
-  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABsAAAATCAYAAABhh3Y4AAAAAXNSR0IArs4c6QAAAFZJREFUSA1jrKmpafv//38xELMx0AgwMjL+AuJeFqAlubS0COR+qPm5TED2FJDNNPIU2FiozybT0o5Rs4dBCDCO5jNKYnE0n1ESeiNI72g+oyiyYfkMAKCpRQemMsj0AAAAAElFTkSuQmCC');
-  /* Should use SVG (below). See https://github.com/internetarchive/bookreader/issues/100 */
-  /*background: url('data:image/svg+xml;utf8,<svg width="15px" height="12px" viewBox="0 0 15 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"> <g id="hamburger-svg" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="square"> <path d="M0,1 L14,1" id="Line" stroke="#000000"></path> <path d="M2.39808173e-14,6 L14,6" id="Line-Copy" stroke="#000000"></path> <path d="M1.15463195e-14,11 L14,11" id="Line-Copy-2" stroke="#000000"></path> </g></svg>') center / 50% 50% no-repeat;*/
-
-	display: block;
-	width: 40px;
-	height: 40px;
-	position: absolute;
-	top: 0;
-  left: 10px;
-  border: none;
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 17px;
+  width: 26px;
+  height: 3px;
+  margin: 18px 0;
   outline: none;
+  border: none;
+  border-radius: 3px;
+  background: #7a7a7a;
+  &:before,
+  &:after {
+    position: absolute;
+    top: -8px;
+    right: 0;
+    left: 0;
+    height: 3px;
+    content: "";
+    border-radius: 3px;
+    background: #7a7a7a;
+  }
+  &:after {
+    top: auto;
+    bottom: -8px;
+  }
 }
 
 .DrawerIconWrapper {


### PR DESCRIPTION
Fixes #100 

With PNG hamburger:

<img width="460" alt="Screen Shot 2019-06-07 at 3 29 30 PM" src="https://user-images.githubusercontent.com/39553/59128858-37928080-8939-11e9-9e31-e27e5eda69a0.png">


With CSS hamburger:

<img width="454" alt="Screen Shot 2019-06-07 at 2 31 30 PM" src="https://user-images.githubusercontent.com/39553/59128871-3f522500-8939-11e9-8620-2e931da4b8ae.png">
