### PR TITLE
Fix BookReader Analytics Not Firing

### DIFF
--- a/BookReader/plugins/plugin.archive_analytics.js
+++ b/BookReader/plugins/plugin.archive_analytics.js
@@ -5,11 +5,11 @@ jQuery.extend(BookReader.defaultOptions, {
   enableArchiveAnalytics: true
 });
 
-BookReader.prototype.init = (function(super_) {
-  return function() {
-    super_.call(this);
+BookReader.prototype.setup = (function(super_) {
+  return function(options) {
+    super_.call(this, options);
 
-    if (this.options.enableArchiveAnalytics) {
+    if (options.enableArchiveAnalytics) {
       this.bind(
         BookReader.eventNames.fragmentChange,
         function() {
@@ -18,7 +18,7 @@ BookReader.prototype.init = (function(super_) {
       );
     }
   };
-})(BookReader.prototype.init);
+})(BookReader.prototype.setup);
 
 BookReader.prototype.archiveAnalyticsSend = function() {
   if (!window.archive_analytics) {


### PR DESCRIPTION
This fixes the initialization of the `archive_analytics` plugin. The `enableArchiveAnalytics` flag was not present during initialization (possibly a race condition?), but is available during `setup()`. Most of the other plugins use the `setup()` method for their initialization.

**NOTE** I tried writing tests for this, but there is a whole slew of initialization issues with default values not being set and in order to get the tests slightly working, I had to modify a bunch of files that change the initialization behavior. I think this can be handled independently.