### PR TITLE
Updates to Drag Motion Detection

### DIFF
--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -3793,8 +3793,6 @@ BookReader.prototype.initDragCheck = function(clientX, clientY) {
      * Based on the really quite awesome "Today's Guardian" at http://guardian.gyford.com/
      */
     this._drag = {
-        mightBeFlicking: false,
-        didFlick: false,
         mightBeDraggin: false,
         didDrag: false,
         startTime: (new Date).getTime(),
@@ -3829,7 +3827,6 @@ BookReader.prototype.swipeMousedownHandler = function(event) {
     );
 
     self.initDragCheck(event.clientX, event.clientY);
-    self._drag.mightBeFlicking = true;
     self._drag.mightBeDragging = true;
 
     event.preventDefault();
@@ -3839,38 +3836,16 @@ BookReader.prototype.swipeMousedownHandler = function(event) {
 };
 
 BookReader.prototype.swipeMousemoveHandler = function(event) {
+    var startOfDragTime = 100;
     var self = event.data['br'];
     var _drag = self._drag;
-    if (! _drag.mightBeFlicking) {
-        return;
-    }
 
     // Update _drag data
     _drag.deltaX = event.clientX - _drag.startX;
     _drag.deltaY = event.clientY - _drag.startY;
     _drag.deltaT = (new Date).getTime() - _drag.startTime;
 
-    var absX = Math.abs(_drag.deltaX);
-    var absY = Math.abs(_drag.deltaY);
-
-    // Minimum distance in the amount of tim to trigger the flick
-    var minFlickLength = Math.min(self.refs.$br.width() / 5, 80);
-    var maxFlickTime = 400;
-
-    // Check for horizontal flick
-    if (absX > absY && (absX > minFlickLength) && _drag.deltaT < maxFlickTime) {
-        _drag.mightBeFlicking = false; // only trigger once
-        _drag.didFlick = true;
-        if (self.mode == self.constMode2up) {
-            if (_drag.deltaX < 0) {
-                self.right();
-            } else {
-                self.left();
-            }
-        }
-    }
-
-    if ( _drag.deltaT > maxFlickTime && !_drag.didFlick) {
+    if ( _drag.deltaT > startOfDragTime) {
         if (_drag.mightBeDragging) {
             // Dragging
             _drag.didDrag = true;
@@ -3890,12 +3865,11 @@ BookReader.prototype.swipeMousemoveHandler = function(event) {
 
 BookReader.prototype.swipeMouseupHandler = function(event) {
     var _drag = event.data['br']._drag;
-    _drag.mightBeFlicking = false;
     _drag.mightBeDragging = false;
 
     $(event.target).unbind('mouseout.swipe').unbind('mouseup.swipe').unbind('mousemove.swipe');
 
-    if (_drag.didFlick || _drag.didDrag) {
+    if (_drag.didDrag) {
         // Swallow event if completed drag gesture
         event.preventDefault();
         event.returnValue  = false;

--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -3792,7 +3792,7 @@ BookReader.prototype.initSwipeData = function(clientX, clientY) {
     /*
      * Based on the really quite awesome "Today's Guardian" at http://guardian.gyford.com/
      */
-    this._swipe = {
+    this._drag = {
         mightBeFlicking: false,
         didFlick: false,
         mightBeDraggin: false,
@@ -3829,8 +3829,8 @@ BookReader.prototype.swipeMousedownHandler = function(event) {
     );
 
     self.initSwipeData(event.clientX, event.clientY);
-    self._swipe.mightBeFlicking = true;
-    self._swipe.mightBeDragging = true;
+    self._drag.mightBeFlicking = true;
+    self._drag.mightBeDragging = true;
 
     event.preventDefault();
     event.returnValue  = false;
@@ -3840,29 +3840,29 @@ BookReader.prototype.swipeMousedownHandler = function(event) {
 
 BookReader.prototype.swipeMousemoveHandler = function(event) {
     var self = event.data['br'];
-    var _swipe = self._swipe;
-    if (! _swipe.mightBeFlicking) {
+    var _drag = self._drag;
+    if (! _drag.mightBeFlicking) {
         return;
     }
 
-    // Update swipe data
-    _swipe.deltaX = event.clientX - _swipe.startX;
-    _swipe.deltaY = event.clientY - _swipe.startY;
-    _swipe.deltaT = (new Date).getTime() - _swipe.startTime;
+    // Update _drag data
+    _drag.deltaX = event.clientX - _drag.startX;
+    _drag.deltaY = event.clientY - _drag.startY;
+    _drag.deltaT = (new Date).getTime() - _drag.startTime;
 
-    var absX = Math.abs(_swipe.deltaX);
-    var absY = Math.abs(_swipe.deltaY);
+    var absX = Math.abs(_drag.deltaX);
+    var absY = Math.abs(_drag.deltaY);
 
-    // Minimum distance in the amount of tim to trigger the swipe
+    // Minimum distance in the amount of tim to trigger the flick
     var minFlickLength = Math.min(self.refs.$br.width() / 5, 80);
     var maxFlickTime = 400;
 
-    // Check for horizontal swipe
-    if (absX > absY && (absX > minFlickLength) && _swipe.deltaT < maxFlickTime) {
-        _swipe.mightBeFlicking = false; // only trigger once
-        _swipe.didFlick = true;
+    // Check for horizontal flick
+    if (absX > absY && (absX > minFlickLength) && _drag.deltaT < maxFlickTime) {
+        _drag.mightBeFlicking = false; // only trigger once
+        _drag.didFlick = true;
         if (self.mode == self.constMode2up) {
-            if (_swipe.deltaX < 0) {
+            if (_drag.deltaX < 0) {
                 self.right();
             } else {
                 self.left();
@@ -3870,17 +3870,17 @@ BookReader.prototype.swipeMousemoveHandler = function(event) {
         }
     }
 
-    if ( _swipe.deltaT > maxFlickTime && !_swipe.didFlick) {
-        if (_swipe.mightBeDragging) {
+    if ( _drag.deltaT > maxFlickTime && !_drag.didFlick) {
+        if (_drag.mightBeDragging) {
             // Dragging
-            _swipe.didDrag = true;
+            _drag.didDrag = true;
             self.refs.$brContainer
-            .scrollTop(self.refs.$brContainer.scrollTop() - event.clientY + _swipe.lastY)
-            .scrollLeft(self.refs.$brContainer.scrollLeft() - event.clientX + _swipe.lastX);
+            .scrollTop(self.refs.$brContainer.scrollTop() - event.clientY + _drag.lastY)
+            .scrollLeft(self.refs.$brContainer.scrollLeft() - event.clientX + _drag.lastX);
         }
     }
-    _swipe.lastX = event.clientX;
-    _swipe.lastY = event.clientY;
+    _drag.lastX = event.clientX;
+    _drag.lastY = event.clientY;
 
     event.preventDefault();
     event.returnValue  = false;
@@ -3889,14 +3889,14 @@ BookReader.prototype.swipeMousemoveHandler = function(event) {
 };
 
 BookReader.prototype.swipeMouseupHandler = function(event) {
-    var _swipe = event.data['br']._swipe;
-    _swipe.mightBeFlicking = false;
-    _swipe.mightBeDragging = false;
+    var _drag = event.data['br']._drag;
+    _drag.mightBeFlicking = false;
+    _drag.mightBeDragging = false;
 
     $(event.target).unbind('mouseout.swipe').unbind('mouseup.swipe').unbind('mousemove.swipe');
 
-    if (_swipe.didFlick || _swipe.didDrag) {
-        // Swallow event if completed swipe gesture
+    if (_drag.didFlick || _drag.didDrag) {
+        // Swallow event if completed drag gesture
         event.preventDefault();
         event.returnValue  = false;
         event.cancelBubble = true;

--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -3793,8 +3793,8 @@ BookReader.prototype.initSwipeData = function(clientX, clientY) {
      * Based on the really quite awesome "Today's Guardian" at http://guardian.gyford.com/
      */
     this._swipe = {
-        mightBeSwiping: false,
-        didSwipe: false,
+        mightBeFlicking: false,
+        didFlick: false,
         mightBeDraggin: false,
         didDrag: false,
         startTime: (new Date).getTime(),
@@ -3829,7 +3829,7 @@ BookReader.prototype.swipeMousedownHandler = function(event) {
     );
 
     self.initSwipeData(event.clientX, event.clientY);
-    self._swipe.mightBeSwiping = true;
+    self._swipe.mightBeFlicking = true;
     self._swipe.mightBeDragging = true;
 
     event.preventDefault();
@@ -3841,7 +3841,7 @@ BookReader.prototype.swipeMousedownHandler = function(event) {
 BookReader.prototype.swipeMousemoveHandler = function(event) {
     var self = event.data['br'];
     var _swipe = self._swipe;
-    if (! _swipe.mightBeSwiping) {
+    if (! _swipe.mightBeFlicking) {
         return;
     }
 
@@ -3854,13 +3854,13 @@ BookReader.prototype.swipeMousemoveHandler = function(event) {
     var absY = Math.abs(_swipe.deltaY);
 
     // Minimum distance in the amount of tim to trigger the swipe
-    var minSwipeLength = Math.min(self.refs.$br.width() / 5, 80);
-    var maxSwipeTime = 400;
+    var minFlickLength = Math.min(self.refs.$br.width() / 5, 80);
+    var maxFlickTime = 400;
 
     // Check for horizontal swipe
-    if (absX > absY && (absX > minSwipeLength) && _swipe.deltaT < maxSwipeTime) {
-        _swipe.mightBeSwiping = false; // only trigger once
-        _swipe.didSwipe = true;
+    if (absX > absY && (absX > minFlickLength) && _swipe.deltaT < maxFlickTime) {
+        _swipe.mightBeFlicking = false; // only trigger once
+        _swipe.didFlick = true;
         if (self.mode == self.constMode2up) {
             if (_swipe.deltaX < 0) {
                 self.right();
@@ -3870,7 +3870,7 @@ BookReader.prototype.swipeMousemoveHandler = function(event) {
         }
     }
 
-    if ( _swipe.deltaT > maxSwipeTime && !_swipe.didSwipe) {
+    if ( _swipe.deltaT > maxFlickTime && !_swipe.didFlick) {
         if (_swipe.mightBeDragging) {
             // Dragging
             _swipe.didDrag = true;
@@ -3890,12 +3890,12 @@ BookReader.prototype.swipeMousemoveHandler = function(event) {
 
 BookReader.prototype.swipeMouseupHandler = function(event) {
     var _swipe = event.data['br']._swipe;
-    _swipe.mightBeSwiping = false;
+    _swipe.mightBeFlicking = false;
     _swipe.mightBeDragging = false;
 
     $(event.target).unbind('mouseout.swipe').unbind('mouseup.swipe').unbind('mousemove.swipe');
 
-    if (_swipe.didSwipe || _swipe.didDrag) {
+    if (_swipe.didFlick || _swipe.didDrag) {
         // Swallow event if completed swipe gesture
         event.preventDefault();
         event.returnValue  = false;

--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -3793,7 +3793,7 @@ BookReader.prototype.initDragCheck = function(clientX, clientY) {
      * Based on the really quite awesome "Today's Guardian" at http://guardian.gyford.com/
      */
     this._drag = {
-        mightBeDraggin: false,
+        mightBeDragging: false,
         didDrag: false,
         startTime: (new Date).getTime(),
         startX: clientX,

--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -3742,7 +3742,7 @@ BookReader.prototype.bindNavigationHandlers = function() {
         }
     });
 
-    this.initSwipeData();
+    this.initDragCheck();
 
     $(document).off('mousemove.navigation', this.el);
     $(document).on(
@@ -3788,7 +3788,7 @@ BookReader.prototype.navigationMousemoveHandler = function(event) {
     }
 };
 
-BookReader.prototype.initSwipeData = function(clientX, clientY) {
+BookReader.prototype.initDragCheck = function(clientX, clientY) {
     /*
      * Based on the really quite awesome "Today's Guardian" at http://guardian.gyford.com/
      */
@@ -3828,7 +3828,7 @@ BookReader.prototype.swipeMousedownHandler = function(event) {
         self.swipeMousemoveHandler
     );
 
-    self.initSwipeData(event.clientX, event.clientY);
+    self.initDragCheck(event.clientX, event.clientY);
     self._drag.mightBeFlicking = true;
     self._drag.mightBeDragging = true;
 

--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -3757,7 +3757,7 @@ BookReader.prototype.bindNavigationHandlers = function() {
       'mousedown.swipe',
       '.BRpageimage',
       { 'br': this },
-      this.swipeMousedownHandler
+      this.dragMousedownHandler
     );
 
     this.bindMozTouchHandlers();
@@ -3806,7 +3806,7 @@ BookReader.prototype.initDragCheck = function(clientX, clientY) {
     }
 };
 
-BookReader.prototype.swipeMousedownHandler = function(event) {
+BookReader.prototype.dragMousedownHandler = function(event) {
     var self = event.data['br'];
 
     // We should be the last bubble point for the page images
@@ -3817,13 +3817,13 @@ BookReader.prototype.swipeMousedownHandler = function(event) {
 
     $(event.target).bind('mouseout.swipe',
         { 'br': self},
-        self.swipeMouseupHandler
+        self.dragMouseupHandler
     ).bind('mouseup.swipe',
         { 'br': self},
-        self.swipeMouseupHandler
+        self.dragMouseupHandler
     ).bind('mousemove.swipe',
         { 'br': self },
-        self.swipeMousemoveHandler
+        self.dragMousemoveHandler
     );
 
     self.initDragCheck(event.clientX, event.clientY);
@@ -3835,7 +3835,7 @@ BookReader.prototype.swipeMousedownHandler = function(event) {
     return false;
 };
 
-BookReader.prototype.swipeMousemoveHandler = function(event) {
+BookReader.prototype.dragMousemoveHandler = function(event) {
     var startOfDragTime = 100;
     var self = event.data['br'];
     var _drag = self._drag;
@@ -3863,7 +3863,7 @@ BookReader.prototype.swipeMousemoveHandler = function(event) {
     return false;
 };
 
-BookReader.prototype.swipeMouseupHandler = function(event) {
+BookReader.prototype.dragMouseupHandler = function(event) {
     var _drag = event.data['br']._drag;
     _drag.mightBeDragging = false;
 


### PR DESCRIPTION
In the core code, we detect desktop mouse movement and determine when a user drags.
In there, we have a notion of "swipe", which is essentially a shorter `drag`.

Current implementation muddies up next phase in standardizing book tap targets in 2up mode.

Solution, is to remove page flip when swiping.  This renders the notion of `swipe` obsolete.

This PR reconfigures the internal reference dictionary that we build from handling mouse events.  Updates include:
- renaming top level reference dictionary from `_swipe` => `_drag`
- renaming initializer function from `initSwipeData` => `initDragCheck`
- remove page flip connected to `swipe` notion

