### PR TITLE
Use env to set environment variables in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     "serve-live": "npx live-server . --port 8000 --ignore=coverage,tests,src",
     "serve-dev": "npx concurrently --kill-others npm:serve-live npm:build-js:watch npm:build-css:watch",
     "test": "jest",
-    "test:e2e": "BASE_URL=http://127.0.0.1:8000/BookReaderDemo/ testcafe",
-    "test:e2e:dev": "BASE_URL=http://127.0.0.1:8000/BookReaderDemo/ testcafe --live --dev",
+    "test:e2e": "env BASE_URL=http://127.0.0.1:8000/BookReaderDemo/ testcafe",
+    "test:e2e:dev": "env BASE_URL=http://127.0.0.1:8000/BookReaderDemo/ testcafe --live --dev",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage --colors",
     "codecov": "codecov"


### PR DESCRIPTION
Closes #312 

This was failing in Windows. Note this will likely still fail in windows without a bash client (might need something like cross-env if we want to support that use case).

Src: https://stackoverflow.com/a/27090755/2317712

Testing:
- `npm run test:e2e` starts testcafe (Windows + git bash)