### PR TITLE
OCR Clean up

### DIFF
--- a/src/js/plugins/tts/PageChunk.js
+++ b/src/js/plugins/tts/PageChunk.js
@@ -110,9 +110,9 @@ export default class PageChunk {
     let textList = text.trim().split(' ')
     const firstWord = textList[0];
     if(firstWord.length == 1 && firstWord != 'I' && firstWord != 'A') {
-        textList.shift();
-        textList[0] = firstWord + textList[0];
-      }
+      textList.shift();
+      textList[0] = firstWord + textList[0];
+    }
     textList = textList.join(' ')
     return textList;
   }

--- a/src/js/plugins/tts/PageChunk.js
+++ b/src/js/plugins/tts/PageChunk.js
@@ -53,7 +53,8 @@ export default class PageChunk {
   static _fromTextWrapperResponse(leafIndex, chunksResponse) {
     return chunksResponse.map((c, i) => {
       const correctedLineRects = PageChunk._fixChunkRects(c.slice(1));
-      const correctedText = PageChunk._removeDanglingHyphens(c[0]);
+      let correctedText = PageChunk._removeDanglingHyphens(c[0]);
+      correctedText = PageChunk._fixIsolatedLetters(correctedText)
       return new PageChunk(leafIndex, i, correctedText, correctedLineRects);
     });
   }
@@ -98,6 +99,22 @@ export default class PageChunk {
    */
   static _removeDanglingHyphens(text) {
     return text.replace(/-\s+/g, '');
+  }
+
+  /**
+   * Concatenate isolated letters caused due to wrong interpretation of OCR
+   * @param {string} text 
+   * @return {string}
+   */
+  static _fixIsolatedLetters(text) {
+    let textList = text.trim().split(' ')
+    const firstWord = textList[0];
+    if(firstWord.length == 1 && firstWord != 'I' && firstWord != 'A') {
+        textList.shift();
+        textList[0] = firstWord + textList[0];
+      }
+    textList = textList.join(' ')
+    return textList;
   }
 }
 

--- a/src/js/plugins/tts/PageChunk.js
+++ b/src/js/plugins/tts/PageChunk.js
@@ -112,7 +112,7 @@ export default class PageChunk {
     if(firstWord.length == 1 && firstWord != 'I' && firstWord != 'A') {
       textList.shift();
       textList[0] = firstWord + textList[0];
-    }
+      }
     textList = textList.join(' ')
     return textList;
   }

