### PR TITLE
Run travis on master branch pushes!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 dist: bionic
 
+# Only run travis when pushing to master branch (and PRs)
+branches:
+  only:
+    - master
+
 addons:
   firefox: latest
   chrome: stable


### PR DESCRIPTION
Looks like I forgot master is also a branch :D 

I enabled "build on pushed branches" in https://travis-ci.com/github/internetarchive/bookreader/settings, and set it to only build master via .travis.yml