### PR TITLE
Fix random page flipping

### DIFF
--- a/src/js/plugins/plugin.url.js
+++ b/src/js/plugins/plugin.url.js
@@ -152,13 +152,15 @@ BookReader.prototype.urlUpdateFragment = function() {
 
       const newUrlPath = `${baseWithoutSlash}${newFragmentWithSlash}${newQueryString}`;
       window.history.replaceState({}, null, newUrlPath);
+      this.oldLocationHash = newFragment + newQueryString;
+
     }
   } else {
     const newQueryStringSearch = this.urlParamsFiltersOnlySearch(this.readQueryString());
     window.location.replace('#' + newFragment + newQueryStringSearch);
-  }
+    this.oldLocationHash = newFragment + newQueryStringSearch;
 
-  this.oldLocationHash = newFragment + newQueryString;
+  }
 };
 
 /**


### PR DESCRIPTION
Previous fix involving `plugin.url.js` was not working anymore in URL hash mode due to changes to `urlUpdateFragment` made in the generic demo feature.
Changed this.oldLocationHash to use newQueryStringSearch instead of newQueryString in url hash mode.
closes #349 