### PR TITLE
Text Speed selector has white text on white on Chrome #507

### DIFF
--- a/src/css/_controls.scss
+++ b/src/css/_controls.scss
@@ -60,6 +60,9 @@
     border: none;
     cursor: pointer;
     background: transparent url("icons/playback-speed.svg") 50% 0 no-repeat;
+    option {
+      background: $controlsBG;
+    }
   }
 
   .active {


### PR DESCRIPTION
Closes #507

- Change background color to controlsBG to match the rest of the controls UI

![image](https://user-images.githubusercontent.com/6251786/97435759-47787f00-18f7-11eb-8e7b-72a58d117fab.png)
