### PR TITLE
Enables initial view mode to be defined

### DIFF
--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -111,7 +111,8 @@ BookReader.eventNames = {
 };
 
 BookReader.defaultOptions = {
-    // A string, such as "mode/1up"
+    // A string, such as "mode/1up". See
+    // http://openlibrary.org/dev/docs/bookurls for valid syntax
     defaults: null,
 
     // Padding in 1up

--- a/BookReaderDemo/index.html
+++ b/BookReaderDemo/index.html
@@ -9,6 +9,7 @@
   <body>
     <ul>
       <li><a href="demo-simple.html">Simple</a></li>
+      <li><a href="view_mode.html">Set initial view mode</a></li>
       <li><a href="demo-fullscreen.html">Fullscreen with mobile nav</a></li>
       <li><a href="demo-fullscreen-mobile.html">Inline on page, with mobile nav on fullscreen</a></li>
       <li><a href="demo-vendor-fullscreen.html">Vendor native fullscreen</a></li>

--- a/BookReaderDemo/view_mode.html
+++ b/BookReaderDemo/view_mode.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>bookreader initial view mode demo</title>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="apple-mobile-web-app-capable" content="yes">
+
+    <!-- JS dependencies -->
+    <script src="../BookReader/jquery-1.10.1.js"></script>
+    <script src="../BookReader/jquery-ui-1.12.0.min.js"></script>
+    <script src="../BookReader/jquery.browser.min.js"></script>
+    <script src="../BookReader/dragscrollable-br.js"></script>
+    <script src="../BookReader/jquery.colorbox-min.js"></script>
+    <script src="../BookReader/jquery.bt.min.js"></script>
+
+    <!-- BookReader and plugins -->
+    <link rel="stylesheet" href="../BookReader/BookReader.css"/>
+    <script src="../BookReader/BookReader.js"></script>
+
+    <!-- Custom CSS overrides -->
+    <link rel="stylesheet" href="BookReaderDemo.css"/>
+</head>
+<body>
+  <h1>Initial view mode set to 1up</h1>
+  <div id="BookReader">
+      Internet Archive BookReader Demo<br/>
+      <noscript>
+      <p>
+          The BookReader requires JavaScript to be enabled. Please check that your browser supports JavaScript and that it is enabled in the browser settings.  You can also try one of the <a href="https://archive.org/details/goodytwoshoes00newyiala"> other formats of the book</a>.
+      </p>
+      </noscript>
+  </div>
+  <script type="text/javascript" src="BookReaderJSSimple.js"></script>
+  <script>
+    // Needs to be prefixed with 'mode/'. BookReader modes are: '1up', '2up',
+    // 'thumb'. BookReader defaults to 2up mode.
+    instantiateBookReader('#BookReader', {
+      defaults: 'mode/1up'
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Closes #195 

This allows for the `mode` property on the supplied options to be used to override the initial mode. Added a page with a demo and comment in the demo's code indicating where the mode values can be found. Currently, you can use class properties `constMode1up`, `constMode2up`, and `constModeThumb`.