### PR TITLE
Switch back to using PNG for hamburger icon

### DIFF
--- a/BookReader/BookReader.css
+++ b/BookReader/BookReader.css
@@ -2012,31 +2012,16 @@ html.mm-background .BookReader {
 }
 
 .BRmobileHamburger {
+  background: center center no-repeat transparent;
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABsAAAATCAYAAABhh3Y4AAAAAXNSR0IArs4c6QAAAFZJREFUSA1jrKmpafv//38xELMx0AgwMjL+AuJeFqAlubS0COR+qPm5TED2FJDNNPIU2FiozybT0o5Rs4dBCDCO5jNKYnE0n1ESeiNI72g+oyiyYfkMAKCpRQemMsj0AAAAAElFTkSuQmCC");
   display: block;
+  width: 40px;
+  height: 40px;
   position: absolute;
   top: 0;
-  left: 17px;
-  width: 26px;
-  height: 3px;
-  margin: 18px 0;
-  outline: none;
+  left: 10px;
   border: none;
-  border-radius: 3px;
-  background: #7a7a7a;
-}
-.BRmobileHamburger:before, .BRmobileHamburger:after {
-  position: absolute;
-  top: -8px;
-  right: 0;
-  left: 0;
-  height: 3px;
-  content: "";
-  border-radius: 3px;
-  background: #7a7a7a;
-}
-.BRmobileHamburger:after {
-  top: auto;
-  bottom: -8px;
+  outline: none;
 }
 
 .DrawerIconWrapper {

--- a/src/css/_MobileNav.scss
+++ b/src/css/_MobileNav.scss
@@ -45,32 +45,19 @@ html.mm-background .BookReader {
 }
 
 .BRmobileHamburger {
-  display: block;
-  position: absolute;
-  top: 0;
-  left: 17px;
-  width: 26px;
-  height: 3px;
-  margin: 18px 0;
-  outline: none;
+	background: center center no-repeat transparent;
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABsAAAATCAYAAABhh3Y4AAAAAXNSR0IArs4c6QAAAFZJREFUSA1jrKmpafv//38xELMx0AgwMjL+AuJeFqAlubS0COR+qPm5TED2FJDNNPIU2FiozybT0o5Rs4dBCDCO5jNKYnE0n1ESeiNI72g+oyiyYfkMAKCpRQemMsj0AAAAAElFTkSuQmCC');
+  /* Should use SVG (below). See https://github.com/internetarchive/bookreader/issues/100 */
+  /*background: url('data:image/svg+xml;utf8,<svg width="15px" height="12px" viewBox="0 0 15 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"> <g id="hamburger-svg" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="square"> <path d="M0,1 L14,1" id="Line" stroke="#000000"></path> <path d="M2.39808173e-14,6 L14,6" id="Line-Copy" stroke="#000000"></path> <path d="M1.15463195e-14,11 L14,11" id="Line-Copy-2" stroke="#000000"></path> </g></svg>') center / 50% 50% no-repeat;*/
+
+	display: block;
+	width: 40px;
+	height: 40px;
+	position: absolute;
+	top: 0;
+  left: 10px;
   border: none;
-  border-radius: 3px;
-  background: #7a7a7a;
-  &:before,
-  &:after {
-    position: absolute;
-    top: -8px;
-    right: 0;
-    left: 0;
-    height: 3px;
-    content: "";
-    border-radius: 3px;
-    background: #7a7a7a;
-  }
-  &:after {
-    top: auto;
-    bottom: -8px;
-  }
+  outline: none;
 }
 
 .DrawerIconWrapper {


### PR DESCRIPTION
Closes #144 

Reverts internetarchive/bookreader#106 ; it was causing an odd issue where the button would only work if clicked on the hamburger buns or patty :P Choosing a revert here since it seems like the least likely change to cause more bugs (the fact that it requires very little work, is also appealing :P ). We can find a longer-term solution in the future.

✅ Tested: FF73; Ch 80 on Win10
Steps:
1. Visit http://localhost:8000/BookReaderDemo/demo-fullscreen.html#mode/2up
2. Resize until in mobile view
3. Click hamburger icon