--- a/src/js/plugins/tts/PageChunk.js
+++ b/src/js/plugins/tts/PageChunk.js
@@ -53,7 +53,7 @@ export default class PageChunk {
   static _fromTextWrapperResponse(leafIndex, chunksResponse) {
     return chunksResponse.map((c, i) => {
       const correctedLineRects = PageChunk._fixChunkRects(c.slice(1));
-      let correctedText = PageChunk._removeDanglingHyphens(c[0]);
+      let correctedText = PageChunk._trimUnwantedSymbols(c[0]);
       correctedText = PageChunk._fixIsolatedLetters(correctedText)
       return new PageChunk(leafIndex, i, correctedText, correctedLineRects);
     });
@@ -93,14 +93,14 @@ export default class PageChunk {
   }
 
   /**
-   * Remove "dangling" hyphens from read aloud text to avoid TTS stuttering
+   * Trim unwanted symbols present in text to prevent TTS speaking out the symbols
    * @param {string} text 
    * @return {string}
    */
-  static _removeDanglingHyphens(text) {
-    return text.replace(/-\s+/g, '');
+  static _trimUnwantedSymbols(text) {
+    text = text.replace(/-\s+/g, '');
+    return text.replace(/[^0-9a-zA-Z"!&,. -]/g, ''); //Trim all the unwanted symbols other than comma,fullstop and & which is pronounced while reading
   }
-
   /**
    * Concatenate isolated letters caused due to wrong interpretation of OCR
    * @param {string} text 
@@ -112,7 +112,7 @@ export default class PageChunk {
     if(firstWord.length == 1 && firstWord != 'I' && firstWord != 'A') {
       textList.shift();
       textList[0] = firstWord + textList[0];
-      }
+    }
     textList = textList.join(' ')
     return textList;
   }

--- a/tests/plugins/tts/PageChunk.test.js
+++ b/tests/plugins/tts/PageChunk.test.js
@@ -35,26 +35,32 @@ describe('_fromTextWrapperResponse', () => {
     });
 });
 
-describe('_removeDanglingHyphens', () => {
-    const { _removeDanglingHyphens } = PageChunk;
+describe('_trimUnwantedSymbols', () => {
+    const { _trimUnwantedSymbols } = PageChunk;
 
     test('No change to empty string', () => {
-        expect(_removeDanglingHyphens('')).toEqual('');
+        expect(_trimUnwantedSymbols('')).toEqual('');
     });
 
     test('No change when no hyphens string', () => {
-        expect(_removeDanglingHyphens('Hello world!')).toEqual('Hello world!');
+        expect(_trimUnwantedSymbols('Hello world!')).toEqual('Hello world!');
     });
 
     test('No change to hyphens mid-word', () => {
-        expect(_removeDanglingHyphens('It is mid-word!')).toEqual('It is mid-word!');
+        expect(_trimUnwantedSymbols('It is mid-word!')).toEqual('It is mid-word!');
     });
 
     test('Removes hyphens followed by spaces', () => {
-        expect(_removeDanglingHyphens('It is not mid- word!')).toEqual('It is not midword!');
-        expect(_removeDanglingHyphens('mid- word fid- word')).toEqual('midword fidword');
+        expect(_trimUnwantedSymbols('It is not mid- word!')).toEqual('It is not midword!');
+        expect(_trimUnwantedSymbols('mid- word fid- word')).toEqual('midword fidword');
     });
+    
+    test('Removes unwanted symbols from text', () => {
+        expect(_trimUnwantedSymbols('**Go away yourself!^_- %$')).toEqual('Go away yourself!');
+        expect(_trimUnwantedSymbols('mid- word fid- word')).toEqual('midword fidword');
+    });    
 });
+
 
 describe('_fixIsolatedLetters', () => {
     const { _fixIsolatedLetters } = PageChunk;

--- a/tests/plugins/tts/PageChunk.test.js
+++ b/tests/plugins/tts/PageChunk.test.js
@@ -55,3 +55,24 @@ describe('_removeDanglingHyphens', () => {
         expect(_removeDanglingHyphens('mid- word fid- word')).toEqual('midword fidword');
     });
 });
+
+describe('_fixIsolatedLetters', () => {
+    const { _fixIsolatedLetters } = PageChunk;
+
+    test('No change to empty string', () => {
+        expect(_fixIsolatedLetters('')).toEqual('');
+    });
+
+    test('Concatenate when isolated letter other than A and I are found', () => {
+        expect(_fixIsolatedLetters('W hen they come for me!')).toEqual('When they come for me!');
+    });
+
+    test('No change to already fixed words', () => {
+        expect(_fixIsolatedLetters('This sentence is correct')).toEqual('This sentence is correct');
+    });
+
+    test('Ambiguous case where it is difficult to decide whether to concatenate or not', () => {
+        expect(_fixIsolatedLetters('It is absolutely fine')).toEqual('It is absolutely fine');
+        expect(_fixIsolatedLetters('I love book reader')).toEqual('I love book reader');
+    });
+});


### PR DESCRIPTION
Clean and optimize text generated by OCR
Closes #264 and #274 
- Concatenates incorrectly split words in the text files
eg: ``W hen they came`` fixes to ``When they came`` 
- Prevents TTS to speak out symbols generated due to wrong OCR interpretations.