### PR TITLE
use fullscreen toggle flow to fire event

### DIFF
--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -490,7 +490,7 @@ BookReader.prototype.init = function() {
   // Must be called after this.init.initComplete set to true to allow
   // BookReader.prototype.resize to run.
   if (this.options.startFullscreen) {
-    this.enterFullscreen();
+    this.toggleFullscreen();
   }
 }
 


### PR DESCRIPTION
When we need to start the bookreader in fullscreen, we need to pass it through the fullscreen toggler so we can fire the event for the item & book navigators to respond appropriately.

Testing: 
go to https://www-isa.archive.org/details/fivehundredpoint08tussuoft/page/n5/mode/2up?q=fasdfioawer&view=theater -> bookreader opens fullscreen, in-browser