### PR TITLE
4.6.0

### DIFF
--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -79,7 +79,7 @@ function BookReader(options) {
     this.setup(options);
 }
 
-BookReader.version = '4.5.1';
+BookReader.version = '4.6.0';
 
 // Mode constants
 BookReader.constMode1up = 1;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 4.6.0
+Big change: all the plugins are now written in es6, and compiled to es5. There should
+be no observable changes, but note this was a big change.
+
+- Fix: UI on archive.org not consistent with demos due to CSS conflicts; @rchrd2
+- Convert all plugins to es6 + webpack; @cdrini @iisa @nsharma123
+- Increase jest coverage 39% → 47%; @cdrini @iisa @nsharma123
+- Increase testcafe coverage; @iisa
+- Add testcafe to travis; @cdrini
+- Add more/enforce more lint rules; @cdrini
+- Make demo pages more in sync with Internet Archive pages; @mc2
+- Add `npm run serve-dev` for auto-watching + auto-refreshing dev server; @cdrini
+
 # 4.5.1
 - Fix: Click-to-flip now works in 2up mode zoomed in
 - Fix: Image panning sometimes not working

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bookreader",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookreader",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "description": "The Internet Archive BookReader.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Review app: https://58-review-br-es6ify-b09jkq.archive.org/

After you push/merge, use this link to release: https://github.com/internetarchive/bookreader/releases/new?tag=v4.6.0&title=v4.6.0&body=Big%20change%3A%20all%20the%20plugins%20are%20now%20written%20in%20es6%2C%20and%20compiled%20to%20es5.%20There%20should%0Abe%20no%20observable%20changes%2C%20but%20note%20this%20was%20a%20big%20change.%0A%0A-%20Fix%3A%20UI%20on%20archive.org%20not%20consistent%20with%20demos%20due%20to%20CSS%20conflicts%3B%20%40rchrd2%0A-%20Convert%20all%20plugins%20to%20es6%20%2B%20webpack%3B%20%40cdrini%20%40iisa%20%40nsharma123%0A-%20Increase%20jest%20coverage%2039%25%20%E2%86%92%2047%25%3B%20%40cdrini%20%40iisa%20%40nsharma123%0A-%20Increase%20testcafe%20coverage%3B%20%40iisa%0A-%20Add%20testcafe%20to%20travis%3B%20%40cdrini%0A-%20Add%20more%2Fenforce%20more%20lint%20rules%3B%20%40cdrini%0A-%20Make%20demo%20pages%20more%20in%20sync%20with%20Internet%20Archive%20pages%3B%20%40mc2%0A-%20Add%20%60npm%20run%20serve-dev%60%20for%20auto-watching%20%2B%20auto-refreshing%20dev%20server%3B%20%40cdrini%0A