### PR TITLE
Prefetch should skip unviewable pages

### DIFF
--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -1870,32 +1870,30 @@ BookReader.prototype.pruneUnusedImgs = function() {
   }
 };
 
+/**
+ * Fetches the currently displayed images (if not already fetching)
+ * as wells as any nearby pages.
+ */
 BookReader.prototype.prefetch = function() {
   // $$$ We should check here if the current indices have finished
   //     loading (with some timeout) before loading more page images
   //     See https://bugs.edge.launchpad.net/bookreader/+bug/511391
+  const { max, min } = Math;
+  const { book } = this._models;
+  const { currentIndexL, currentIndexR } = this.twoPage;
+  const ADJACENT_PAGES_TO_LOAD = 3;
 
-  // prefetch visible pages first
-  this.prefetchImg(this.twoPage.currentIndexL);
-  this.prefetchImg(this.twoPage.currentIndexR);
-
-  var adjacentPagesToLoad = 3;
-
-  var lowCurrent = Math.min(this.twoPage.currentIndexL, this.twoPage.currentIndexR);
-  var highCurrent = Math.max(this.twoPage.currentIndexL, this.twoPage.currentIndexR);
-
-  var start = Math.max(lowCurrent - adjacentPagesToLoad, 0);
-  var end = Math.min(highCurrent + adjacentPagesToLoad, this._models.book.getNumLeafs() - 1);
-
-  // Load images spreading out from current
-  for (var i = 1; i <= adjacentPagesToLoad; i++) {
-    var goingDown = lowCurrent - i;
-    if (goingDown >= start) {
-      this.prefetchImg(goingDown);
+  let lowPage = book.getPage(min(currentIndexL, currentIndexR));
+  let highPage = book.getPage(max(currentIndexL, currentIndexR));
+  for (let i = 0; i < ADJACENT_PAGES_TO_LOAD + 1; i++) {
+    if (lowPage) {
+      this.prefetchImg(lowPage.index);
+      lowPage = lowPage.findPrev({ combineConsecutiveUnviewables: true });
     }
-    var goingUp = highCurrent + i;
-    if (goingUp <= end) {
-      this.prefetchImg(goingUp);
+
+    if (highPage) {
+      this.prefetchImg(highPage.index);
+      highPage = highPage.findNext({ combineConsecutiveUnviewables: true });
     }
   }
 };

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -1870,34 +1870,6 @@ BookReader.prototype.pruneUnusedImgs = function() {
   }
 };
 
-/**
- * Fetches the currently displayed images (if not already fetching)
- * as wells as any nearby pages.
- */
-BookReader.prototype.prefetch = function() {
-  // $$$ We should check here if the current indices have finished
-  //     loading (with some timeout) before loading more page images
-  //     See https://bugs.edge.launchpad.net/bookreader/+bug/511391
-  const { max, min } = Math;
-  const { book } = this._models;
-  const { currentIndexL, currentIndexR } = this.twoPage;
-  const ADJACENT_PAGES_TO_LOAD = 3;
-
-  let lowPage = book.getPage(min(currentIndexL, currentIndexR));
-  let highPage = book.getPage(max(currentIndexL, currentIndexR));
-  for (let i = 0; i < ADJACENT_PAGES_TO_LOAD + 1; i++) {
-    if (lowPage) {
-      this.prefetchImg(lowPage.index);
-      lowPage = lowPage.findPrev({ combineConsecutiveUnviewables: true });
-    }
-
-    if (highPage) {
-      this.prefetchImg(highPage.index);
-      highPage = highPage.findNext({ combineConsecutiveUnviewables: true });
-    }
-  }
-};
-
 /************************/
 /** Mode2Up extensions **/
 /************************/
@@ -2001,6 +1973,9 @@ exposeOverrideableMethod(Mode2Up, '_modes.mode2Up', 'jumpIndexForLeftEdgePageX',
 /** @deprecated unused outside BookReader, Mode2Up */
 BookReader.prototype.jumpIndexForRightEdgePageX = Mode2Up.prototype.jumpIndexForRightEdgePageX;
 exposeOverrideableMethod(Mode2Up, '_modes.mode2Up', 'jumpIndexForRightEdgePageX', 'jumpIndexForRightEdgePageX');
+/** @deprecated unused outside Mode2Up */
+BookReader.prototype.prefetch = Mode2Up.prototype.prefetch;
+exposeOverrideableMethod(Mode2Up, '_modes.mode2Up', 'prefetch', 'prefetch');
 
 /**
  * Immediately stop flip animations.  Callbacks are triggered.

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -1171,7 +1171,9 @@ export class Mode2Up {
     const { currentIndexL, currentIndexR } = this.br.twoPage;
     const ADJACENT_PAGES_TO_LOAD = 3;
 
-    let lowPage = book.getPage(min(currentIndexL, currentIndexR));
+    // currentIndexL can be -1; getPage returns the last page of the book
+    // when given -1, so need to prevent that.
+    let lowPage = book.getPage(max(0, min(currentIndexL, currentIndexR)));
     let highPage = book.getPage(max(currentIndexL, currentIndexR));
     for (let i = 0; i < ADJACENT_PAGES_TO_LOAD + 1; i++) {
       if (lowPage) {

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -1157,6 +1157,34 @@ export class Mode2Up {
       return jumpIndex;
     }
   }
+
+  /**
+   * Fetches the currently displayed images (if not already fetching)
+   * as wells as any nearby pages.
+   */
+  prefetch() {
+    // $$$ We should check here if the current indices have finished
+    //     loading (with some timeout) before loading more page images
+    //     See https://bugs.edge.launchpad.net/bookreader/+bug/511391
+    const { max, min } = Math;
+    const { book } = this;
+    const { currentIndexL, currentIndexR } = this.br.twoPage;
+    const ADJACENT_PAGES_TO_LOAD = 3;
+
+    let lowPage = book.getPage(min(currentIndexL, currentIndexR));
+    let highPage = book.getPage(max(currentIndexL, currentIndexR));
+    for (let i = 0; i < ADJACENT_PAGES_TO_LOAD + 1; i++) {
+      if (lowPage) {
+        this.br.prefetchImg(lowPage.index);
+        lowPage = lowPage.findPrev({ combineConsecutiveUnviewables: true });
+      }
+
+      if (highPage) {
+        this.br.prefetchImg(highPage.index);
+        highPage = highPage.findNext({ combineConsecutiveUnviewables: true });
+      }
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Previously, it would prefetch the unviewable pages as well (as in the dummy page; not the actual uri). Now it only prefetches the first unviewable, and then everything else. Also moved this function to Mode2Up, since it's only used there.