### PR TITLE
Search result is now highlighted when user lands on this page

### DIFF
--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -72,6 +72,7 @@ export class Mode2Up {
 
     this.displayedIndices = [this.br.twoPage.currentIndexL, this.br.twoPage.currentIndexR];
     this.setMouseHandlers();
+    this.br.displayedIndices = this.displayedIndices;
     this.br.updateToolbarZoom(this.br.reduce);
   }
 

--- a/tests/BookReader/Mode2Up.test.js
+++ b/tests/BookReader/Mode2Up.test.js
@@ -10,31 +10,60 @@ import { deepCopy } from '../utils.js';
 import { Mode2Up } from '../../src/js/BookReader/Mode2Up.js';
 import BookReader from '../../src/js/BookReader.js';
 
+beforeAll(() => {
+  global.alert = jest.fn();
+})
 afterEach(() => {
-    sinon.restore();
+  jest.restoreAllMocks();
+  sinon.restore();
 });
 
 /** @type {BookReaderOptions['data']} */
 const SAMPLE_DATA = [
-    [
-        { width: 123, height: 123, uri: 'https://archive.org/image0.jpg', pageNum: '1' },
-    ],
-    [
-        { width: 123, height: 123, uri: 'https://archive.org/image1.jpg', pageNum: '2' },
-        { width: 123, height: 123, uri: 'https://archive.org/image2.jpg', pageNum: '3' },
-    ],
-    [
-        { width: 123, height: 123, uri: 'https://archive.org/image3.jpg', pageNum: '4' },
-    ],
+  [
+    { width: 123, height: 123, uri: 'https://archive.org/image0.jpg', pageNum: '1' },
+  ],
+  [
+    { width: 123, height: 123, uri: 'https://archive.org/image1.jpg', pageNum: '2' },
+    { width: 123, height: 123, uri: 'https://archive.org/image2.jpg', pageNum: '3' },
+  ],
+  [
+    { width: 123, height: 123, uri: 'https://archive.org/image3.jpg', pageNum: '4' },
+  ],
 ];
 
 describe('zoom', () => {
-    test('stops animations when zooming', () => {
-        const br = new BookReader({ data: SAMPLE_DATA });
-        br.init();
+  test('stops animations when zooming', () => {
+    const br = new BookReader({ data: SAMPLE_DATA });
+    br.init();
 
-        const stopAnim = sinon.spy(br, 'stopFlipAnimations');
-        br._modes.mode2Up.zoom('in');
-        expect(stopAnim.callCount).toBe(1);
-    });
+    const stopAnim = sinon.spy(br, 'stopFlipAnimations');
+    br._modes.mode2Up.zoom(1);
+    expect(stopAnim.callCount).toBe(1);
+  });
+});
+
+describe('draw 2up leaves', () => {
+  test('calls `drawLeafs` on init as default', () => {
+    const br = new BookReader({ data: SAMPLE_DATA });
+    const drawLeafs = sinon.spy(br._modes.mode2Up, 'drawLeafs');
+
+    br.init();
+    expect(drawLeafs.callCount).toBe(1);
+  })
+
+  test('sets `this.displayedIndices`', () => {
+    const extremelyWrongValueForDisplayedIndices = null;
+    const br = new BookReader({ data: SAMPLE_DATA });
+
+    br.init();
+    br.displayedIndices = extremelyWrongValueForDisplayedIndices;
+    expect(br.displayedIndices).toBe(extremelyWrongValueForDisplayedIndices);
+
+    br._modes.mode2Up.drawLeafs();
+
+    expect(br.displayedIndices).not.toBe(extremelyWrongValueForDisplayedIndices);
+    expect(br.displayedIndices.length).toBe(2); // is array
+    expect(br.displayedIndices).toEqual([-1, 0]); // default to starting index on right, placeholder for left
+  })
 });


### PR DESCRIPTION
Problem: 
Go to https://archive.org/details/sim_the-bibliotheca-sacra_1905-04_62_246/page/334/mode/2up/search/Egyptian+sacrifices - and the search result on the page you landed on does not have highlight.
If you flip forward and then back, the highlight is there.

This fixes the problem.
Go to: https://www-isa.archive.org/details/newatlantis642baco/page/42/mode/2up/search/atlantis
and the result is highlighted on load ✅ 

To test locally:
- checkout branch
- update your dependencies, cmd: `npm install`
- run your dev server, cmd: `npm run serve-dev`
- go to `http://127.0.0.1:8080/BookReaderDemo/demo-ia-plato.html#page/388/mode/2up/search/honest` - and you will see the result highlighted on the page you dropped into

