### PR TITLE
hover message fixed

### DIFF
--- a/src/css/_controls.scss
+++ b/src/css/_controls.scss
@@ -97,7 +97,7 @@
     bottom: -80px;
     right: 0;
     left: 0;
-    z-index: 1;
+    z-index: 3;
     padding: 5px 0;
     margin: 0;
     align-items: center;


### PR DESCRIPTION
fixes #509 
![captureee](https://user-images.githubusercontent.com/43555219/97451192-83443080-1959-11eb-895b-f7517183a409.JPG)


![Screenshot (28)](https://user-images.githubusercontent.com/43555219/97451234-8e975c00-1959-11eb-80aa-34590c688951.png)

the hover in mobile is triggered only when the button is clicked so for that I make the z-index of the tts bar to be 3 so that the message will not be visible 

Stakeholders
@cdrini 