### PR TITLE
BookReader: zoomed-in 2 page view, clicking page does not change the page

### DIFF
--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -2798,27 +2798,31 @@ BookReader.prototype.flipRightToLeft = function(newIndexL, newIndexR) {
 BookReader.prototype.setMouseHandlers2UP = function() {
     var self = this;
     ['L', 'R'].forEach(function(dir) {
-      var currentIndexEl = self.prefetchedImgs[self.twoPage['currentIndex' + dir]];
-      self.setClickHandler2UP(currentIndexEl,
-          { self: self },
-          function(e) {
-              if (e.which == 3) {
-                  // right click
-                  return !e.data.self.protected;
-              }
+        var currentIndexEl = self.prefetchedImgs[self.twoPage['currentIndex' + dir]];
+        self.setClickHandler2UP(currentIndexEl,
+            { self: self },
+            function(e) {
+                if (e.which == 3) {
+                    // right click
+                    return !e.data.self.protected;
+                }
 
-              // Changes per WEBDEV-2737
-              // BookReader: zoomed-in 2 page view, clicking page should change the page
-              $(currentIndexEl)
-              .mousemove(function() {
-                  e.preventDefault();
-              })
-              .mouseup(function() {
-                  e.data.self.trigger(BookReader.eventNames.stop);
-                  e.data.self.left();
-              });
-          }
-      );
+                // Changes per WEBDEV-2737
+                // BookReader: zoomed-in 2 page view, clicking page should change the page
+                $(currentIndexEl)
+                .mousemove(function() {
+                    e.preventDefault();
+                })
+                .mouseup(function() {
+                    e.data.self.trigger(BookReader.eventNames.stop);
+                    if (dir === 'L') {
+                        e.data.self.left();
+                    } else {
+                        e.data.self.right();
+                    }
+                });
+            }
+        );
     });
 };
 

--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -2796,52 +2796,30 @@ BookReader.prototype.flipRightToLeft = function(newIndexL, newIndexR) {
 };
 
 BookReader.prototype.setMouseHandlers2UP = function() {
-    var currentIndexL = this.prefetchedImgs[this.twoPage.currentIndexL];
-    this.setClickHandler2UP(currentIndexL,
-        { self: this },
-        function(e) {
-            if (e.which == 3) {
-                // right click
-                if (e.data.self.protected) {
-                    return false;
-                }
-                return true;
-            }
+    var self = this;
+    ['L', 'R'].forEach(function(dir) {
+      var currentIndexEl = self.prefetchedImgs[self.twoPage['currentIndex' + dir]];
+      self.setClickHandler2UP(currentIndexEl,
+          { self: self },
+          function(e) {
+              if (e.which == 3) {
+                  // right click
+                  return !e.data.self.protected;
+              }
 
-            // Changes per WEBDEV-2737
-            // BookReader: zoomed-in 2 page view, clicking page should change the page
-            $(currentIndexL)
-            .mousemove(function() {
-                e.preventDefault();
-            })
-            .mouseup(function() {
-                e.data.self.trigger(BookReader.eventNames.stop);
-                e.data.self.left();
-            });
-        }
-    );
-
-    var currentIndexR = this.prefetchedImgs[this.twoPage.currentIndexR];
-    this.setClickHandler2UP(currentIndexR,
-        { self: this },
-        function(e) {
-            if (e.which == 3) {
-                // right click
-                return !e.data.self.protected;
-            }
-
-            // Changes per WEBDEV-2737
-            // BookReader: zoomed-in 2 page view, clicking page should change the page
-            $(currentIndexR)
-            .mousemove(function() {
-                e.preventDefault();
-            })
-            .mouseup(function() {
-                e.data.self.trigger(BookReader.eventNames.stop);
-                e.data.self.right();
-            });
-        }
-    );
+              // Changes per WEBDEV-2737
+              // BookReader: zoomed-in 2 page view, clicking page should change the page
+              $(currentIndexEl)
+              .mousemove(function() {
+                  e.preventDefault();
+              })
+              .mouseup(function() {
+                  e.data.self.trigger(BookReader.eventNames.stop);
+                  e.data.self.left();
+              });
+          }
+      );
+    });
 };
 
 BookReader.prototype.prefetchImg = function(index) {

--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -2815,11 +2815,7 @@ BookReader.prototype.setMouseHandlers2UP = function() {
                 })
                 .mouseup(function() {
                     e.data.self.trigger(BookReader.eventNames.stop);
-                    if (dir === 'L') {
-                        e.data.self.left();
-                    } else {
-                        e.data.self.right();
-                    }
+                    e.data.self[dir === 'L' ? 'left' : 'right']();
                 });
             }
         );

--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -2811,7 +2811,7 @@ BookReader.prototype.setMouseHandlers2UP = function() {
         })
         .mouseup(function() {
             e.data.self.trigger(BookReader.eventNames.stop);
-            e.data.self[e.data.direction == 'L' ? 'left' : 'right']();
+            e.data.self[e.data.direction === 'L' ? 'left' : 'right']();
         });
     }
 

