### PR TITLE
fix: table of contents black text on black 

### DIFF
--- a/src/css/_MobileNav.scss
+++ b/src/css/_MobileNav.scss
@@ -172,7 +172,7 @@ li.BRtable-contents-el {
 
   &.chapter-clickable {
     font-weight: normal;
-    color: black;
+    color: white;
   }
 
   &.current-chapter {

--- a/src/css/_MobileNav.scss
+++ b/src/css/_MobileNav.scss
@@ -172,7 +172,6 @@ li.BRtable-contents-el {
 
   &.chapter-clickable {
     font-weight: normal;
-    color: white;
   }
 
   &.current-chapter {


### PR DESCRIPTION
Closes #514

Changing color of .chapter-clickable to white as other text in table of contents.