### PR TITLE
Fix 1up fullscreen loading

### DIFF
--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -1585,39 +1585,35 @@ BookReader.prototype.isFullscreen = function() {
 };
 
 /**
- * Fullscreen mode manager
- * - toggles fullscreen
+ * Toggles fullscreen
+ * @param { boolean } bindKeyboardControls
+ */
+BookReader.prototype.toggleFullscreen = function(bindKeyboardControls = true) {
+  if (this.isFullscreen()) {
+    this.exitFullScreen();
+  } else {
+    this.enterFullscreen(bindKeyboardControls);
+  }
+};
+
+/**
+ * Enters fullscreen
+ * including:
+ * - animation
  * - binds keyboard controls
  * - fires custom event
  * @param { boolean } bindKeyboardControls
  */
-BookReader.prototype.toggleFullscreen = function(bindKeyboardControls = true) {
-  this._fullscreenCloseHandler = function _fullscreenCloseHandler(e) {
-    if (e.keyCode === 27) this.toggleFullscreen();
-  }.bind(this);
-  const handleExit = () => {
-    this.exitFullScreen();
-    $(document).unbind('keyup', this._fullscreenCloseHandler);
-  }
-  const handleEnter = () => {
-    this.enterFullscreen();
-    if (bindKeyboardControls) {
-      $(document).keyup(this._fullscreenCloseHandler);
-    }
-  }
-
-  if (this.isFullscreen()) {
-    handleExit();
-  } else {
-    handleEnter();
-  }
-
-  this.trigger('fullscreenToggled');
-};
-
-BookReader.prototype.enterFullscreen = function() {
+BookReader.prototype.enterFullscreen = function(bindKeyboardControls = true) {
   const currentIndex = this.currentIndex();
   this.refs.$brContainer.css('opacity', 0);
+
+  if (bindKeyboardControls) {
+    this._fullscreenCloseHandler = (e) => {
+      if (e.keyCode === 27) this.toggleFullscreen();
+    };
+    $(document).keyup(this._fullscreenCloseHandler);
+  }
 
   const windowWidth = $(window).width();
   if (windowWidth <= this.onePageMinBreakpoint) {
@@ -1627,17 +1623,26 @@ BookReader.prototype.enterFullscreen = function() {
   this.isFullscreenActive = true;
   this.updateBrClasses();
 
-
   this.refs.$brContainer.animate({opacity: 1}, 'fast', 'linear',() => {
     this.resize();
     this.jumpToIndex(currentIndex);
   });
 
   this.textSelectionPlugin?.stopPageFlip(this.refs.$brContainer);
+  this.trigger('fullscreenToggled');
 };
 
+/**
+ * Exits fullscreen
+ * - toggles fullscreen
+ * - binds keyboard controls
+ * - fires custom event
+ * @param { boolean } bindKeyboardControls
+ */
 BookReader.prototype.exitFullScreen = function() {
   this.refs.$brContainer.css('opacity', 0);
+
+  $(document).unbind('keyup', this._fullscreenCloseHandler);
 
   var windowWidth = $(window).width();
   if (windowWidth <= this.onePageMinBreakpoint) {
@@ -1651,6 +1656,7 @@ BookReader.prototype.exitFullScreen = function() {
   this.refs.$brContainer.animate({opacity: 1}, 400, 'linear');
 
   this.textSelectionPlugin?.stopPageFlip(this.refs.$brContainer);
+  this.trigger('fullscreenToggled');
 };
 
 /**

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -1595,18 +1595,17 @@ BookReader.prototype.toggleFullscreen = function(bindKeyboardControls = true) {
   this._fullscreenCloseHandler = function _fullscreenCloseHandler(e) {
     if (e.keyCode === 27) this.toggleFullscreen();
   }.bind(this);
-
   const handleExit = () => {
     this.exitFullScreen();
     $(document).unbind('keyup', this._fullscreenCloseHandler);
   }
-
   const handleEnter = () => {
     this.enterFullscreen();
     if (bindKeyboardControls) {
       $(document).keyup(this._fullscreenCloseHandler);
     }
   }
+
   if (this.isFullscreen()) {
     handleExit();
   } else {
@@ -1628,9 +1627,11 @@ BookReader.prototype.enterFullscreen = function() {
   this.isFullscreenActive = true;
   this.updateBrClasses();
 
-  this.resize();
 
-  this.refs.$brContainer.animate({opacity: 1}, 400, 'linear', () => this.jumpToIndex(currentIndex));
+  this.refs.$brContainer.animate({opacity: 1}, 'fast', 'linear',() => {
+    this.resize();
+    this.jumpToIndex(currentIndex);
+  });
 
   this.textSelectionPlugin?.stopPageFlip(this.refs.$brContainer);
 };

--- a/tests/BookReader/BookReaderPublicFunctions.test.js
+++ b/tests/BookReader/BookReaderPublicFunctions.test.js
@@ -35,8 +35,6 @@ describe('BookReader.prototype.toggleFullscreen', ()  => {
     expect(br.enterFullscreen).toHaveBeenCalled();
   });
 
-
-
   test('will start with opening fullscreen', () => {
     const br = new BookReader();
     br.mode = br.constMode1up;
@@ -72,8 +70,52 @@ describe('BookReader.prototype.enterFullscreen', ()  => {
     br.enterFullscreen();
     expect(br._fullscreenCloseHandler).toBeDefined();
   });
-})
 
+  test('fires certain events when called', () => {
+    const br = new BookReader();
+    br.mode = br.constMode1up;
+    br.switchMode = jest.fn();
+    br.updateBrClasses = jest.fn();
+    br.trigger = jest.fn();
+    br.resize = jest.fn();
+    br.jumpToIndex = jest.fn();
+    const animateMock = (options, speed, style, callback) => {
+      callback();
+    };
+    br.refs.$brContainer = {
+      css: jest.fn(),
+      animate: animateMock,
+    };
+
+    br.enterFullscreen();
+    expect(br.switchMode).toHaveBeenCalledTimes(1);
+    expect(br.updateBrClasses).toHaveBeenCalledTimes(1);
+    expect(br.trigger).toHaveBeenCalledTimes(1);
+    expect(br.resize).toHaveBeenCalledTimes(1);
+    expect(br.jumpToIndex).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('BookReader.prototype.exitFullScreen', () => {
+  test('fires certain events when called', () => {
+    const br = new BookReader();
+    br.mode = br.constMode1up;
+    br.switchMode = jest.fn();
+    br.updateBrClasses = jest.fn();
+    br.trigger = jest.fn();
+    br.resize = jest.fn();
+    br.refs.$brContainer = {
+      css: jest.fn(),
+      animate: jest.fn(),
+    };
+
+    br.exitFullScreen();
+    expect(br.switchMode).toHaveBeenCalledTimes(1);
+    expect(br.updateBrClasses).toHaveBeenCalledTimes(1);
+    expect(br.trigger).toHaveBeenCalledTimes(1);
+    expect(br.resize).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe('BookReader.prototype.trigger', () => {
   test('fires custom event', () => {

--- a/tests/BookReader/BookReaderPublicFunctions.test.js
+++ b/tests/BookReader/BookReaderPublicFunctions.test.js
@@ -12,8 +12,11 @@ describe('BookReader.prototype.toggleFullscreen', ()  => {
     const br = new BookReader();
     br.mode = br.constMode1up;
     br.enterFullscreen = jest.fn();
-
     br.trigger = jest.fn();
+    br.refs.$brContainer = {
+      css: jest.fn(),
+      animate: jest.fn()
+    }
 
     br.toggleFullscreen();
     expect(br.enterFullscreen).toHaveBeenCalled();
@@ -22,7 +25,12 @@ describe('BookReader.prototype.toggleFullscreen', ()  => {
   test('will bind `_fullscreenCloseHandler` by default', () => {
     const br = new BookReader();
     br.mode = br.constMode1up;
-    br.enterFullscreen = jest.fn();
+    br.switchMode = jest.fn();
+    br.updateBrClasses = jest.fn();
+    br.refs.$brContainer = {
+      css: jest.fn(),
+      animate: jest.fn(),
+    };
     expect(br._fullscreenCloseHandler).toBeUndefined();
 
     br.toggleFullscreen();

--- a/tests/BookReader/BookReaderPublicFunctions.test.js
+++ b/tests/BookReader/BookReaderPublicFunctions.test.js
@@ -8,6 +8,19 @@ afterEach(() => {
 });
 
 describe('BookReader.prototype.toggleFullscreen', ()  => {
+  test('uses `isFullscreen` to check fullscreen state', () => {
+    const isFSmock = jest.fn();
+    isFSmock.mockReturnValueOnce(false);
+    const br = new BookReader();
+    br.mode = br.constMode1up;
+    br.enterFullscreen = jest.fn();
+    br.isFullscreen = isFSmock;
+
+    br.toggleFullscreen();
+    expect(br.isFullscreen).toHaveBeenCalled();
+    expect(br.isFullscreen).toHaveBeenCalled();
+  });
+
   test('will always emit an event', () => {
     const br = new BookReader();
     br.mode = br.constMode1up;

--- a/tests/BookReader/BookReaderPublicFunctions.test.js
+++ b/tests/BookReader/BookReaderPublicFunctions.test.js
@@ -35,20 +35,7 @@ describe('BookReader.prototype.toggleFullscreen', ()  => {
     expect(br.enterFullscreen).toHaveBeenCalled();
   });
 
-  test('will bind `_fullscreenCloseHandler` by default', () => {
-    const br = new BookReader();
-    br.mode = br.constMode1up;
-    br.switchMode = jest.fn();
-    br.updateBrClasses = jest.fn();
-    br.refs.$brContainer = {
-      css: jest.fn(),
-      animate: jest.fn(),
-    };
-    expect(br._fullscreenCloseHandler).toBeUndefined();
 
-    br.toggleFullscreen();
-    expect(br._fullscreenCloseHandler).toBeDefined();
-  });
 
   test('will start with opening fullscreen', () => {
     const br = new BookReader();
@@ -69,6 +56,24 @@ describe('BookReader.prototype.toggleFullscreen', ()  => {
     expect(br.exitFullScreen).toHaveBeenCalled();
   });
 });
+
+describe('BookReader.prototype.enterFullscreen', ()  => {
+  test('will bind `_fullscreenCloseHandler` by default', () => {
+    const br = new BookReader();
+    br.mode = br.constMode1up;
+    br.switchMode = jest.fn();
+    br.updateBrClasses = jest.fn();
+    br.refs.$brContainer = {
+      css: jest.fn(),
+      animate: jest.fn(),
+    };
+    expect(br._fullscreenCloseHandler).toBeUndefined();
+
+    br.enterFullscreen();
+    expect(br._fullscreenCloseHandler).toBeDefined();
+  });
+})
+
 
 describe('BookReader.prototype.trigger', () => {
   test('fires custom event', () => {

--- a/tests/BookReader/BookReaderPublicFunctions.test.js
+++ b/tests/BookReader/BookReaderPublicFunctions.test.js
@@ -7,6 +7,48 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
+describe('BookReader.prototype.toggleFullscreen', ()  => {
+  test('will always emit an event', () => {
+    const br = new BookReader();
+    br.mode = br.constMode1up;
+    br.enterFullscreen = jest.fn();
+
+    br.trigger = jest.fn();
+
+    br.toggleFullscreen();
+    expect(br.enterFullscreen).toHaveBeenCalled();
+  });
+
+  test('will bind `_fullscreenCloseHandler` by default', () => {
+    const br = new BookReader();
+    br.mode = br.constMode1up;
+    br.enterFullscreen = jest.fn();
+    expect(br._fullscreenCloseHandler).toBeUndefined();
+
+    br.toggleFullscreen();
+    expect(br._fullscreenCloseHandler).toBeDefined();
+  });
+
+  test('will start with opening fullscreen', () => {
+    const br = new BookReader();
+    br.mode = br.constMode1up;
+    br.enterFullscreen = jest.fn();
+
+    br.toggleFullscreen();
+    expect(br.enterFullscreen).toHaveBeenCalled();
+  });
+
+  test('will close fullscreen if BookReader is in fullscreen', () => {
+    const br = new BookReader();
+    br.mode = br.constMode1up;
+    br.exitFullScreen = jest.fn();
+    br.isFullscreenActive = true;
+
+    br.toggleFullscreen();
+    expect(br.exitFullScreen).toHaveBeenCalled();
+  });
+});
+
 describe('BookReader.prototype.trigger', () => {
   test('fires custom event', () => {
     const br = new BookReader();


### PR DESCRIPTION
Problem: starting 1up mode in fullscreen did not start at the requested page.

### Primary issue:
- while the outer bookreader container changes size to fullscreen, somewhere in the `resize` chain changes the page.

### Current Solution:
- pin current index at start of fullscreen toggle
- **then** set it after entrance animation, so that the bookreader's containers are already enlarged.
  - this prevents extra calls that change the page due to resizing functionality
- added a boolean to whether or not we set the keyboard Fullscreen Escape shortcut: `bindKeyboardControls`
  - this is to accommodate /stream page's basic default fullscreen view (they never leave it)
    - /stream page will now use main fullscreen toggle fn: `br.toggleFullscreen` to initiate Fullscreen instead of doing a work around
- some code rearrangement, to move the ESC keypress bind out of `enterFullscreen` & `exitFullscreen`
- unit tests around `toggleFullscreen`

### Testing:

go to: https://www-isa.archive.org/stream/chrysostom_pauline_homilies_field_vol_5#page/n34/mode/1up => goes to n34

go to: https://www-isa.archive.org/details/chrysostom_pauline_homilies_field_vol_5/page/n34/mode/1up?view=theater => ultimately goes to n34


(internal: https://webarchive.jira.com/browse/WEBDEV-3912)