### PR TITLE
Treat CSS build files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # keep these lines sorted in ascending order.
 # Build files
+BookReader/BookReader.css* binary
 BookReader/BookReader.js binary
 BookReader/*.js.map binary
 BookReader/plugins/*.js.map binary


### PR DESCRIPTION
This way CSS changes don't show up twice when running `git diff`.