### PR TITLE
Adds data attribute to 2up page containers for side designation

### DIFF
--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -658,6 +658,7 @@ BookReader.prototype.drawLeafs = function() {
  * @protected
  */
 BookReader.prototype._createPageContainer = function(index, styles) {
+  const { pageSide } = this._models.book.getPage(index);
   const css = Object.assign({ position: 'absolute' }, styles);
   const modeClasses = {
     [this.constMode1up]: '1up',
@@ -667,7 +668,7 @@ BookReader.prototype._createPageContainer = function(index, styles) {
   const container = $('<div />', {
     'class': `BRpagecontainer BRmode${modeClasses[this.mode]} pagediv${index}`,
     css,
-  }).append($('<div />', { 'class': 'BRscreen' }));
+  }).attr('data-side', pageSide).append($('<div />', { 'class': 'BRscreen' }));
   container.toggleClass('protected', this.protected);
 
   return container;


### PR DESCRIPTION
Since 2up mode page containers are in reverse DOM order when flipping pages forward, there is no accurate method of determining which container is the left positioned container and which is right. This adds a data attribute based on the leaf data to determine which side the container is positioned on.