### PR TITLE
Update webpack to dynamically compile files from a list

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,21 @@
 const path = require('path');
 
-module.exports = [
-    buildJsFromTo({from: 'plugins/plugin.archive_analytics.js', to: 'BookReader/plugins/plugin.archive_analytics.js'}),
-    buildJsFromTo({from: 'plugins/menu_toggle/plugin.menu_toggle.js', to: 'BookReader/plugins/plugin.menu_toggle.js'}),
-    buildJsFromTo({from: 'plugins/tts/plugin.tts.js', to: 'BookReader/plugins/plugin.tts.js'}),
+const listOfFiles = [
+    'plugins/plugin.archive_analytics.js',
+    'plugins/menu_toggle/plugin.menu_toggle.js',
+    'plugins/tts/plugin.tts.js',
 ];
+
+const compileFiles = async () => {
+    const nestedDirs = new RegExp('/(.*)/');
+    return await listOfFiles.map((filePath) => {
+        const flattenedFilePath = filePath.replace(nestedDirs, '/');
+        return buildJsFromTo({
+            from: filePath,
+            to: `BookReader/${flattenedFilePath}`
+        });
+    });
+};
 
 /**
  * @param {Object} opts
@@ -32,3 +43,5 @@ function buildJsFromTo({ from: srcEntryFile, to: outputFile }) {
         devtool: 'source-map'
     };
 }
+
+module.exports = compileFiles();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,9 @@ const path = require('path');
 
 module.exports = buildJSFiles();
 
+/**
+ * Applies bundling to the listed files.
+ */
 function buildJSFiles () {
     const listOfFiles = [
         'plugins/plugin.archive_analytics.js',
@@ -19,6 +22,8 @@ function buildJSFiles () {
 }
 
 /**
+ * Applies webpack config to files that it is bundling.
+ *
  * @param {Object} opts
  * @param {String} opts.from
  * @param {String} opts.to

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,21 +1,22 @@
 const path = require('path');
 
-const listOfFiles = [
-    'plugins/plugin.archive_analytics.js',
-    'plugins/menu_toggle/plugin.menu_toggle.js',
-    'plugins/tts/plugin.tts.js',
-];
+module.exports = buildJSFiles();
 
-const compileFiles = async () => {
+function buildJSFiles () {
+    const listOfFiles = [
+        'plugins/plugin.archive_analytics.js',
+        'plugins/menu_toggle/plugin.menu_toggle.js',
+        'plugins/tts/plugin.tts.js',
+    ];
     const nestedDirs = new RegExp('/(.*)/');
-    return await listOfFiles.map((filePath) => {
+    return listOfFiles.map((filePath) => {
         const flattenedFilePath = filePath.replace(nestedDirs, '/');
         return buildJsFromTo({
             from: filePath,
             to: `BookReader/${flattenedFilePath}`
         });
     });
-};
+}
 
 /**
  * @param {Object} opts
@@ -43,5 +44,3 @@ function buildJsFromTo({ from: srcEntryFile, to: outputFile }) {
         devtool: 'source-map'
     };
 }
-
-module.exports = compileFiles();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,9 +11,9 @@ function buildJSFiles () {
         'plugins/menu_toggle/plugin.menu_toggle.js',
         'plugins/tts/plugin.tts.js',
     ];
-    const nestedDirs = new RegExp('/(.*)/');
+    const nestedDirRegex = new RegExp('/(.*)/');
     return listOfFiles.map((filePath) => {
-        const flattenedFilePath = filePath.replace(nestedDirs, '/');
+        const flattenedFilePath = filePath.replace(nestedDirRegex, '/');
         return buildJsFromTo({
             from: filePath,
             to: `BookReader/${flattenedFilePath}`

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,18 +1,17 @@
 const path = require('path');
 
-module.exports = buildJSFiles();
+module.exports = buildJSFiles([
+    'plugins/plugin.archive_analytics.js',
+    'plugins/menu_toggle/plugin.menu_toggle.js',
+    'plugins/tts/plugin.tts.js',
+]);
 
 /**
  * Applies bundling to the listed files.
  */
-function buildJSFiles () {
-    const listOfFiles = [
-        'plugins/plugin.archive_analytics.js',
-        'plugins/menu_toggle/plugin.menu_toggle.js',
-        'plugins/tts/plugin.tts.js',
-    ];
+function buildJSFiles (files) {
     const nestedDirRegex = new RegExp('/(.*)/');
-    return listOfFiles.map((filePath) => {
+    return files.map((filePath) => {
         const flattenedFilePath = filePath.replace(nestedDirRegex, '/');
         return buildJsFromTo({
             from: filePath,


### PR DESCRIPTION
Takes a file from the file list and outputs compiled file in the `BookReader` directory.
It keeps the same flattened directory structure as the file mapper it replaces.

Note: I purposely kept the file list, and didn't fully automate because I wanted to make the entrypoints explicit.

This is part of internal ticket: https://webarchive.jira.com/browse/WEBDEV-3183

Regex example: https://regexr.com/4v9m4

### How to test:
- pull down branch
- at top of BookReader directory, run the following:
  - `npm install` to update your modules
  - `npx webpack` to build the files
    - if you didn't delete any built files or update an es6 file listed, no files should have updated
    - if you update a file and run `npx webpack` - a change should be picked up by git for you to commit/review