### PR TITLE
Fix high resolution displays having blurry images

### DIFF
--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -786,6 +786,7 @@ BookReader.prototype.drawLeafsOnePage = function() {
         src: this._getPageURI(index, this.reduce, 0),
         srcset: this._getPageURISrcset(index, this.reduce, 0)
       });
+      console.log(this._getPageURISrcset(index, this.reduce, 0))
       pageContainer.append(img);
 
       BRpageViewEl.appendChild(pageContainer[0]);
@@ -2739,31 +2740,32 @@ BookReader.prototype._getPageURISrcset = function(index, reduce, rotate) {
     return srcsetStr;
   }
 
+  let ratio = reduce;
   if ('undefined' == typeof(reduce)) {
     // reduce not passed in
     // $$$ this probably won't work for thumbnail mode
-    var ratio = this._models.book.getPageHeight(index) / this.twoPage.height;
-    var scale;
-    // $$$ we make an assumption here that the scales are available pow2 (like kakadu)
-    if (ratio < 2) {
-      return srcsetStr;
-    } else if (ratio < 4) {
-      scale = [1];
-    } else if (ratio < 8) {
-      scale = [2,1];
-    } else if (ratio < 16) {
-      scale = [4,2,1];
-    } else  if (ratio < 32) {
-      scale = [8,4,2,1];
-    } else {
-      scale = [16,8,4,2,1];
-    }
-    scale.forEach((el, i) => {
-      srcsetStr = srcsetStr + this._models.book.getPageURI(index, scale[i], rotate) + " "
-      + Math.pow(2, i + 1) + "x, ";
-    } )
-    return srcsetStr;
+    ratio = this._models.book.getPageHeight(index) / this.twoPage.height;
   }
+  var scale;
+  // $$$ we make an assumption here that the scales are available pow2 (like kakadu)
+  if (ratio < 2) {
+    return srcsetStr;
+  } else if (ratio < 4) {
+    scale = [1];
+  } else if (ratio < 8) {
+    scale = [2,1];
+  } else if (ratio < 16) {
+    scale = [4,2,1];
+  } else  if (ratio < 32) {
+    scale = [8,4,2,1];
+  } else {
+    scale = [16,8,4,2,1];
+  }
+  scale.forEach((el, i) => {
+    srcsetStr = srcsetStr + this._models.book.getPageURI(index, scale[i], rotate) + " "
+      + Math.pow(2, i + 1) + "x, ";
+  } )
+  return srcsetStr;
 }
 
 

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -786,7 +786,6 @@ BookReader.prototype.drawLeafsOnePage = function() {
         src: this._getPageURI(index, this.reduce, 0),
         srcset: this._getPageURISrcset(index, this.reduce, 0)
       });
-      console.log(this._getPageURISrcset(index, this.reduce, 0))
       pageContainer.append(img);
 
       BRpageViewEl.appendChild(pageContainer[0]);
