### PR TITLE
Plugin, search: hide search results pins when menu toggles

### DIFF
--- a/BookReader/plugins/plugin.search.js
+++ b/BookReader/plugins/plugin.search.js
@@ -41,6 +41,12 @@ BookReader.prototype.init = (function (super_) {
                 goToFirstResult: true
             });
         }
+
+        var br = this;
+        $(document).on('BookReader:navToggled', function() {
+            var nextVisibleState = br.navigationIsVisible() ? 'visible' : 'hidden';
+            br.refs.$BRfooter.find('.BRsearch').css({ visibility: nextVisibleState });
+        })
     };
 })(BookReader.prototype.init);
 

--- a/BookReader/plugins/plugin.search.js
+++ b/BookReader/plugins/plugin.search.js
@@ -44,8 +44,8 @@ BookReader.prototype.init = (function (super_) {
 
         var br = this;
         $(document).on('BookReader:navToggled', function() {
-            var nextVisibleState = br.navigationIsVisible() ? 'visible' : 'hidden';
-            br.refs.$BRfooter.find('.BRsearch').css({ visibility: nextVisibleState });
+            var pinsVisibleState = br.navigationIsVisible() ? 'visible' : 'hidden';
+            br.refs.$BRfooter.find('.BRsearch').css({ visibility: pinsVisibleState });
         })
     };
 })(BookReader.prototype.init);

--- a/BookReader/plugins/plugin.search.js
+++ b/BookReader/plugins/plugin.search.js
@@ -46,7 +46,7 @@ BookReader.prototype.init = (function (super_) {
         $(document).on('BookReader:navToggled', function() {
             var pinsVisibleState = br.navigationIsVisible() ? 'visible' : 'hidden';
             br.refs.$BRfooter.find('.BRsearch').css({ visibility: pinsVisibleState });
-        })
+        });
     };
 })(BookReader.prototype.init);
 
@@ -71,7 +71,7 @@ BookReader.prototype.buildMobileDrawerElement = (function (super_) {
                 +"      </div>"
                 +"    </li>"
             ));
-        };
+        }
         return $el;
     };
 })(BookReader.prototype.buildMobileDrawerElement);


### PR DESCRIPTION
Add custom event listener to new ambient event `BookReader:navToggled`
where the pins hide when the menu hides

Please note that this compounds on the latest menu toggle #171 & zoom click #172 fixes

https://webarchive.jira.com/browse/WEBDEV-2736

Evidence:
![br-search-pins-toggle-with-menu](https://user-images.githubusercontent.com/7840857/67831668-4cb0ad00-fa9c-11e9-942d-856f6fb150fc.gif)
