### PR TITLE
Start fullscreen post resize

### DIFF
--- a/BookReaderDemo/immersion-1up.html
+++ b/BookReaderDemo/immersion-1up.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="apple-mobile-web-app-capable" content="yes">
+
+    <!-- JS dependencies -->
+    <script src="../BookReader/jquery-1.10.1.js"></script>
+    <script src="../BookReader/jquery-ui-1.12.0.min.js"></script>
+    <script src="../BookReader/jquery.browser.min.js"></script>
+    <script src="../BookReader/dragscrollable-br.js"></script>
+    <script src="../BookReader/jquery.colorbox-min.js"></script>
+    <script src="../BookReader/jquery.bt.min.js"></script>
+    <script src="../BookReader/soundmanager/script/soundmanager2-jsmin.js"></script>
+
+    <!-- mmenu for mobile nav -->
+    <script src="../BookReader/mmenu/dist/js/jquery.mmenu.min.js"></script>
+    <script src="../BookReader/mmenu/dist/addons/navbars/jquery.mmenu.navbars.min.js" ></script>
+    <link rel="stylesheet" href="../BookReader/mmenu/dist/css/jquery.mmenu.css" />
+    <link rel="stylesheet" href="../BookReader/mmenu/dist/addons/navbars/jquery.mmenu.navbars.css" />
+
+    <!-- Bookreader -->
+    <script src="../BookReader/BookReader.js"></script>
+    <link rel="stylesheet" href="../BookReader/BookReader.css"/>
+
+    <!-- plugins needed for archive.org, in same order as archive.org -->
+    <script src="../BookReader/plugins/plugin.mobile_nav.js"></script>
+    <script src="../BookReader/plugins/plugin.search.js"></script>
+    <script src="../BookReader/plugins/plugin.chapters.js"></script>
+    <script src="../BookReader/plugins/plugin.tts.js"></script>
+    <script src="../BookReader/plugins/plugin.url.js"></script>
+    <script src="../BookReader/plugins/plugin.autoplay.js"></script>
+    <script src="../BookReader/plugins/plugin.resume.js"></script>
+    <script src="../BookReader/plugins/plugin.archive_analytics.js"></script>
+
+    <link rel="stylesheet" href="BookReaderDemo.css"/>
+</head>
+<body>
+
+<div id="BookReader">
+    Internet Archive BookReader Demo - Chapters, Mobile Nav<br/>
+    <noscript>
+    <p>
+        The BookReader requires JavaScript to be enabled. Please check that your browser supports JavaScript and that it is enabled in the browser settings.  You can also try one of the <a href="https://archive.org/details/ramalan-ronggo-warsito-ramalan-jayabaya-ramalan-sabdopalon-nayagenggong"> other formats of the book</a>.
+    </p>
+    </noscript>
+</div>
+
+<script>
+// Override options coming from IA
+BookReader.optionOverrides.imagesBaseURL = '/BookReader/images/';
+BookReader.optionOverrides.urlMode = 'history';
+BookReader.optionOverrides.urlHistoryBasePath = `${window.location.pathname}/`;
+BookReader.optionOverrides.startFullscreen = true;
+</script>
+<script>
+$(function() {
+  var s1Promise = $.getScript('//archive.org/bookreader/BookReaderHelpers.js');
+  var s2Promise = $.getScript('//archive.org/bookreader/BookReaderJSIA.js');
+  $.when(s1Promise, s2Promise).done(function(s1Result, s2Result) {
+    $.ajax({
+      url: '//ia803108.us.archive.org/BookReader/BookReaderJSIA.php?id=ramalan-ronggo-warsito-ramalan-jayabaya-ramalan-sabdopalon-nayagenggong&itemPath=/16/items/ramalan-ronggo-warsito-ramalan-jayabaya-ramalan-sabdopalon-nayagenggong&server=ia803108.us.archive.org&format=jsonp&subPrefix=ramalan-ronggo-warsito-ramalan-jayabaya-ramalan-sabdopalon-nayagenggong-300ppi',
+      type: 'GET',
+      dataType: 'jsonp',
+    }).then(function(response) {
+      BookReaderJSIAinit(response.data);
+    });
+  }).fail(function() {
+    console.log('Error initializing bookreader');
+  });
+});
+</script>
+
+</body>
+</html>

--- a/BookReaderDemo/index.html
+++ b/BookReaderDemo/index.html
@@ -24,6 +24,7 @@
       <li><a href="demo-autoplay.html">Autoplay (kiosk mode)</a></li>
       <li><a href="demo-plugin-menu-toggle.html">Plugin: Full screen menu toggle</a></li>
       <li><a href="immersion-mode.html">Start in immersion (fullscreen) mode</a></li>
+      <li><a href="immersion-1up.html">Start in immersion mode on 1up default item</a></li>
     </ul>
   </body>
 </html>

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -386,13 +386,13 @@ BookReader.prototype.init = function() {
     }
   }
 
-  if (this.options.startFullscreen) {
-    this.enterFullscreen();
-  }
-
   this.resizeBRcontainer();
   this.updateFromParams(params);
   this.initUIStrings();
+
+  if (this.options.startFullscreen) {
+    this.enterFullscreen();
+  }
 
   // Bind to events
 

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -390,10 +390,6 @@ BookReader.prototype.init = function() {
   this.updateFromParams(params);
   this.initUIStrings();
 
-  if (this.options.startFullscreen) {
-    this.enterFullscreen();
-  }
-
   // Bind to events
 
   if (!this.isTouchDevice) this.setupTooltips();
@@ -427,6 +423,12 @@ BookReader.prototype.init = function() {
   this.suppressFragmentChange = false;
 
   this.init.initComplete = true;
+
+  // Must be called after this.init.initComplete set to true to allow
+  // BookReader.prototype.resize to run.
+  if (this.options.startFullscreen) {
+    this.enterFullscreen();
+  }
 }
 
 /**

--- a/src/js/BookReader/options.js
+++ b/src/js/BookReader/options.js
@@ -203,6 +203,10 @@ export const DEFAULT_OPTIONS = {
     },
   },
 
+  /**
+   * @type {Boolean}
+   * Optional: if true, starts in fullscreen mode
+   */
   startFullscreen: false,
 };
 


### PR DESCRIPTION
This fixes an issue where fullscreen was started before the pages were initially resized to fit the BookReader container and a corresponding class was removed to display the images. A new demo page was added to illustrate the ability to enable fullscreen mode on init for items that start in a mode other than 2up.