### PR TITLE
4.4.0

### DIFF
--- a/BookReader/BookReader.css
+++ b/BookReader/BookReader.css
@@ -2193,5 +2193,3 @@ html.mm-background .BookReader {
   clear: both;
   visibility: hidden;
 }
-
-/*# sourceMappingURL=BookReader.css.map */

--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -79,7 +79,7 @@ function BookReader(options) {
     this.setup(options);
 }
 
-BookReader.version = '4.3.2';
+BookReader.version = '4.4.0';
 
 // Mode constants
 BookReader.constMode1up = 1;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.4.0
+- New ReadAloud controls + engine. Uses browser's SpeechSynthesis API instead of server-side test-to-speech
+
 # 4.3.2
 - menu toggle plugin, now applies to in-page & fullscreen views + early escapes when navbar isn't present
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bookreader",
-  "version": "4.3.2",
+  "version": "4.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookreader",
-  "version": "4.3.2",
+  "version": "4.4.0",
   "description": "The Internet Archive BookReader.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Version bump

Release: https://github.com/internetarchive/bookreader/releases/new?tag=v4.4.0&title=v4.4.0&body=-%20New%20ReadAloud%20controls%20%2B%20engine.%20Uses%20browser's%20SpeechSynthesis%20API%20instead%20of%20server-side%20test-to-speech%0A