### PR TITLE
Update Text selection error handling to handle empty xml file

### DIFF
--- a/src/js/plugins/plugin.text_selection.js
+++ b/src/js/plugins/plugin.text_selection.js
@@ -42,12 +42,16 @@ export class TextSelectionPlugin {
     this.djvuPagesPromise = $.ajax({
       type: "GET",
       url: applyVariables(this.options.fullDjvuXmlUrl, this.optionVariables),
-      dataType: "xml",
-
-      error: function (e) {
+      dataType: "html",
+      error: (e) => undefined
+    }).then((res) => {
+      try {
+        const xmlMap = $.parseXML(res);
+        return xmlMap && $(xmlMap).find("OBJECT");
+      } catch (e) {
         return undefined;
       }
-    }).then(xmlMap  => xmlMap && $(xmlMap).find("OBJECT"));
+    });
   }
 
   /**
@@ -59,9 +63,16 @@ export class TextSelectionPlugin {
       return $.ajax({
         type: "GET",
         url: applyVariables(this.options.singlePageDjvuXmlUrl, this.optionVariables, { pageIndex: index }),
-        dataType: "xml",
+        dataType: "html",
         error: (e) => undefined,
-      }).then(xmlDoc  => xmlDoc && $(xmlDoc).find("OBJECT")[0]);
+      }).then((res) => {
+        try {
+          const xmlDoc = $.parseXML(res);
+          return xmlDoc && $(xmlDoc).find("OBJECT")[0];
+        } catch (e) {
+          return undefined;
+        }
+      });
     } else {
       const XMLpagesArr = await this.djvuPagesPromise;
       if (XMLpagesArr) return XMLpagesArr[index];

--- a/tests/plugins/plugin.text_selection.test.js
+++ b/tests/plugins/plugin.text_selection.test.js
@@ -20,6 +20,7 @@ const FAKE_XML_MULT_WORDS = `<OBJECT data="file://localhost//tmp/derive/goodytwo
 <WORD coords="1600,2768,1700,2640">test3</WORD></LINE></PARAGRAPH></OBJECT>`;
 const FAKE_XML_5COORDS = `<OBJECT data="file://localhost//tmp/derive/goodytwoshoes00newyiala//goodytwoshoes00newyiala.djvu" height="3192" type="image/x.djvu" usemap="goodytwoshoes00newyiala_0001.djvu" width="2454">
 <PARAGRAPH><LINE><WORD coords="1216,2768,1256,2640,2690">test</WORD></LINE></PARAGRAPH></OBJECT>`;
+const FAKE_XML_EMPTY = '';
 
 describe("Generic tests", () => {
 
@@ -54,6 +55,7 @@ describe("Generic tests", () => {
       case 1: return $(parser.parseFromString(FAKE_XML_1WORD, "text/xml"));
       case 2: return $(parser.parseFromString(FAKE_XML_MULT_WORDS, "text/xml"));
       case 3: return $(parser.parseFromString(FAKE_XML_5COORDS, "text/xml"));
+      case 4: return $(parser.parseFromString(FAKE_XML_EMPTY, "text/xml"))
       }
     });
   });
@@ -96,6 +98,14 @@ describe("Generic tests", () => {
     expect($container.find(".textSelectionSVG").length).toBe(1);
     expect($container.find(".BRparagElement").length).toBe(1);
     expect($container.find(".BRwordElement").length).toBe(1);
+  });
+
+  test("createTextLayer can handle empty xml", async () => {
+    const $container = br.refs.$brContainer;
+    await br.textSelectionPlugin.createTextLayer(4, $container);
+    expect($container.find(".textSelectionSVG").length).toBe(1);
+    expect($container.find(".BRparagElement").length).toBe(0);
+    expect($container.find(".BRwordElement").length).toBe(0);
   });
 
   const LONG_PRESS_DURATION = 500;


### PR DESCRIPTION
### Problem: 
Some items do not have a dejavu.xml, and when that happens, the xml parser borks inside of promise chain.

#### Repro:
- go to: https://archive.org/stream/EQuran00003/E-Quran-00003#page/n54/mode/1up
- open console - you see lots of errors
![image](https://user-images.githubusercontent.com/7840857/98716606-b5359980-2340-11eb-9c1d-c95b7298aecf.png)

### Solution:
- wrap response in a try/catch to parse incoming XML

Go to: https://www-isa2.archive.org/stream/EQuran00003/E-Quran-00003#page/n54/mode/1up

Error no longer happens in console

Go to a book that has dejavu.xml available:
- https://www-isa2.archive.org/stream/goody#page/n22/mode/1up
- you can select text

