### PR TITLE
Skips subsequent creation of search views when setup called 1+n times

### DIFF
--- a/src/js/plugins/search/plugin.search.js
+++ b/src/js/plugins/search/plugin.search.js
@@ -50,6 +50,7 @@ BookReader.prototype.setup = (function (super_) {
     this.subPrefix = options.subPrefix;
     this.bookPath = options.bookPath;
 
+    if (this.searchView) { return; }
     this.searchView = new SearchView({
       br: this,
       selector: '#BRsearch_tray',

--- a/src/js/plugins/search/view.js
+++ b/src/js/plugins/search/view.js
@@ -186,7 +186,10 @@ class SearchView {
   }
 
   teardownSearchNavigation() {
-    if (!this.dom.searchNavigation) { return; }
+    if (!this.dom.searchNavigation) {
+      this.dom.searchNavigation = $('.BRsearch-navigation');
+    }
+    if (!this.dom.searchNavigation.length) { return; }
 
     this.dom.searchNavigation.off('.searchNavigation').remove();
     this.dom.searchNavigation = null;
@@ -423,6 +426,7 @@ class SearchView {
   handleSearchCallback(e, { results }) {
     this.matches = results.matches;
     this.setCurrentMatchIndex();
+    this.teardownSearchNavigation();
     this.renderSearchNavigation();
     this.bindSearchNavigationEvents();
     this.renderMatches(results.matches);


### PR DESCRIPTION
The search plugin's `setup` method is being called twice, causing two instances of the search views to be created. This checks for the existence of a search view and skips creating a new instance, while also adding a call to teardown the search navigation when search results are returned to ensure one search navigation is being rendered for search results.

Testing steps and review app can be found in [WEBDEV-3832](https://webarchive.jira.com/browse/WEBDEV-3832)