### PR TITLE
Get book's language as ISO 639-1

### DIFF
--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -119,6 +119,8 @@ BookReader.defaultOptions = {
     bookUrlText: null,
     bookUrlTitle: null,
     enableBookTitleLink: true,
+    /** @type {string} language in ISO 639-1 (PRIVATE: languages in other formats) */
+    bookLanguage: null,
 
     // Fields used to populate the info window
     metadata: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bookreader",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4569,6 +4569,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "iso-language-codes": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/iso-language-codes/-/iso-language-codes-1.0.5.tgz",
+      "integrity": "sha512-FeBnVYbhKr8vaWjPQDbTedH3oPLJAt+qXqUxdBeeffJYjYAHzMAhC1diKFllvds69nRCJmzIrN69KPwcNg7s4Q=="
     },
     "isobject": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/internetarchive/bookreader#readme",
   "dependencies": {
     "es6-promise": "^4.2.8",
+    "iso-language-codes": "^1.0.5",
     "jquery": "^3.4.1"
   },
   "private": true,

--- a/src/js/plugins/tts/AbstractTTSEngine.js
+++ b/src/js/plugins/tts/AbstractTTSEngine.js
@@ -14,6 +14,10 @@ import AsyncStream from './AsyncStream.js';
  * @typedef {Object} TTSEngineOptions 
  * @property {String} server
  * @property {String} bookPath
+ * @property {String?} bookLanguage language in ISO 639-1. (PRIVATE: Will also
+ * handle language name in English, native name, 639-2/T, or 639-2/B . (archive.org books
+ * appear to use 639-2/B ? But I don't think that's a guarantee). See
+ * https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes )
  * @property {Function} onLoadingStart
  * @property {Function} onLoadingComplete
  * @property {Function} onDone called when the entire book is done

--- a/src/js/plugins/tts/plugin.tts.js
+++ b/src/js/plugins/tts/plugin.tts.js
@@ -4,6 +4,7 @@
 
 import 'es6-promise/auto';
 import FestivalTTSEngine from './FestivalTTSEngine.js';
+import { toISO6391 } from './utils.js';
 
 // Default options for TTS
 jQuery.extend(BookReader.defaultOptions, {
@@ -21,6 +22,7 @@ BookReader.prototype.setup = (function (super_) {
             this.ttsEngine = new FestivalTTSEngine({
                 server: options.server,
                 bookPath: options.bookPath,
+                bookLanguage: toISO6391(options.bookLanguage),
                 onLoadingStart: this.showProgressPopup.bind(this, 'Loading audio...'),
                 onLoadingComplete: this.removeProgressPopup.bind(this),
                 onDone: this.ttsStop.bind(this),

--- a/src/js/plugins/tts/utils.js
+++ b/src/js/plugins/tts/utils.js
@@ -1,0 +1,47 @@
+import langs from 'iso-language-codes/js/data.js';
+
+/**
+ * @typedef {string} ISO6391
+ * Language code in ISO 639-1 format. e.g. en, fr, zh
+ **/
+
+/** Each lang is an array, with each index mapping to a different property */
+const COLUMN_TO_LANG_INDEX = {
+    'Name': 0,
+    'Endonym': 1,
+    'ISO 639-1': 2,
+    'ISO 639-2/T': 3,
+    'ISO 639-2/B': 4
+};
+
+/**
+ * @param {string} language in some format
+ * @return {ISO6391?}
+ */
+export function toISO6391(language) {
+    if (!language) return null;
+    language = language.toLowerCase();
+
+    return searchForISO6391(language, ['ISO 639-1']) ||
+    searchForISO6391(language, ['ISO 639-2/B']) ||
+    searchForISO6391(language, ['ISO 639-2/T', 'Endonym', 'Name']);
+}
+
+/**
+ * Searches for the given long in the given columns.
+ * @param {string} language
+ * @param {Array<keyof COLUMN_TO_LANG_INDEX>} columnsToSearch
+ * @return {ISO6391?}
+ */
+function searchForISO6391(language, columnsToSearch) {
+    for (let i = 0; i < langs.length; i++) {
+        for (let colI = 0; colI < columnsToSearch.length; colI++) {
+            const column = columnsToSearch[colI];
+            const columnValue = langs[i][COLUMN_TO_LANG_INDEX[column]];
+            if (columnValue.split(', ').map(x => x.toLowerCase()).indexOf(language) != -1) {
+                return langs[i][COLUMN_TO_LANG_INDEX['ISO 639-1']];
+            }
+        }
+    }
+    return null;
+}

--- a/tests/plugins/tts/utils.test.js
+++ b/tests/plugins/tts/utils.test.js
@@ -1,0 +1,37 @@
+import * as utils from '../../../src/js/plugins/tts/utils.js';
+
+describe('toISO6391', () => {
+    const { toISO6391 } = utils;
+
+    test('ISO 639-1', () => {
+        expect(toISO6391('en')).toBe('en');
+        expect(toISO6391('fr')).toBe('fr');
+        expect(toISO6391('SQ')).toBe('sq');
+        expect(toISO6391('aa')).toBe('aa');
+    });
+
+    test('ISO 639-2/T', () => {
+        expect(toISO6391('amh')).toBe('am');
+        expect(toISO6391('BIH')).toBe('bh');
+    });
+
+    test('ISO 639-2/B', () => {
+        expect(toISO6391('BAQ')).toBe('eu');
+        expect(toISO6391('chi')).toBe('zh');
+    });
+
+    test('Name', () => {
+        expect(toISO6391('english')).toBe('en');
+        expect(toISO6391('German')).toBe('de');
+    });
+
+    test('Endonym', () => {
+        expect(toISO6391('français')).toBe('fr');
+        expect(toISO6391('汉语')).toBe('zh');
+    });
+
+    test('Mismatch', () => {
+        expect(toISO6391('Parseltongue')).toBe(null);
+        expect(toISO6391('Pig Latin')).toBe(null);
+    });
+});


### PR DESCRIPTION
Add a `bookLanguage` option to book reader that we can use for TTS. This has corresponding changes to petabox to _provide_ the language, which will go out once this is merged ( https://git.archive.org/ia/petabox/tree/131-bookreader-book-lang ).

Closes #131 

## Summary of Requirements
- [X] Determine format of language field used in IA metadata files.
    - It's often ISO 639-2/B, but can be anything
- [X] Create helper method in plugin.tts.js that converts that to BCP 47 format.
    - See `toISO6391`

## Notes
- Added another dependency.
- The `toISO6391` function is purposefully not very performant; it'll only get run once per page load, so I opted for an algorithm that requires the data to be in as condensed a format as possible.

## Open Questions
- It feels a little wrong to be doing this here? I think it would more appropriate for the `toISO6391` function to be inside petabox, so it does the data wrangling before providing the language to the bookreader.

## Stakeholders
@jbuckner @mekarpeles 