--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -835,9 +835,9 @@ BookReader.prototype.bindGestures = function(jElement) {
     });
 };
 
-BookReader.prototype.setClickHandler2UP = function( element, data, handler) {
+BookReader.prototype.setClickHandler2UP = function(element, data, handler) {
     $(element).unbind('mousedown').bind('mousedown', data, function(e) {
-        handler(e);
+        handler(this, e);
     });
 };
 
@@ -2797,29 +2797,34 @@ BookReader.prototype.flipRightToLeft = function(newIndexL, newIndexR) {
 
 BookReader.prototype.setMouseHandlers2UP = function() {
     var self = this;
-    ['L', 'R'].forEach(function(dir) {
-        var currentIndexEl = self.prefetchedImgs[self.twoPage['currentIndex' + dir]];
-        self.setClickHandler2UP(currentIndexEl,
-            { self: self },
-            function(e) {
-                if (e.which == 3) {
-                    // right click
-                    return !e.data.self.protected;
-                }
+    var handler = function(element, e) {
+        if (e.which == 3) {
+            // right click
+            return !e.data.self.protected;
+        }
 
-                // Changes per WEBDEV-2737
-                // BookReader: zoomed-in 2 page view, clicking page should change the page
-                $(currentIndexEl)
-                .mousemove(function() {
-                    e.preventDefault();
-                })
-                .mouseup(function() {
-                    e.data.self.trigger(BookReader.eventNames.stop);
-                    e.data.self[dir === 'L' ? 'left' : 'right']();
-                });
-            }
-        );
-    });
+        // Changes per WEBDEV-2737
+        // BookReader: zoomed-in 2 page view, clicking page should change the page
+        $(element)
+        .mousemove(function() {
+            e.preventDefault();
+        })
+        .mouseup(function() {
+            e.data.self.trigger(BookReader.eventNames.stop);
+            e.data.self[e.data.direction == 'L' ? 'left' : 'right']();
+        });
+    }
+
+    this.setClickHandler2UP(
+        this.prefetchedImgs[self.twoPage['currentIndexR']],
+        { self: self, direction: 'R' },
+        handler
+    );
+    this.setClickHandler2UP(
+        this.prefetchedImgs[self.twoPage['currentIndexL']],
+        { self: self, direction: 'L' },
+        handler
+    );
 };
 
 BookReader.prototype.prefetchImg = function(index) {

--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -836,7 +836,7 @@ BookReader.prototype.bindGestures = function(jElement) {
 };
 
 BookReader.prototype.setClickHandler2UP = function( element, data, handler) {
-    $(element).unbind('click').bind('click', data, function(e) {
+    $(element).unbind('mousedown').bind('mousedown', data, function(e) {
         handler(e);
     });
 };
@@ -2796,7 +2796,8 @@ BookReader.prototype.flipRightToLeft = function(newIndexL, newIndexR) {
 };
 
 BookReader.prototype.setMouseHandlers2UP = function() {
-    this.setClickHandler2UP( this.prefetchedImgs[this.twoPage.currentIndexL],
+    var currentIndexL = this.prefetchedImgs[this.twoPage.currentIndexL];
+    this.setClickHandler2UP(currentIndexL,
         { self: this },
         function(e) {
             if (e.which == 3) {
@@ -2807,15 +2808,21 @@ BookReader.prototype.setMouseHandlers2UP = function() {
                 return true;
             }
 
-            if (! e.data.self.twoPageIsZoomedIn()) {
+            // Changes per WEBDEV-2737
+            // BookReader: zoomed-in 2 page view, clicking page should change the page
+            $(currentIndexL)
+            .mousemove(function() {
+                e.preventDefault();
+            })
+            .mouseup(function() {
                 e.data.self.trigger(BookReader.eventNames.stop);
                 e.data.self.left();
-            }
-            e.preventDefault();
+            });
         }
     );
 
-    this.setClickHandler2UP( this.prefetchedImgs[this.twoPage.currentIndexR],
+    var currentIndexR = this.prefetchedImgs[this.twoPage.currentIndexR];
+    this.setClickHandler2UP(currentIndexR,
         { self: this },
         function(e) {
             if (e.which == 3) {
@@ -2823,11 +2830,16 @@ BookReader.prototype.setMouseHandlers2UP = function() {
                 return !e.data.self.protected;
             }
 
-            if (! e.data.self.twoPageIsZoomedIn()) {
+            // Changes per WEBDEV-2737
+            // BookReader: zoomed-in 2 page view, clicking page should change the page
+            $(currentIndexR)
+            .mousemove(function() {
+                e.preventDefault();
+            })
+            .mouseup(function() {
                 e.data.self.trigger(BookReader.eventNames.stop);
                 e.data.self.right();
-            }
-            e.preventDefault();
+            });
         }
     );
 };


### PR DESCRIPTION
This PR is based on https://webarchive.jira.com/browse/WEBDEV-2737

- When you have zoomed-in 2 page view, should be be able to drag image to see around.
- When you have zoomed-in 2 page view, you should be able to click on book image to change page.