### PR TITLE
Fixed advanced demo not turning pages

### DIFF
--- a/src/js/BookReader/BookModel.js
+++ b/src/js/BookReader/BookModel.js
@@ -321,8 +321,8 @@ export class BookModel {
   }
 
   /**
-   * Helper. Return a prop for a given index. Returns `fallbackValue` if property not on
-   * page. Returns undefined if page index is invalid.
+   * Helper. Return a prop for a given index. Returns `fallbackValue` if index is invalid or
+   * property not on page.
    * @param {PageIndex} index
    * @param {keyof PageData} prop
    * @param {*} fallbackValue return if property not on the record
@@ -331,10 +331,7 @@ export class BookModel {
   _getDataProp(index, prop, fallbackValue = undefined) {
     const dataf = this._getDataFlattened();
     const invalidIndex = isNaN(index) || index < 0 || index >= dataf.length;
-
-    if (invalidIndex) return undefined;
-
-    if ('undefined' == typeof(dataf[index][prop]))
+    if (invalidIndex || 'undefined' == typeof(dataf[index][prop]))
       return fallbackValue;
     return dataf[index][prop];
   }


### PR DESCRIPTION
 This issue was fixed by returning fallback value if index is invalid in `_getDataProp `function.
Also affected `/demo-plugin-menu-toggle.html` and `/demo-advanced.html`.
closes #358 