### PR TITLE
Run build in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_script:
   - fluxbox >/dev/null 2>&1 &
   - sleep 3
 script:
+  - npm run build
   - npm run lint
   - npm run test:coverage
   - npm run test:e2e

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The Fragment Change message is sent to the parent window when the embedded BookR
 
 The source JavaScript is written in ES6 (located in the `src/js` directory) and in ES5 (located in `BookReader`). `npm run serve-dev` starts an auto-reloading dev server, that builds js/css that has been edited at `localhost:8000`.
 
-Until the next major version bump, we have to store the build files inside the repo to maintain backwards compatibility, so you will have to also commit the build files in your PRs. We recommend keeping these as separate commits labelled "Build files", since that makes it easier to resolve merge conflicts or just drop them as necessary. To just build, run `npm run build`.
+Until the next major version bump, we have to store the build files inside the repo to maintain backwards compatibility. Please _DO NOT_ include these files in your PR. Anything in the `BookReader/` directory should not be committed.
 
 ## Releases
 


### PR DESCRIPTION
Run the build step inside Travis to ensure the tests are running on the latest code. This means we no longer need to include the build files in PRs \o/ . The build files will only be added when a release is cut (automatically by the release script).

Note: If you're testing this on a review app or something, you'll now have to run `npm build` on the review app.