### PR TITLE
Fixes #349 BookReader flipping randomly goes wonky

### DIFF
--- a/src/js/plugins/plugin.url.js
+++ b/src/js/plugins/plugin.url.js
@@ -157,7 +157,7 @@ BookReader.prototype.urlUpdateFragment = function() {
     window.location.replace('#' + newFragment + newQueryString);
   }
 
-  this.oldLocationHash = newFragment;
+  this.oldLocationHash = newFragment + newQueryString;
 };
 
 /**


### PR DESCRIPTION
The issue was caused by a bad comparison of the oldLocationHash not
including the newQueryString for comparison. This led to the
(newFragment != this.oldLocationHash) test failing after the page
had been traversed to.