### PR TITLE
Mouse drag of image inconsistent for onepage view

### DIFF
--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -628,12 +628,6 @@ BookReader.prototype.init = function() {
         this.$('.BRicon.share').hide();
     }
 
-    this.$('.BRpagediv1up').bind('mousedown', this, function() {
-        // $$$ the purpose of this is to disable selection of the image (makes it turn blue)
-        //     but this also interferes with right-click.  See https://bugs.edge.launchpad.net/gnubook/+bug/362626
-        return false;
-    });
-
     this.trigger(BookReader.eventNames.PostInit);
 
     this.init.initComplete = true;


### PR DESCRIPTION
This PR is based of https://webarchive.jira.com/browse/WEBDEV-2995

- Currently on this page https://archive.org/details/goody/mode/1up you **can't** drag image to see next 
 page. Either you can scroll the page using mouse wheel or flip right and/or flit left.
- Same behaviour is applied on liner notes.