### PR TITLE
4.4.1

### DIFF
--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -31,7 +31,7 @@ if (location.toString().indexOf('_debugShowConsole=true') != -1) {
         logEl.style.overflow = 'auto';
         $(document.body).prepend(logEl);
 
-        var form = $(`<form><input style="width:100%; font-family: monospace;" id="_debugLogInput"></form>`);
+        var form = $('<form><input style="width:100%; font-family: monospace;" id="_debugLogInput"></form>');
         $(logEl).append(form);
         form.submit(function(ev) {
             ev.preventDefault();

--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -79,7 +79,7 @@ function BookReader(options) {
     this.setup(options);
 }
 
-BookReader.version = '4.4.0';
+BookReader.version = '4.4.1';
 
 // Mode constants
 BookReader.constMode1up = 1;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.4.1
+- Remove accidental es6 syntax in BookReader.js (breaking IE11)
+
 # 4.4.0
 - New ReadAloud controls + engine. Uses browser's SpeechSynthesis API instead of server-side test-to-speech
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bookreader",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookreader",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "The Internet Archive BookReader.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fix IE 11 issue

https://github.com/internetarchive/bookreader/releases/new?tag=v4.4.1&title=v4.4.1&body=-%20Remove%20accidental%20es6%20syntax%20in%20BookReader.js%20(breaking%20IE11)%0A