### PR TITLE
Search inside cleanup

### DIFF
--- a/src/js/plugins/plugin.mobile_nav.js
+++ b/src/js/plugins/plugin.mobile_nav.js
@@ -9,6 +9,8 @@
  * <link rel="stylesheet" href="../BookReader/mmenu/dist/addons/navbars/jquery.mmenu.navbars.css" />
  */
 
+import * as utils from '../BookReader/utils.js';
+
 jQuery.extend(BookReader.defaultOptions, {
   enableMobileNav: true,
   mobileNavTitle: 'Internet Archive',
@@ -103,7 +105,7 @@ BookReader.prototype.initToolbar = (function (super_) {
         }
       });
 
-      window.addEventListener('resize', (e) => {
+      const closeMobileMenu = (e) => {
         // Need to close the mobile menu to reset DOM & Style
         // driven by menu plugin
         const width = $( window ).width();
@@ -112,7 +114,9 @@ BookReader.prototype.initToolbar = (function (super_) {
         if (mobileMenuIsOpen && (width >= 800)) {
           $mmenuEl.data('mmenu').close ();
         }
-      });
+      };
+
+      window.addEventListener('resize', utils.debounce(closeMobileMenu, 900));
     }
   };
 })(BookReader.prototype.initToolbar);

--- a/src/js/plugins/plugin.mobile_nav.js
+++ b/src/js/plugins/plugin.mobile_nav.js
@@ -102,6 +102,17 @@ BookReader.prototype.initToolbar = (function (super_) {
           $mmenuEl.data('mmenu').open();
         }
       });
+
+      window.addEventListener('resize', (e) => {
+        // Need to close the mobile menu to reset DOM & Style
+        // driven by menu plugin
+        const width = $( window ).width();
+        const mobileMenuIsOpen = $mmenuEl.data('mmenu').getInstance().vars.opened;
+        // $brBreakPointMobile: 800px;
+        if (mobileMenuIsOpen && (width >= 800)) {
+          $mmenuEl.data('mmenu').close ();
+        }
+      });
     }
   };
 })(BookReader.prototype.initToolbar);

--- a/src/js/plugins/plugin.search.js
+++ b/src/js/plugins/plugin.search.js
@@ -115,7 +115,7 @@ BookReader.prototype.initToolbar = (function (super_) {
       e.preventDefault();
       const val = $(e.target).find('.BRsearchInput').val();
       if (!val.length) return false;
-      this.search(val);
+      this.search(val, { disablePopup: true });
       this.$('.BRmobileSearchResultWrapper').append(
         `<div>Your search results will appear below.</div>
           <div class="loader tc mt20"></div>`

--- a/src/js/plugins/plugin.search.js
+++ b/src/js/plugins/plugin.search.js
@@ -115,7 +115,7 @@ BookReader.prototype.initToolbar = (function (super_) {
       e.preventDefault();
       const val = $(e.target).find('.BRsearchInput').val();
       if (!val.length) return false;
-      this.search(val, { disablePopup: true });
+      this.search(val);
       this.$('.BRmobileSearchResultWrapper').append(
         `<div>Your search results will appear below.</div>
           <div class="loader tc mt20"></div>`

--- a/src/js/plugins/plugin.search.js
+++ b/src/js/plugins/plugin.search.js
@@ -148,7 +148,7 @@ BookReader.prototype.initToolbar = (function (super_) {
  * @param {string} term
  * @param {SearchOptions} options
  */
-BookReader.prototype.search = function(term, options) {
+BookReader.prototype.search = function(term = '', options) {
   options = options !== undefined ? options : {};
   /** @type {SearchOptions} */
   const defaultOptions = {
@@ -159,13 +159,15 @@ BookReader.prototype.search = function(term, options) {
   };
   options = jQuery.extend({}, defaultOptions, options);
 
+  /* DOM updates */
   this.$('.BRsearchInput').blur(); //cause mobile safari to hide the keyboard
-
   this.removeSearchResults();
+  // update value to desktop & mobile search inputs
+  this.$('.BRsearchInput').val(term);
+  /* End DOM updates */
 
-  this.searchTerm = term;
   // strip slashes, since this goes in the url
-  this.searchTerm = this.searchTerm.replace(/\//g, ' ');
+  this.searchTerm = term.replace(/\//g, ' ');
 
   this.trigger(BookReader.eventNames.fragmentChange);
 

--- a/src/js/plugins/plugin.search.js
+++ b/src/js/plugins/plugin.search.js
@@ -412,8 +412,9 @@ BookReader.prototype.updateSearchHilites2UP = function() {
     match.par[0].boxes.forEach(box => {
       const pageIndex = this.leafNumToIndex(match.par[0].page);
       const pageIsInView = jQuery.inArray(pageIndex, this.displayedIndices) >= 0;
+      const { isViewable } = this._models.book.getPage(pageIndex);
 
-      if (pageIsInView) {
+      if (pageIsInView && isViewable) {
         if (!box.div) {
           //create a div for the search highlight, and stash it in the box object
           box.div = document.createElement('div');


### PR DESCRIPTION
**1) search term highlight does not show when the page is unviewable**

- Go to: https://www-isa.archive.org/details/goldengalleonsof0000grah
- inside book search, input & initiate search for: `island`
- pins drop -> click around -> ...
  - ... -> if page is viewable, search is highlighted
  - ... -> if page isn't viewable, "try again later" placeholder is visible with no highlight

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/7840857/83422382-4e4da500-a3de-11ea-99af-0c989f027dbe.gif)

**2) Both mobile & desktop search inputs sync in value on search term change**

- Go to: https://www-isa.archive.org/details/goldengalleonsof0000grah
- inside book search, input & initiate search for: `island`
- shrink viewport width until it's in mobile view
- open menu 🍔  -> then click `Search` panel
- In search term form, input & initiate on term `shipwreck`
- no results, cool
- grow viewport width until it is "desktop" size again
- desktop input should also have `shipwreck` as value

![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/7840857/83423693-32e39980-a3e0-11ea-94ec-a0dba07602ae.gif)

**3) Mobile menu closes when a panel is open and the viewport stretches to desktop**
- Go to: https://www-isa.archive.org/details/goldengalleonsof0000grah
- inside book search, input & initiate search for: `island`
- shrink viewport width until you get mobile menu
- open menu 🍔  -> then click `Search` panel
- keep panel open
- grow viewport width until it is "desktop" size again
- Mobile menu closes properly.

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/7840857/83423069-565a1480-a3df-11ea-901e-eacf76d46e3b.gif)
