### PR TITLE
Feature/text sel options

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,7 @@ module.exports = {
         "MediaMetadata": "readonly"
     },
     "parserOptions": {
-        "ecmaVersion": 2018,
+        "ecmaVersion": 2020,
         "sourceType": "module"
     },
     "rules": {

--- a/BookReaderDemo/demo-internetarchive.html
+++ b/BookReaderDemo/demo-internetarchive.html
@@ -51,19 +51,24 @@
     </noscript>
 </div>
 
-<script>
-// Override options coming from IA
-BookReader.optionOverrides.imagesBaseURL = '/BookReader/images/';
-BookReader.optionOverrides.enableTextSelection = true;
-</script>
-
 <script id="pageUrl" type="text/javascript"></script>
 
 <script>
-  var URL_PART1 = "https://archive.org/bookreader/BookReaderJSLocate.php?id=";
-  var URL_PART2 = "&subPrefix=";
-  var bookId = location.href.match(/ocaid=([^&#]+)/i)[1];
-  document.getElementById('pageUrl').src = URL_PART1 + bookId + URL_PART2;
+  var ocaid = location.href.match(/ocaid=([^&#]+)/i)[1];
+
+  // Override options coming from IA
+  BookReader.optionOverrides.imagesBaseURL = '/BookReader/images/',
+  BookReader.optionOverrides.vars = {
+    ocaid: ocaid
+  };
+  BookReader.optionOverrides.plugins = {
+    textSelection: {
+      fullDjvuXmlUrl: 'https://cors.archive.org/cors/{{ocaid}}/{{ocaid}}_djvu.xml'
+    }
+  };
+
+  var script_url = 'https://archive.org/bookreader/BookReaderJSLocate.php?subPrefix=&id=' + ocaid;
+  document.getElementById('pageUrl').src = script_url;
 </script>
 
 </body>

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -88,8 +88,6 @@ BookReader.prototype.setup = function(options) {
   /** Overriden by plugin.search.js */
   this.enableSearch = false;
 
-  this.enableTextSelection = options.enableTextSelection;
-
   /**
    * Used to supress fragment change for init with canonical URLs
    * @var {boolean}
@@ -1071,7 +1069,7 @@ BookReader.prototype.zoom = function(direction) {
     break
   }
 
-  if (this.enableTextSelection) this.textSelectionPlugin.stopPageFlip(this.refs.$brContainer);
+  this.textSelectionPlugin?.stopPageFlip(this.refs.$brContainer);
   return;
 };
 
@@ -1559,7 +1557,7 @@ BookReader.prototype.switchMode = function(
   var eventName = mode + 'PageViewSelected';
   this.trigger(BookReader.eventNames[eventName]);
 
-  if (this.enableTextSelection) this.textSelectionPlugin.stopPageFlip(this.refs.$brContainer);
+  this.textSelectionPlugin?.stopPageFlip(this.refs.$brContainer);
 };
 
 BookReader.prototype.updateBrClasses = function() {
@@ -1615,7 +1613,7 @@ BookReader.prototype.enterFullscreen = function() {
   }.bind(this);
   $(document).keyup(this._fullscreenCloseHandler);
 
-  if (this.enableTextSelection) this.textSelectionPlugin.stopPageFlip(this.refs.$brContainer);
+  this.textSelectionPlugin?.stopPageFlip(this.refs.$brContainer);
 };
 
 BookReader.prototype.exitFullScreen = function() {
@@ -1634,7 +1632,7 @@ BookReader.prototype.exitFullScreen = function() {
   this.resize();
   this.refs.$brContainer.animate({opacity: 1}, 400, 'linear');
 
-  if (this.enableTextSelection) this.textSelectionPlugin.stopPageFlip(this.refs.$brContainer);
+  this.textSelectionPlugin?.stopPageFlip(this.refs.$brContainer);
 };
 
 /**

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -669,8 +669,7 @@ export class Mode2Up {
 
         this.br.refs.$brContainer.removeClass("BRpageFlipping");
 
-        if (this.br.enableTextSelection) this.br.textSelectionPlugin.stopPageFlip(this.br.refs.$brContainer);
-
+        this.br.textSelectionPlugin?.stopPageFlip(this.br.refs.$brContainer);
         this.br.trigger('pageChanged');
       });
     });
@@ -807,8 +806,7 @@ export class Mode2Up {
 
         this.br.refs.$brContainer.removeClass("BRpageFlipping");
 
-        if (this.br.enableTextSelection) this.br.textSelectionPlugin.stopPageFlip(this.br.refs.$brContainer);
-
+        this.br.textSelectionPlugin?.stopPageFlip(this.br.refs.$brContainer);
         this.br.trigger('pageChanged');
       });
     });

--- a/src/js/BookReader/options.js
+++ b/src/js/BookReader/options.js
@@ -123,8 +123,23 @@ export const DEFAULT_OPTIONS = {
   /** Should image downloads be blocked */
   protected: false,
 
-  /** Enables text selection layer */
-  enableTextSelection: false,
+  /**
+   * Settings for individual plugins. Note they have to be imported first.
+   * WIP: Most plugins just put their options anywhere in this global options file,
+   * but going forward we'll keep them here.
+   **/
+  plugins: {
+    /** @type {import('../plugins/plugin.text_selection.js').TextSelectionPluginOptions} */
+    textSelection: null,
+  },
+
+  /**
+   * Any variables you want to define. If an option has a StringWithVars type, or
+   * has something like `{{server}}/foo.com` in its value, these variables replace
+   * the `{{foo}}`.
+   * @type { {[var_name: string]: any } }
+   */
+  vars: {},
 
   /**
    * @type {Array<[PageData, PageData]|[PageData]>}

--- a/src/util/strings.js
+++ b/src/util/strings.js
@@ -2,8 +2,8 @@
 
 /**
  * @param {StringWithVars|String} template
- * @param { {[string]: any } } vars
- * @param { {[string]: any } } [overrides]
+ * @param { {[varName: string]: any } } vars
+ * @param { {[varName: string]: any } } [overrides]
  */
 export function applyVariables(template, vars, overrides={}) {
   return template?.replace(/\{\{([^}]*?)\}\}/g, ($0, $1) => {

--- a/src/util/strings.js
+++ b/src/util/strings.js
@@ -1,15 +1,34 @@
-/** @typedef {String} StringWithVars A template string with {{foo}} style variables */
+/**
+ * @typedef {String} StringWithVars
+ * A template string with {{foo}} style variables
+ * Also supports filters, like {{bookPath|urlencode}} (See APPLY_FILTERS for the
+ * supported list of filters)
+ **/
 
 /**
  * @param {StringWithVars|String} template
- * @param { {[varName: string]: any } } vars
- * @param { {[varName: string]: any } } [overrides]
+ * @param { {[varName: string]: { toString: () => string} } } vars
+ * @param { {[varName: string]: { toString: () => string} } } [overrides]
  */
-export function applyVariables(template, vars, overrides={}) {
+export function applyVariables(template, vars, overrides={}, possibleFilters=APPLY_FILTERS) {
   return template?.replace(/\{\{([^}]*?)\}\}/g, ($0, $1) => {
-    return $1 in overrides ? overrides[$1]
-      : $1 in vars ? vars[$1]
-      // If it's not defined, don't expand it at all
-      : $0;
+    if (!$1) return $0;
+    /** @type {string} */
+    const expression = $1;
+    const [varName, ...filterNames] = expression.split('|').map(x => x.trim());
+    const defined = varName in overrides || varName in vars;
+
+    // If it's not defined, don't expand it at all
+    if (!defined) return $0;
+    
+    const value = varName in overrides ? overrides[varName]
+    : varName in vars ? vars[varName] : null;
+    const filters = filterNames.map(n => possibleFilters[n]);
+    return filters.reduce((acc, cur) => cur(acc), value && value.toString());
   });
 }
+
+/** @type { {[filterName: String]:( string => string)} } */
+export const APPLY_FILTERS = {
+  urlencode: encodeURIComponent,
+};

--- a/src/util/strings.js
+++ b/src/util/strings.js
@@ -1,0 +1,15 @@
+/** @typedef {String} StringWithVars A template string with {{foo}} style variables */
+
+/**
+ * @param {StringWithVars|String} template
+ * @param { {[string]: any } } vars
+ * @param { {[string]: any } } [overrides]
+ */
+export function applyVariables(template, vars, overrides={}) {
+  return template?.replace(/\{\{([^}]*?)\}\}/g, ($0, $1) => {
+    return $1 in overrides ? overrides[$1]
+      : $1 in vars ? vars[$1]
+      // If it's not defined, don't expand it at all
+      : $0;
+  });
+}

--- a/tests/plugins/plugin.text_selection.test.js
+++ b/tests/plugins/plugin.text_selection.test.js
@@ -109,14 +109,14 @@ describe("Generic tests", () => {
 
 describe("textSelectionPlugin cosntructor", () => {
   test("textSelectionPlugin constructor with firefox browser", () => {
-    const tsp = new TextSelectionPlugin(true)
+    const tsp = new TextSelectionPlugin({}, {}, true)
     expect(tsp.djvuPagesPromise).toBe(null);
     expect(tsp.svgParagraphElement).toBe("g");
     expect(tsp.svgWordElement).toBe("text");
   });
 
   test("textSelectionPlugin constructor not on firefox browser", () => {
-    const tsp = new TextSelectionPlugin(false)
+    const tsp = new TextSelectionPlugin({}, {}, false)
     expect(tsp.djvuPagesPromise).toBe(null);
     expect(tsp.svgParagraphElement).toBe("text");
     expect(tsp.svgWordElement).toBe("tspan");

--- a/tests/util/strings.test.js
+++ b/tests/util/strings.test.js
@@ -1,4 +1,4 @@
-import { applyVariables } from '../../src/util/strings.js';
+import { APPLY_FILTERS, applyVariables } from '../../src/util/strings.js';
 
 describe('applyVariables', () => {
   test('null cases', () => {
@@ -26,5 +26,38 @@ describe('applyVariables', () => {
 
   test('Overrides do override', () => {
     expect(applyVariables('Hello {{name}}', {name: 'Bill'}, {name: 'Bobby'})).toEqual('Hello Bobby');
+  });
+
+  test('Nullish values', () => {
+    expect(applyVariables('Hello {{name}}', {name: undefined})).toEqual('Hello undefined');
+    expect(applyVariables('Hello {{name}}', {name: null})).toEqual('Hello null');
+    expect(applyVariables('Hello {{name}}', {name: ''})).toEqual('Hello ');
+  });
+
+  test('Non-string values', () => {
+    expect(applyVariables('Hello {{name}}', {name: 10})).toEqual('Hello 10');
+    expect(applyVariables('Hello {{name}}', {name: 0})).toEqual('Hello 0');
+  });
+
+  test('Filters', () => {
+    expect(applyVariables('Hello {{name|urlencode}}', {name: 'Jim bob'})).toEqual('Hello Jim%20bob');
+    expect(applyVariables('Hello {{name|urlencode}}', {name: 0})).toEqual('Hello 0');
+    expect(applyVariables('Hello {{name|urlencode}}', {})).toEqual('Hello {{name|urlencode}}');
+  });
+
+  test('Custom filters', () => {
+    expect(applyVariables('Hello {{name|upper}}', {name: 'Jim bob'}, {}, {upper: s => s.toUpperCase()})).toEqual('Hello JIM BOB');
+  });
+
+  test('Multiple filters', () => {
+    const filters = Object.assign({}, APPLY_FILTERS, {
+      upper: s => s.toUpperCase(),
+      lower: s => s.toLowerCase(),
+      double: s => s + s,
+    });
+    expect(applyVariables('Hello {{name|upper|urlencode}}', {name: 'Jim bob'}, {}, filters)).toEqual('Hello JIM%20BOB');
+    expect(applyVariables('Hello {{name|upper|lower}}', {name: 'Jim bob'}, {}, filters)).toEqual('Hello jim bob');
+    expect(applyVariables('Hello {{name|lower|upper}}', {name: 'Jim bob'}, {}, filters)).toEqual('Hello JIM BOB');
+    expect(applyVariables('Hello {{name|lower|double}}', {name: 'Jim bob'}, {}, filters)).toEqual('Hello jim bobjim bob');
   });
 });

--- a/tests/util/strings.test.js
+++ b/tests/util/strings.test.js
@@ -1,0 +1,30 @@
+import { applyVariables } from '../../src/util/strings.js';
+
+describe('applyVariables', () => {
+  test('null cases', () => {
+    expect(applyVariables(null, {})).toBeUndefined();
+    expect(applyVariables('', {})).toEqual('');
+    expect(applyVariables('', {x: 3})).toEqual('');
+  });
+
+  test('Ignores undefined variables', () => {
+    expect(applyVariables('Hello {{name}}!', {})).toEqual('Hello {{name}}!');
+  });
+
+  test('Replaces multiple instances', () => {
+    expect(applyVariables('Hello {{name}}! How are you doing, {{name}}?', {name: 'Bill'})).toEqual('Hello Bill! How are you doing, Bill?');
+    expect(applyVariables('Hello {{name}}! You are {{age}}, {{name}}', {name: 'Bill', age: 54})).toEqual('Hello Bill! You are 54, Bill');
+  });
+
+  test('Is case sensitive', () => {
+    expect(applyVariables('Hello {{name}}', {NAME: 'Bill'})).toEqual('Hello {{name}}');
+  });
+
+  test('Supports variable names with funny chars', () => {
+    expect(applyVariables('Hello {{first name}}', {'first name': 'Bill'})).toEqual('Hello Bill');
+  });
+
+  test('Overrides do override', () => {
+    expect(applyVariables('Hello {{name}}', {name: 'Bill'}, {name: 'Bobby'})).toEqual('Hello Bobby');
+  });
+});


### PR DESCRIPTION
Add new options to change text selection url used to fetch djvu xml.

Testing can happen on https://www-drini.archive.org/details/goodytwoshoes00newyiala , which has:

```js
{
  vars: { bookId: '...', server: '...', bookPath: '...' },
  plugins: {
    textSelection: { enabled: true, singlePageDjvuXml: '...blah...' }
  }
}
```

The the `vars` and mustache-style templates for the options are a little awkward, but here's what I considered:

- Tried having explicit objects (like `{ url: '', parameters: { path: '' } }`, etc). This resulted in too much code on the BR side to handle it. And it became brittle, and very verbose.
- No vars, and have petabox construct the url itself. This works, but is a little repetitive. With `vars`, they can be set once, and use in any settings in a semi-logical way. They might also be useful in the future if a var changes mid-way. If it's in petabox, you'd have to do a hard reload.

Open questions/concerns:
- I don't like how `pageIndex` looks exactly like the other vars, when it's in fact different.
- Note this will use the old, big djvu on the netlify app. Coordinating these was a little awkward, so this will have to get released, then the petabox side will need to get released (with the new version), then I can open a new PR to make this use the single-page option.