### PR TITLE
Circumvent bug in BR JSIA code

### DIFF
--- a/BookReaderDemo/demo-internetarchive.html
+++ b/BookReaderDemo/demo-internetarchive.html
@@ -60,6 +60,9 @@
   // Override options coming from IA
   BookReader.optionOverrides.imagesBaseURL = '/BookReader/images/';
 
+  // Temp; Circumvent bug in BookReaderJSIA code
+  window.Sentry = null;
+
   var script_url = 'https://archive.org/bookreader/BookReaderJSLocate.php?subPrefix=&id=' + ocaid;
   document.getElementById('pageUrl').src = script_url;
 </script>


### PR DESCRIPTION
Sentry was added to IA, and they code like `if (Sentry) { ... }`. Should be `if (window.Sentry)`. Temp fix until that's resolved.