### PR TITLE
320/bug/autoplay e2e fails

### DIFF
--- a/tests/e2e/autoplay.test.js
+++ b/tests/e2e/autoplay.test.js
@@ -4,7 +4,6 @@ const { BASE_URL } = process.env;
 const getLocationHref = ClientFunction(() => window.location.href.toString());
 const FLIP_SPEED = 1000;
 const FIRST_PAGE_DELAY = 1500;
-const FLIP_DELAY = 2000;
 
 fixture `Autoplay plugin`.page `${BASE_URL}demo-autoplay.html`;
 

--- a/tests/e2e/autoplay.test.js
+++ b/tests/e2e/autoplay.test.js
@@ -3,11 +3,12 @@ import { ClientFunction } from 'testcafe';
 const { BASE_URL } = process.env;
 const getLocationHref = ClientFunction(() => window.location.href.toString());
 const FLIP_SPEED = 1000;
+const FIRST_PAGE_DELAY = 1500;
 const FLIP_DELAY = 2000;
 
 fixture `Autoplay plugin`.page `${BASE_URL}demo-autoplay.html`;
 
 test('page auto-advances after allotted flip speed and delay', async t => {
-  await t.wait(FLIP_SPEED + FLIP_DELAY);
+  await t.wait(2 * FLIP_SPEED + FIRST_PAGE_DELAY);
   await t.expect(getLocationHref()).match(/page\/n3/);
 });

--- a/tests/e2e/autoplay.test.js
+++ b/tests/e2e/autoplay.test.js
@@ -3,7 +3,7 @@ import { ClientFunction } from 'testcafe';
 const { BASE_URL } = process.env;
 const getLocationHref = ClientFunction(() => window.location.href.toString());
 const FLIP_SPEED = 1000;
-const FIRST_PAGE_DELAY = 1500;
+const FIRST_PAGE_DELAY = 2000;
 
 fixture `Autoplay plugin`.page `${BASE_URL}demo-autoplay.html`;
 


### PR DESCRIPTION
Closes #320  
Random delay between flipping the book cover and the first page caused unexpected test failures.
Added longer wait time to cover for these randoms delays (before it was assumed that delay was always 0)
From: 3000ms -> 2% fails (original)
to: 4000ms -> 0% fails