### PR TITLE
Removes xvfb-run command in front of e2e test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,11 @@ node_js:
   - '12'
 install:
   - npm install
+before_script:
+  - fluxbox >/dev/null 2>&1 &
+  - sleep 3
 script:
   - npm run lint
   - npm run test:coverage
-  - xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" npm run test:e2e
+  - npm run test:e2e
   - npm run codecov


### PR DESCRIPTION
Per https://github.com/DevExpress/testcafe/pull/4828/commits/8fdedc9a58e99972a05ff7c54cd04a851dabbec8
adds a `before_script` block