### PR TITLE
Refactor: simpler webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,61 +1,42 @@
+// @ts-check
 const path = require('path');
 
-module.exports = buildJSFiles([
-  'BookReader.js',
-  'plugins/menu_toggle/plugin.menu_toggle.js',
-  'plugins/plugin.archive_analytics.js',
-  'plugins/plugin.autoplay.js',
-  'plugins/plugin.chapters.js',
-  'plugins/plugin.iframe.js',
-  'plugins/plugin.mobile_nav.js',
-  'plugins/plugin.print.js',
-  'plugins/plugin.resume.js',
-  'plugins/plugin.search.js',
-  'plugins/plugin.themes.js',
-  'plugins/plugin.url.js',
-  'plugins/plugin.vendor-fullscreen.js',
-  'plugins/tts/plugin.tts.js',
-]);
+/** @type {import('webpack').Configuration} */
+module.exports = {
+  mode: 'production',
+  // Output file -> srcfile
+  entry: {
+    'BookReader.js': './src/js/BookReader.js',
 
-/**
- * Applies bundling to the listed files.
- */
-function buildJSFiles(files) {
-  const nestedDirRegex = new RegExp('/(.*)/');
-  return files.map((filePath) => {
-    const flattenedFilePath = filePath.replace(nestedDirRegex, '/');
-    return buildJsFromTo({
-      from: filePath,
-      to: `BookReader/${flattenedFilePath}`
-    });
-  });
-}
+    // Plugins
+    'plugins/plugin.menu_toggle.js': './src/js/plugins/menu_toggle/plugin.menu_toggle.js',
+    'plugins/plugin.archive_analytics.js': './src/js/plugins/plugin.archive_analytics.js',
+    'plugins/plugin.autoplay.js': './src/js/plugins/plugin.autoplay.js',
+    'plugins/plugin.chapters.js': './src/js/plugins/plugin.chapters.js',
+    'plugins/plugin.iframe.js': './src/js/plugins/plugin.iframe.js',
+    'plugins/plugin.mobile_nav.js': './src/js/plugins/plugin.mobile_nav.js',
+    'plugins/plugin.print.js': './src/js/plugins/plugin.print.js',
+    'plugins/plugin.resume.js': './src/js/plugins/plugin.resume.js',
+    'plugins/plugin.search.js': './src/js/plugins/plugin.search.js',
+    'plugins/plugin.themes.js': './src/js/plugins/plugin.themes.js',
+    'plugins/plugin.url.js': './src/js/plugins/plugin.url.js',
+    'plugins/plugin.vendor-fullscreen.js': './src/js/plugins/plugin.vendor-fullscreen.js',
+    'plugins/plugin.tts.js': './src/js/plugins/tts/plugin.tts.js',
+  },
 
-/**
- * Applies webpack config to files that it is bundling.
- *
- * @param {Object} opts
- * @param {String} opts.from
- * @param {String} opts.to
- */
-function buildJsFromTo({ from: srcEntryFile, to: outputFile }) {
-  return {
-    mode: 'production',
-    entry: './' + path.join('src/js/', srcEntryFile),
-    module: {
-      rules: [
-        { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader" }
-      ]
-    },
+  module: {
+    rules: [
+      { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader" }
+    ]
+  },
 
-    output: {
-      filename: path.basename(outputFile),
-      path: path.resolve(__dirname, path.parse(outputFile).dir)
-    },
+  output: {
+    filename: '[name]',
+    path: path.resolve(__dirname, 'BookReader')
+  },
 
-    // Accurate source maps at the expense of build time.
-    // The source map is intentionally exposed
-    // to users via sourceMapFilename for prod debugging.
-    devtool: 'source-map'
-  };
-}
+  // Accurate source maps at the expense of build time.
+  // The source map is intentionally exposed
+  // to users via sourceMapFilename for prod debugging.
+  devtool: 'source-map'
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,20 +8,20 @@ module.exports = {
   entry: {
     'BookReader.js': './src/js/BookReader.js',
 
-    // Plugins
-    'plugins/plugin.menu_toggle.js': './src/js/plugins/menu_toggle/plugin.menu_toggle.js',
+    // Plugins (sorted!)
     'plugins/plugin.archive_analytics.js': './src/js/plugins/plugin.archive_analytics.js',
     'plugins/plugin.autoplay.js': './src/js/plugins/plugin.autoplay.js',
     'plugins/plugin.chapters.js': './src/js/plugins/plugin.chapters.js',
     'plugins/plugin.iframe.js': './src/js/plugins/plugin.iframe.js',
+    'plugins/plugin.menu_toggle.js': './src/js/plugins/menu_toggle/plugin.menu_toggle.js',
     'plugins/plugin.mobile_nav.js': './src/js/plugins/plugin.mobile_nav.js',
     'plugins/plugin.print.js': './src/js/plugins/plugin.print.js',
     'plugins/plugin.resume.js': './src/js/plugins/plugin.resume.js',
     'plugins/plugin.search.js': './src/js/plugins/plugin.search.js',
     'plugins/plugin.themes.js': './src/js/plugins/plugin.themes.js',
+    'plugins/plugin.tts.js': './src/js/plugins/tts/plugin.tts.js',
     'plugins/plugin.url.js': './src/js/plugins/plugin.url.js',
     'plugins/plugin.vendor-fullscreen.js': './src/js/plugins/plugin.vendor-fullscreen.js',
-    'plugins/plugin.tts.js': './src/js/plugins/tts/plugin.tts.js',
   },
 
   module: {


### PR DESCRIPTION
We'd over-abstracted this; we can just use a basic setup :)

This will also make it easier to dedupe the shared code inside BookReader once we go to webpack 5 (still in beta :( )! https://webpack.js.org/configuration/entry-context/#dependencies