### PR TITLE
Remove exit animation TTS toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>BookReader Vendor Native Fullscreen Demo</title>
+    <title>BookReader Demos</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/src/css/_controls.scss
+++ b/src/css/_controls.scss
@@ -91,10 +91,21 @@
     height: 30px;
   }
 
+  @keyframes slideUp {
+    from {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
   .read-aloud {
     display: none;
     position: absolute;
-    bottom: -80px;
+    bottom: 100%;
     right: 0;
     left: 0;
     z-index: 1;
@@ -103,13 +114,11 @@
     align-items: center;
     justify-content: center;
     list-style: none;
-    transition: bottom .25s linear;
     background: $controlsBG;
+
     &.visible {
       display: flex;
-    }
-    &.animate {
-      bottom: 100%;
+      animation: slideUp 0.2s;
     }
 
     li {

--- a/src/css/_controls.scss
+++ b/src/css/_controls.scss
@@ -92,7 +92,7 @@
   }
 
   .read-aloud {
-    display: flex;
+    display: none;
     position: absolute;
     bottom: -80px;
     right: 0;
@@ -106,6 +106,9 @@
     transition: bottom .25s linear;
     background: $controlsBG;
     &.visible {
+      display: flex;
+    }
+    &.animate {
       bottom: 100%;
     }
 

--- a/src/js/plugins/tts/plugin.tts.js
+++ b/src/js/plugins/tts/plugin.tts.js
@@ -186,6 +186,7 @@ BookReader.prototype.ttsStart = function () {
     this.switchMode(this.constMode1up);
 
   this.refs.$BRReadAloudToolbar.addClass('visible');
+  setTimeout(() => this.refs.$BRReadAloudToolbar.addClass('animate'), 20);
   this.$('.BRicon.read').addClass('unread active');
   this.ttsSendAnalyticsEvent('Start');
   this.ttsEngine.start(this.currentIndex(), this.getNumLeafs());
@@ -222,7 +223,8 @@ BookReader.prototype.ttsPlayPause = function() {
 // ttsStop()
 //______________________________________________________________________________
 BookReader.prototype.ttsStop = function () {
-  this.refs.$BRReadAloudToolbar.removeClass('visible');
+  this.refs.$BRReadAloudToolbar.removeClass('animate');
+  setTimeout(() => this.refs.$BRReadAloudToolbar.removeClass('visible'), 250);
   this.$('.BRicon.read').removeClass('unread active');
   this.ttsSendAnalyticsEvent('Stop');
   this.ttsEngine.stop();

--- a/src/js/plugins/tts/plugin.tts.js
+++ b/src/js/plugins/tts/plugin.tts.js
@@ -186,7 +186,6 @@ BookReader.prototype.ttsStart = function () {
     this.switchMode(this.constMode1up);
 
   this.refs.$BRReadAloudToolbar.addClass('visible');
-  setTimeout(() => this.refs.$BRReadAloudToolbar.addClass('animate'), 20);
   this.$('.BRicon.read').addClass('unread active');
   this.ttsSendAnalyticsEvent('Start');
   this.ttsEngine.start(this.currentIndex(), this.getNumLeafs());
@@ -223,8 +222,7 @@ BookReader.prototype.ttsPlayPause = function() {
 // ttsStop()
 //______________________________________________________________________________
 BookReader.prototype.ttsStop = function () {
-  this.refs.$BRReadAloudToolbar.removeClass('animate');
-  setTimeout(() => this.refs.$BRReadAloudToolbar.removeClass('visible'), 250);
+  this.refs.$BRReadAloudToolbar.removeClass('visible');
   this.$('.BRicon.read').removeClass('unread active');
   this.ttsSendAnalyticsEvent('Stop');
   this.ttsEngine.stop();


### PR DESCRIPTION
When focus is given to the search input in the top right of BookReader and tab is pressed twice, the contents of the book container are shifted upward to show the TTS toolbar offscreen. This hides the TTS toolbar when not active, preventing the controls from being part of the tab index. In order to both toggle display and animate position in and out, timeouts are employed to toggle the animation shortly after visibility is given and visibility is removed immediately after the animation out is completed.