### PR TITLE
Emit custom event to trigger

### DIFF
--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -499,7 +499,13 @@ BookReader.prototype.init = function() {
  * @param {array | object} [props]
  */
 BookReader.prototype.trigger = function(name, props = this) {
-  $(document).trigger('BookReader:' + name, props);
+  const eventName = 'BookReader:' + name;
+  $(document).trigger(eventName, props);
+  window.dispatchEvent(new CustomEvent(eventName, {
+    bubbles: true,
+    composed: true,
+    detail: { props },
+  }));
 };
 
 BookReader.prototype.bind = function(name, callback) {

--- a/tests/BookReader/BookReaderPublicFunctions.test.js
+++ b/tests/BookReader/BookReaderPublicFunctions.test.js
@@ -7,6 +7,18 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
+describe('BookReader.prototype.trigger', () => {
+  test('fires custom event', () => {
+    const br = new BookReader();
+    global.br = br;
+    global.dispatchEvent = jest.fn();
+
+    const props = {bar: 1};
+    br.trigger('foo', props);
+    expect(global.dispatchEvent.mock.calls.length).toBe(1);
+  });
+});
+
 describe('`BookReader.prototype.prev`', () => {
   const br = new BookReader();
   global.br = br;


### PR DESCRIPTION
Problem: BookReader jQuery `trigger` events can only be listened to by jQuery.

Solution: This extends `br.trigger` to always throw a custom event.

Testing
- go to: https://deploy-preview-423--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=adventuresofoli00dick
- open dev console
- go to console tab/drawer
- add this function into the console drawer: window.addEventListener('BookReader:fullscreenToggled', (e) => { console.log('successfully caught event', e) });
- click Fullscreen on bookreader
- you see the console output. yay