@@ -1909,7 +1908,7 @@ BookReader.prototype._scrollAmount = function() {
 
 BookReader.prototype.prefetchImg = function(index) {
   var pageURI = this._getPageURI(index);
-  var pageURISrcset = this._getPageURISrcset(index);
+  const pageURISrcset = this._getPageURISrcset(index);
 
   // Load image if not loaded or URI has changed (e.g. due to scaling)
   var loadImage = false;
@@ -2727,7 +2726,7 @@ BookReader.prototype.canSwitchToMode = function(mode) {
 
 
 /**
- * Returns the page URI or transparent image if out of range
+ * Returns the srcset with correct URIs or void string if out of range
  * Also makes the reduce argument optional
  * @param {number} index
  * @param {number} [reduce]
@@ -2735,9 +2734,8 @@ BookReader.prototype.canSwitchToMode = function(mode) {
  * @return {string}
  */
 BookReader.prototype._getPageURISrcset = function(index, reduce, rotate) {
-  let srcsetStr = "";
   if (index < 0 || index >= this._models.book.getNumLeafs()) { // Synthesize page
-    return srcsetStr;
+    return "";
   }
 
   let ratio = reduce;
@@ -2746,10 +2744,10 @@ BookReader.prototype._getPageURISrcset = function(index, reduce, rotate) {
     // $$$ this probably won't work for thumbnail mode
     ratio = this._models.book.getPageHeight(index) / this.twoPage.height;
   }
-  var scale;
+  let scale = [16,8,4,2,1];
   // $$$ we make an assumption here that the scales are available pow2 (like kakadu)
   if (ratio < 2) {
-    return srcsetStr;
+    return "";
   } else if (ratio < 4) {
     scale = [1];
   } else if (ratio < 8) {
@@ -2758,14 +2756,11 @@ BookReader.prototype._getPageURISrcset = function(index, reduce, rotate) {
     scale = [4,2,1];
   } else  if (ratio < 32) {
     scale = [8,4,2,1];
-  } else {
-    scale = [16,8,4,2,1];
   }
-  scale.forEach((el, i) => {
-    srcsetStr = srcsetStr + this._models.book.getPageURI(index, scale[i], rotate) + " "
-      + Math.pow(2, i + 1) + "x, ";
-  } )
-  return srcsetStr;
+  return scale.map((el, i) => (
+    this._models.book.getPageURI(index, scale[i], rotate) + " "
+        + Math.pow(2, i + 1) + "x"
+  )).join(', ');
 }
 
 

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -783,7 +783,8 @@ BookReader.prototype.drawLeafsOnePage = function() {
       });
 
       const img = $('<img />', {
-        src: this._getPageURI(index, this.reduce, 0)
+        src: this._getPageURI(index, this.reduce, 0),
+        srcset: this._getPageURISrcset(index, this.reduce, 0)
       });
       pageContainer.append(img);
 
@@ -2720,6 +2721,49 @@ BookReader.prototype.canSwitchToMode = function(mode) {
 
   return true;
 };
+
+
+/**
+ * Returns the page URI or transparent image if out of range
+ * Also makes the reduce argument optional
+ * @param {number} index
+ * @param {number} [reduce]
+ * @param {number} [rotate]
+ * @return {string}
+ */
+BookReader.prototype._getPageURISrcset = function(index, reduce, rotate) {
+  if (index < 0 || index >= this._models.book.getNumLeafs()) { // Synthesize page
+    return this.imagesBaseURL + "transparent.png";
+  }
+
+  if ('undefined' == typeof(reduce)) {
+    // reduce not passed in
+    // $$$ this probably won't work for thumbnail mode
+    var ratio = this._models.book.getPageHeight(index) / this.twoPage.height;
+    var scale;
+    let srcsetStr = "";
+    // $$$ we make an assumption here that the scales are available pow2 (like kakadu)
+    if (ratio < 2) {
+      return srcsetStr;
+    } else if (ratio < 4) {
+      scale = [1];
+    } else if (ratio < 8) {
+      scale = [2,1];
+    } else if (ratio < 16) {
+      scale = [4,2,1];
+    } else  if (ratio < 32) {
+      scale = [8,4,2,1];
+    } else {
+      scale = [16,8,4,2,1];
+    }
+    scale.forEach((el, i) => {
+      srcsetStr = srcsetStr + this._models.book.getPageURI(index, scale[i], rotate) + " "
+      + (2^(i+1)) + "x "
+    } )
+    return srcsetStr;
+
+}
+
 
 /**
  * Returns the page URI or transparent image if out of range

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -1908,6 +1908,7 @@ BookReader.prototype._scrollAmount = function() {
 
 BookReader.prototype.prefetchImg = function(index) {
   var pageURI = this._getPageURI(index);
+  var pageURISrcset = this._getPageURISrcset(index);
 
   // Load image if not loaded or URI has changed (e.g. due to scaling)
   var loadImage = false;
@@ -1921,7 +1922,8 @@ BookReader.prototype.prefetchImg = function(index) {
     const pageContainer = this._createPageContainer(index);
     $('<img />', {
       'class': 'BRpageimage',
-      src: pageURI
+      src: pageURI,
+      srcset: pageURISrcset
     }).appendTo(pageContainer);
     if (index < 0 || index > (this._models.book.getNumLeafs() - 1) ) {
       // Facing page at beginning or end, or beyond
@@ -2732,8 +2734,9 @@ BookReader.prototype.canSwitchToMode = function(mode) {
  * @return {string}
  */
 BookReader.prototype._getPageURISrcset = function(index, reduce, rotate) {
+  let srcsetStr = "";
   if (index < 0 || index >= this._models.book.getNumLeafs()) { // Synthesize page
-    return this.imagesBaseURL + "transparent.png";
+    return srcsetStr;
   }
 
   if ('undefined' == typeof(reduce)) {
@@ -2741,7 +2744,6 @@ BookReader.prototype._getPageURISrcset = function(index, reduce, rotate) {
     // $$$ this probably won't work for thumbnail mode
     var ratio = this._models.book.getPageHeight(index) / this.twoPage.height;
     var scale;
-    let srcsetStr = "";
     // $$$ we make an assumption here that the scales are available pow2 (like kakadu)
     if (ratio < 2) {
       return srcsetStr;
@@ -2758,10 +2760,10 @@ BookReader.prototype._getPageURISrcset = function(index, reduce, rotate) {
     }
     scale.forEach((el, i) => {
       srcsetStr = srcsetStr + this._models.book.getPageURI(index, scale[i], rotate) + " "
-      + (2^(i+1)) + "x "
+      + Math.pow(2, i + 1) + "x, ";
     } )
     return srcsetStr;
-
+  }
 }
 
 

--- a/tests/BookReader.test.js
+++ b/tests/BookReader.test.js
@@ -149,3 +149,39 @@ test('does not add q= term to urlMode=hash query string', () => {
     'hash'
   )).toBe('?name=value');
 });
+
+test('_getPageURISrcset with 0 page book', () => {
+  br._models.book.getNumLeafs = jest.fn(() => 0);
+  br.init();
+  expect(br._getPageURISrcset(5, undefined, undefined)).toBe("");
+});
+
+test('_getPageURISrcset with negative index', () => {
+  br._models.book.getNumLeafs = jest.fn(() => 0);
+  br.init();
+  expect(br._getPageURISrcset(-7, undefined, undefined)).toBe("");
+});
+
+test('_getPageURISrcset with 0 elements in srcset', () => {
+  br._models.book.getNumLeafs = jest.fn(() => 30);
+  br.init();
+  expect(br._getPageURISrcset(5, 1, undefined)).toBe("");
+});
+
+test('_getPageURISrcset with 2 elements in srcset', () => {
+  br._models.book.getNumLeafs = jest.fn(() => 30);
+  br.init();
+  expect(br._getPageURISrcset(5, 5, undefined)).toBe("/bookreader/static/preview-default.png 2x, /bookreader/static/preview-default.png 4x, ");
+});
+
+test('_getPageURISrcset with the most elements in srcset', () => {
+  br._models.book.getNumLeafs = jest.fn(() => 30);
+  br.init();
+  expect(br._getPageURISrcset(5, 35, undefined)).toBe("/bookreader/static/preview-default.png 2x, /bookreader/static/preview-default.png 4x, /bookreader/static/preview-default.png 8x, /bookreader/static/preview-default.png 16x, /bookreader/static/preview-default.png 32x, ");
+});
+
+test('_getPageURISrcset with undefined reduce param', () => {
+  br._models.book.getNumLeafs = jest.fn(() => 30);
+  br.init();
+  expect(br._getPageURISrcset(5, undefined, undefined)).toBe("/bookreader/static/preview-default.png 2x, /bookreader/static/preview-default.png 4x, /bookreader/static/preview-default.png 8x, /bookreader/static/preview-default.png 16x, /bookreader/static/preview-default.png 32x, ");
+});

--- a/tests/BookReader.test.js
+++ b/tests/BookReader.test.js
@@ -152,36 +152,42 @@ test('does not add q= term to urlMode=hash query string', () => {
 
 test('_getPageURISrcset with 0 page book', () => {
   br._models.book.getNumLeafs = jest.fn(() => 0);
+  br._models.book.getPageURI = jest.fn((index, scale, rotate) => "correctURL.png&scale=" + scale);
   br.init();
   expect(br._getPageURISrcset(5, undefined, undefined)).toBe("");
 });
 
 test('_getPageURISrcset with negative index', () => {
   br._models.book.getNumLeafs = jest.fn(() => 0);
+  br._models.book.getPageURI = jest.fn((index, scale, rotate) => "correctURL.png&scale=" + scale);
   br.init();
   expect(br._getPageURISrcset(-7, undefined, undefined)).toBe("");
 });
 
 test('_getPageURISrcset with 0 elements in srcset', () => {
   br._models.book.getNumLeafs = jest.fn(() => 30);
+  br._models.book.getPageURI = jest.fn((index, scale, rotate) => "correctURL.png&scale=" + scale);
   br.init();
   expect(br._getPageURISrcset(5, 1, undefined)).toBe("");
 });
 
 test('_getPageURISrcset with 2 elements in srcset', () => {
   br._models.book.getNumLeafs = jest.fn(() => 30);
+  br._models.book.getPageURI = jest.fn((index, scale, rotate) => "correctURL.png&scale=" + scale);
   br.init();
-  expect(br._getPageURISrcset(5, 5, undefined)).toBe("/bookreader/static/preview-default.png 2x, /bookreader/static/preview-default.png 4x, ");
+  expect(br._getPageURISrcset(5, 5, undefined)).toBe("correctURL.png&scale=2 2x, correctURL.png&scale=1 4x");
 });
 
 test('_getPageURISrcset with the most elements in srcset', () => {
   br._models.book.getNumLeafs = jest.fn(() => 30);
+  br._models.book.getPageURI = jest.fn((index, scale, rotate) => "correctURL.png&scale=" + scale);
   br.init();
-  expect(br._getPageURISrcset(5, 35, undefined)).toBe("/bookreader/static/preview-default.png 2x, /bookreader/static/preview-default.png 4x, /bookreader/static/preview-default.png 8x, /bookreader/static/preview-default.png 16x, /bookreader/static/preview-default.png 32x, ");
+  expect(br._getPageURISrcset(5, 35, undefined)).toBe("correctURL.png&scale=16 2x, correctURL.png&scale=8 4x, correctURL.png&scale=4 8x, correctURL.png&scale=2 16x, correctURL.png&scale=1 32x");
 });
 
 test('_getPageURISrcset with undefined reduce param', () => {
   br._models.book.getNumLeafs = jest.fn(() => 30);
+  br._models.book.getPageURI = jest.fn((index, scale, rotate) => "correctURL.png&scale=" + scale);
   br.init();
-  expect(br._getPageURISrcset(5, undefined, undefined)).toBe("/bookreader/static/preview-default.png 2x, /bookreader/static/preview-default.png 4x, /bookreader/static/preview-default.png 8x, /bookreader/static/preview-default.png 16x, /bookreader/static/preview-default.png 32x, ");
+  expect(br._getPageURISrcset(5, undefined, undefined)).toBe("correctURL.png&scale=16 2x, correctURL.png&scale=8 4x, correctURL.png&scale=4 8x, correctURL.png&scale=2 16x, correctURL.png&scale=1 32x");
 });


### PR DESCRIPTION
Fixes high resolution displays having blurry images using the HTML srcset property for img elements. The srcset is applied to the bookreader page images so that for each available image, with higher resolution than the one selected by default, there is a corresponding 2x, 4x, 8x or higher attribute.
closes #372 