### PR TITLE
Fix text selection on Safari

### DIFF
--- a/src/js/plugins/plugin.text_selection.js
+++ b/src/js/plugins/plugin.text_selection.js
@@ -1,5 +1,5 @@
 //@ts-check
-import { isFirefox, isSafari } from './tts/utils';
+import { isFirefox, isSafari } from '../../util/browserSniffing.js';
 
 const BookReader = /** @type {typeof import('../BookReader').default} */(window.BookReader);
 

--- a/src/js/plugins/plugin.text_selection.js
+++ b/src/js/plugins/plugin.text_selection.js
@@ -1,11 +1,11 @@
 //@ts-check
-import { isFirefox } from './tts/utils';
+import { isFirefox, isSafari } from './tts/utils';
 
 const BookReader = /** @type {typeof import('../BookReader').default} */(window.BookReader);
 
 export class TextSelectionPlugin {
 
-  constructor(avoidTspans = isFirefox()) {
+  constructor(avoidTspans = isFirefox(), pointerEventsOnParagraph = isSafari()) {
     /**@type {PromiseLike<JQuery<HTMLElement>|undefined>} */
     this.djvuPagesPromise = null;
     // Using text elements insted of tspans for words because Firefox does not allow svg tspan strech.
@@ -13,6 +13,10 @@ export class TextSelectionPlugin {
     this.svgParagraphElement = "text";
     this.svgWordElement = "tspan";
     this.insertNewlines = avoidTspans
+    // Safari has a bug where `pointer-events` doesn't work on `<tspans>`. So
+    // there we will set `pointer-events: all` on the paragraph element. We don't
+    // do this everywhere, because it's a worse experience. Thanks Safari :/
+    this.pointerEventsOnParagraph = pointerEventsOnParagraph;
     if(avoidTspans) {
       this.svgParagraphElement = "g";
       this.svgWordElement = "text";
@@ -139,6 +143,9 @@ export class TextSelectionPlugin {
       if (!words.length) return;
       const paragSvg = document.createElementNS("http://www.w3.org/2000/svg", this.svgParagraphElement);
       paragSvg.setAttribute("class", "BRparagElement");
+      if (this.pointerEventsOnParagraph) {
+        paragSvg.style.pointerEvents = "all";
+      }
 
       const wordHeightArr = [];
 

--- a/src/js/plugins/plugin.text_selection.js
+++ b/src/js/plugins/plugin.text_selection.js
@@ -204,7 +204,8 @@ export class BookreaderWithTextSelection extends BookReader {
    */
   _createPageContainer(index, styles = {}) {
     const $container = super._createPageContainer(index, styles);
-    if(this.enableTextSelection){
+    // Disable if thumb mode; it's too janky
+    if(this.enableTextSelection && this.mode != this.constModeThumb){
       this.textSelectionPlugin.createTextLayer(index, $container);
     }
     return $container;

--- a/src/js/plugins/tts/WebTTSEngine.js
+++ b/src/js/plugins/tts/WebTTSEngine.js
@@ -1,5 +1,6 @@
 /* global br */
-import { isChrome, sleep, promisifyEvent, isFirefox, isAndroid } from './utils.js';
+import { isChrome, isFirefox } from '../../../util/browserSniffing.js';
+import { sleep, promisifyEvent, isAndroid } from './utils.js';
 import AbstractTTSEngine from './AbstractTTSEngine.js';
 /** @typedef {import("./AbstractTTSEngine.js").PageChunk} PageChunk */
 /** @typedef {import("./AbstractTTSEngine.js").AbstractTTSSound} AbstractTTSSound */

--- a/src/js/plugins/tts/utils.js
+++ b/src/js/plugins/tts/utils.js
@@ -36,35 +36,6 @@ export function sleep(ms) {
 }
 
 /**
- * Checks whether the current browser is a Chrome/Chromium browser
- * Code from https://stackoverflow.com/a/4565120/2317712
- * @param {string} [userAgent]
- * @param {string} [vendor]
- * @return {boolean}
- */
-export function isChrome(userAgent = navigator.userAgent, vendor = navigator.vendor) {
-  return /chrome/i.test(userAgent) && /google inc/i.test(vendor);
-}
-
-/**
- * Checks whether the current browser is firefox
- * @param {string} [userAgent]
- * @return {boolean}
- */
-export function isFirefox(userAgent = navigator.userAgent) {
-  return /firefox/i.test(userAgent);
-}
-
-/**
- * Checks whether the current browser is safari
- * @param {string} [userAgent]
- * @return {boolean}
- */
-export function isSafari(userAgent = navigator.userAgent) {
-  return /safari/i.test(userAgent);
-}
-
-/**
  * Checks whether the current browser is on android
  * @param {string} [userAgent]
  * @return {boolean}

--- a/src/js/plugins/tts/utils.js
+++ b/src/js/plugins/tts/utils.js
@@ -56,6 +56,15 @@ export function isFirefox(userAgent = navigator.userAgent) {
 }
 
 /**
+ * Checks whether the current browser is safari
+ * @param {string} [userAgent]
+ * @return {boolean}
+ */
+export function isSafari(userAgent = navigator.userAgent) {
+  return /safari/i.test(userAgent);
+}
+
+/**
  * Checks whether the current browser is on android
  * @param {string} [userAgent]
  * @return {boolean}

--- a/src/util/browserSniffing.js
+++ b/src/util/browserSniffing.js
@@ -1,0 +1,29 @@
+
+/**
+ * Checks whether the current browser is a Chrome/Chromium browser
+ * Code from https://stackoverflow.com/a/4565120/2317712
+ * @param {string} [userAgent]
+ * @param {string} [vendor]
+ * @return {boolean}
+ */
+export function isChrome(userAgent = navigator.userAgent, vendor = navigator.vendor) {
+  return /chrome/i.test(userAgent) && /google inc/i.test(vendor);
+}
+
+/**
+ * Checks whether the current browser is firefox
+ * @param {string} [userAgent]
+ * @return {boolean}
+ */
+export function isFirefox(userAgent = navigator.userAgent) {
+  return /firefox/i.test(userAgent);
+}
+
+/**
+ * Checks whether the current browser is safari
+ * @param {string} [userAgent]
+ * @return {boolean}
+ */
+export function isSafari(userAgent = navigator.userAgent) {
+  return /safari/i.test(userAgent);
+}

--- a/src/util/browserSniffing.js
+++ b/src/util/browserSniffing.js
@@ -21,9 +21,10 @@ export function isFirefox(userAgent = navigator.userAgent) {
 
 /**
  * Checks whether the current browser is safari
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#Browser_Name
  * @param {string} [userAgent]
  * @return {boolean}
  */
 export function isSafari(userAgent = navigator.userAgent) {
-  return /safari/i.test(userAgent);
+  return /safari/i.test(userAgent) && !/chrome|chromium/i.test(userAgent);
 }

--- a/tests/plugins/tts/utils.test.js
+++ b/tests/plugins/tts/utils.test.js
@@ -91,46 +91,6 @@ describe('sleep', () => {
   });
 });
 
-describe('isChrome', () => {
-  const { isChrome } = utils;
-  const tests = [
-    {
-      name: 'Firefox on Windows 10',
-      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0',
-      vendor: '',
-      expected: false
-    },
-    {
-      name: 'Chrome on Windows 10',
-      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
-      vendor: 'Google Inc.',
-      expected: true
-    },
-    {
-      name: 'Edge on Windows 10',
-      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; ServiceUI 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.18362',
-      vendor: '',
-      expected: false
-    },
-    {
-      name: 'IE11 on Windows 10',
-      userAgent: 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; Touch; .NET4.0C; .NET4.0E; Tablet PC 2.0; Zoom 3.6.0; rv:11.0) like Gecko',
-      vendor: '',
-      expected: false
-    },
-    {
-      name: 'Chromium on Windows 10',
-      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3923.0 Safari/537.36',
-      vendor: 'Google Inc.',
-      expected: true
-    },
-  ];
-
-  for (const { name, userAgent, vendor, expected } of tests) {
-    test(name, () => expect(isChrome(userAgent, vendor)).toBe(expected));
-  }
-});
-
 describe('toISO6391', () => {
   const { toISO6391 } = utils;
 

--- a/tests/util/browserSniffing.test.js
+++ b/tests/util/browserSniffing.test.js
@@ -1,42 +1,56 @@
 import {
-  isChrome,
+  isChrome, isFirefox, isSafari,
 } from '../../src/util/browserSniffing.js';
 
-describe('isChrome', () => {
-  const tests = [
-    {
-      name: 'Firefox on Windows 10',
-      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0',
-      vendor: '',
-      expected: false
-    },
-    {
-      name: 'Chrome on Windows 10',
-      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
-      vendor: 'Google Inc.',
-      expected: true
-    },
-    {
-      name: 'Edge on Windows 10',
-      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; ServiceUI 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.18362',
-      vendor: '',
-      expected: false
-    },
-    {
-      name: 'IE11 on Windows 10',
-      userAgent: 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; Touch; .NET4.0C; .NET4.0E; Tablet PC 2.0; Zoom 3.6.0; rv:11.0) like Gecko',
-      vendor: '',
-      expected: false
-    },
-    {
-      name: 'Chromium on Windows 10',
-      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3923.0 Safari/537.36',
-      vendor: 'Google Inc.',
-      expected: true
-    },
-  ];
+const TESTS = [
+  {
+    name: 'Firefox on Windows 10',
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0',
+    vendor: '',
+    machingFn: isFirefox,
+  },
+  {
+    name: 'Chrome on Windows 10',
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
+    vendor: 'Google Inc.',
+    machingFn: isChrome,
+  },
+  {
+    name: 'Edge on Windows 10',
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; ServiceUI 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.18362',
+    vendor: '',
+    machingFn: null,
+  },
+  {
+    name: 'IE11 on Windows 10',
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; Touch; .NET4.0C; .NET4.0E; Tablet PC 2.0; Zoom 3.6.0; rv:11.0) like Gecko',
+    vendor: '',
+    machingFn: null,
+  },
+  {
+    name: 'Chromium on Windows 10',
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3923.0 Safari/537.36',
+    vendor: 'Google Inc.',
+    machingFn: isChrome,
+  },
+  {
+    name: 'Safari 12 on Mojave',
+    userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Safari/605.1.15',
+    vendor: 'Apple Computer, Inc.',
+    machingFn: isSafari,
+  },
+  {
+    name: 'Safari 10 on iPhone 7',
+    userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1',
+    vendor: 'Apple Computer, Inc.',
+    machingFn: isSafari,
+  },
+];
 
-  for (const { name, userAgent, vendor, expected } of tests) {
-    test(name, () => expect(isChrome(userAgent, vendor)).toBe(expected));
-  }
-});
+for (const fn of [isChrome, isFirefox, isSafari]) {
+  describe(fn.name, () => {
+    for (const { name, userAgent, vendor, machingFn } of TESTS) {
+      test(name, () => expect(fn(userAgent, vendor)).toBe(machingFn == fn));
+    }
+  });
+}

--- a/tests/util/browserSniffing.test.js
+++ b/tests/util/browserSniffing.test.js
@@ -1,0 +1,42 @@
+import {
+  isChrome,
+} from '../../src/util/browserSniffing.js';
+
+describe('isChrome', () => {
+  const tests = [
+    {
+      name: 'Firefox on Windows 10',
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0',
+      vendor: '',
+      expected: false
+    },
+    {
+      name: 'Chrome on Windows 10',
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
+      vendor: 'Google Inc.',
+      expected: true
+    },
+    {
+      name: 'Edge on Windows 10',
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; ServiceUI 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.18362',
+      vendor: '',
+      expected: false
+    },
+    {
+      name: 'IE11 on Windows 10',
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; Touch; .NET4.0C; .NET4.0E; Tablet PC 2.0; Zoom 3.6.0; rv:11.0) like Gecko',
+      vendor: '',
+      expected: false
+    },
+    {
+      name: 'Chromium on Windows 10',
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3923.0 Safari/537.36',
+      vendor: 'Google Inc.',
+      expected: true
+    },
+  ];
+
+  for (const { name, userAgent, vendor, expected } of tests) {
+    test(name, () => expect(isChrome(userAgent, vendor)).toBe(expected));
+  }
+});


### PR DESCRIPTION
Where to begin. So the way this works, is the svg text layer has `pointer-events: none` (so that you can right click on non-text and access image options). The word elements (usually `<tspan>`) override this with `pointer-events: all`, so that you can have the cursor hover effect, and so the event listeners work. The problem is that for some reason, on Safari, the `pointer-events: all` override wasn't working on `<tspan>` elements. So the solution I ended up with was on Safari, apply that override on the _paragraph_ element. This has some problems, in that it makes it a little more difficult to pan when in 2up zoomed-in, but should otherwise be fine.

Other things I tried:
- Using `<text>` for the word instead of `<tspan>` (as we do on Firefox). We can't do this on Chrome/Safari, because those browsers add a newline character after `<text>` elements when copying the text, so you get one word per line. I tried modifying the `oncopy` result to make it clean up the copied text, but I found no clean/reliable way to differentiate the word newlines from the paragraph newlines.
- Having HTML embedded in the SVG (via `<foreignObject>`). This would likely work, but was a huge change a would require a lot of testing. Something we might want to explore though at some point, because it did result in smoother selecting.
- Having a `<text>` for each line (currently we have one per paragraph). This would likely work, but would make the copy UX less nice since you'd have newlines instead of paragraphs. Also would require a ton of code changes, which would require a lot of testing.