### PR TITLE
Make preversion script output link of new PRs instead of new commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "iso-language-codes": "1.0.5",
     "jest": "25.1.0",
     "live-server": "1.2.1",
+    "node-fetch": "2.6.0",
     "regenerator-runtime": "0.13.3",
     "sass": "1.22.12",
     "sinon": "7.3.2",

--- a/scripts/preversion.js
+++ b/scripts/preversion.js
@@ -1,4 +1,14 @@
 const { version: OLD_VERSION } = require('../package.json');
-const GITHUB_DIFF_URL = `https://github.com/internetarchive/bookreader/compare/v${OLD_VERSION}...master`
+const fetch = require('node-fetch');
+const OLD_RELEASE_URL = `https://api.github.com/repos/internetarchive/bookreader/releases/tags/v${OLD_VERSION}`;
 
-console.log(`Here's what's changed since the last version: ${GITHUB_DIFF_URL}`);
+async function main() {
+    const {created_at} = await fetch(OLD_RELEASE_URL).then(r => r.json());
+    const today = new Date().toISOString().slice(0, -5);
+    const searchUrl = 'https://github.com/internetarchive/bookreader/pulls?' + new URLSearchParams({
+        q: `is:pr is:merged merged:${created_at}..${today}Z sort:updated-asc`
+    }).toString();
+    console.log(`Here are all the PRs that were merged since the last version: ${searchUrl}`);
+}
+
+main();


### PR DESCRIPTION
The preversion script (run before a version bump happens) outputs a github link to a diff of that last version up to master. This is useful, but also a little too much information. Changing it to provide a link to the PRs that were merged since then.

Before:
> Here's what's changed since the last version: [https://github.com/internetarchive/bookreader/compare/v4.8.0...master](https://github.com/internetarchive/bookreader/compare/v4.8.0...master)


After: 
> Here are all the PRs that were merged since the last version: https://github.com/internetarchive/bookreader/pulls?q=is%3Apr+is%3Amerged+merged%3A2020-04-14T15%3A40%3A13Z..2020-05-07T21%3A24%3A05Z+sort%3Aupdated-asc