### PR TITLE
Fix some text selection issues

### DIFF
--- a/BookReaderDemo/demo-internetarchive.html
+++ b/BookReaderDemo/demo-internetarchive.html
@@ -58,15 +58,7 @@
   var ocaid = location.href.match(/ocaid=([^&#]+)/i)[1];
 
   // Override options coming from IA
-  BookReader.optionOverrides.imagesBaseURL = '/BookReader/images/',
-  BookReader.optionOverrides.vars = {
-    ocaid: ocaid
-  };
-  BookReader.optionOverrides.plugins = {
-    textSelection: {
-      fullDjvuXmlUrl: 'https://cors.archive.org/cors/{{ocaid}}/{{ocaid}}_djvu.xml'
-    }
-  };
+  BookReader.optionOverrides.imagesBaseURL = '/BookReader/images/';
 
   var script_url = 'https://archive.org/bookreader/BookReaderJSLocate.php?subPrefix=&id=' + ocaid;
   document.getElementById('pageUrl').src = script_url;

--- a/src/js/plugins/plugin.text_selection.js
+++ b/src/js/plugins/plugin.text_selection.js
@@ -55,16 +55,16 @@ export class TextSelectionPlugin {
    * @returns {Promise<HTMLElement|undefined>}
    */
   async getPageText(index) {
-    if (this.options.fullDjvuXmlUrl) {
-      const XMLpagesArr = await this.djvuPagesPromise;
-      if (XMLpagesArr) return XMLpagesArr[index];
-    } else {
+    if (this.options.singlePageDjvuXmlUrl) {
       return $.ajax({
         type: "GET",
         url: applyVariables(this.options.singlePageDjvuXmlUrl, this.optionVariables, { pageIndex: index }),
         dataType: "xml",
         error: (e) => undefined,
       }).then(xmlDoc  => xmlDoc && $(xmlDoc).find("OBJECT")[0]);
+    } else {
+      const XMLpagesArr = await this.djvuPagesPromise;
+      if (XMLpagesArr) return XMLpagesArr[index];
     }
   }
 

--- a/src/js/plugins/plugin.text_selection.js
+++ b/src/js/plugins/plugin.text_selection.js
@@ -237,7 +237,8 @@ export class BookreaderWithTextSelection extends BookReader {
   _createPageContainer(index, styles = {}) {
     const $container = super._createPageContainer(index, styles);
     // Disable if thumb mode; it's too janky
-    if (this.mode != this.constModeThumb) {
+    // index can be -1 for "pre-cover" region
+    if (this.mode != this.constModeThumb && index > 0) {
       this.textSelectionPlugin?.createTextLayer(index, $container);
     }
     return $container;

--- a/tests/plugins/plugin.text_selection.test.js
+++ b/tests/plugins/plugin.text_selection.test.js
@@ -60,8 +60,17 @@ describe("Generic tests", () => {
   });
 
   test("_createPageContainer overriden function still creates a BRpagecontainer element", () => {
+    const spy = sinon.spy(br.textSelectionPlugin, 'createTextLayer');
     const $container = br._createPageContainer(1, {});
     expect($container.hasClass("BRpagecontainer")).toBe(true);
+    expect(spy.callCount).toBe(1);
+  });
+
+
+  test("_createPageContainer handles index -1", () => {
+    const spy = sinon.spy(br.textSelectionPlugin, 'createTextLayer');
+    br._createPageContainer(-1, {});
+    expect(spy.callCount).toBe(0);
   });
 
   test("createTextLayer creates an svg layer with paragraph with 1 word element", async () => {


### PR DESCRIPTION
Fix:
- Defining both full djvu xml url and single page djvu xml url causes neither to work; broke textsel on netlify
- No longer need options overrides now text sel is in prod
- Avoid requests for special index=-1 cover; causing a bunch of errors in Sentry
