### PR TITLE
Remove dependOn for jquery and friends

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,10 +10,10 @@ module.exports = {
     // Note the version in the filename is wrong, but kept for backwards compatibility. Won't matter
     // once the entire file is deleted/auto-generated in v5
     'jquery-1.10.1.js': { import: './src/js/jquery-wrapper.js' },
-    'jquery-ui-1.12.0.min.js': { import: './src/js/jquery-ui-wrapper.js', dependOn: 'jquery-1.10.1.js' },
+    'jquery-ui-1.12.0.min.js': { import: './src/js/jquery-ui-wrapper.js' },
     'jquery.browser.min.js': { import: 'jquery.browser', dependOn: 'jquery-1.10.1.js' },
-    'jquery.colorbox-min.js': { import: 'jquery-colorbox', dependOn: 'jquery-1.10.1.js' },
-    'jquery.ui.touch-punch.min.js': { import: 'jquery-ui-touch-punch', dependOn: 'jquery-ui-1.12.0.min.js' },
+    'jquery.colorbox-min.js': { import: 'jquery-colorbox' },
+    'jquery.ui.touch-punch.min.js': { import: 'jquery-ui-touch-punch' },
 
     // BookReader
     'BookReader.js': './src/js/BookReader.js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
     // Note the version in the filename is wrong, but kept for backwards compatibility. Won't matter
     // once the entire file is deleted/auto-generated in v5
     'jquery-1.10.1.js': { import: './src/js/jquery-wrapper.js' },
-    'jquery-ui-1.12.0.min.js': { import: './src/js/jquery-ui-wrapper.js' },
+    'jquery-ui-1.12.0.min.js': { import: './src/js/jquery-ui-wrapper.js', dependOn: 'jquery-1.10.1.js' },
     'jquery.browser.min.js': { import: 'jquery.browser', dependOn: 'jquery-1.10.1.js' },
     'jquery.colorbox-min.js': { import: 'jquery-colorbox' },
     'jquery.ui.touch-punch.min.js': { import: 'jquery-ui-touch-punch' },


### PR DESCRIPTION
dependOn let's webpack include code/polyfills in shared nodes of the dependency tree. But since a client (and in fact IA) might be using its own copy of jquery, this was causing colorbox to break when integrated into IA.

This causes a small jump in file size--and a peculiarly large jump in file size to jquery.browser.min.js 3KB -> 98KB! So I disabled it for this one and will confirm that it is still working correctly on IA.

This won't matter once we import most of these via JS.