### PR TITLE
updated font family to sans-serif for advance and review svg icons

### DIFF
--- a/BookReader/icons/advance.svg
+++ b/BookReader/icons/advance.svg
@@ -15,7 +15,7 @@
           <g transform="translate(11.000000, 10.000000) scale(-1, 1) translate(-11.000000, -10.000000) translate(1.000000, 0.000000)">
             <polyline stroke="#fff" stroke-width="2" stroke-linejoin="round" points="14.4444444 16.6666667 20 16.6666667 20 3.33333333 5.55555556 3.33333333"></polyline>
             <polygon fill="#fff" points="5.55555556 0 5.55555556 6.66666667 1.11111111 3.33333333"></polygon>
-            <text transform="translate(6.666667, 13.333333) scale(-1, 1) translate(-6.666667, -13.333333) " font-family="HelveticaNeue, Helvetica Neue" font-size="10" font-weight="normal" fill="#fff">
+            <text transform="translate(6.666667, 13.333333) scale(-1, 1) translate(-6.666667, -13.333333) " font-family="sans-serif" font-size="10" font-weight="normal" fill="#fff">
               <tspan x="0" y="17.3333333">10</tspan>
             </text>
           </g>

--- a/BookReader/icons/review.svg
+++ b/BookReader/icons/review.svg
@@ -13,7 +13,7 @@
       <g transform="translate(43.000000, 10.000000)">
         <polyline stroke="#fff" stroke-width="2" stroke-linejoin="round" points="14.4444444 16.6666667 20 16.6666667 20 3.33333333 5.55555556 3.33333333"></polyline>
         <polygon fill="#fff" points="5.55555556 0 5.55555556 6.66666667 1.11111111 3.33333333"></polygon>
-        <text font-family="HelveticaNeue, Helvetica Neue" font-size="10" font-weight="normal" fill="#fff">
+        <text font-family="sans-serif" font-size="10" font-weight="normal" fill="#fff">
           <tspan x="0" y="17.3333333">10</tspan>
         </text>
       </g>


### PR DESCRIPTION
For issue #508
"Back/forward SVG icons should have font-family: sans-serif"
Updated the font family to sans-serif for svg files:
/BookReader/icons/advance.svg
/BookReader/icons/review.svg