### PR TITLE
Removes mode switch to 2up when exiting fullscreen in < 800px width browsers

### DIFF
--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -1720,11 +1720,6 @@ BookReader.prototype.exitFullScreen = function() {
 
     $(document).unbind('keyup', this._fullscreenCloseHandler);
 
-    var windowWidth = $(window).width();
-    if (windowWidth <= this.onePageMinBreakpoint) {
-        this.switchMode(this.constMode2up);
-    }
-
     this.isFullscreenActive = false;
     this.updateBrClasses()
 


### PR DESCRIPTION
Fixes #103

![fullscreen_toggle](https://user-images.githubusercontent.com/39553/63603472-c063a480-c597-11e9-850a-2ad2a60c9db8.gif)
