### PR TITLE
update non-asserted page labelling next to nav scrubber

### DIFF
--- a/src/js/BookReader/Navbar/Navbar.js
+++ b/src/js/BookReader/Navbar/Navbar.js
@@ -287,13 +287,13 @@ export class Navbar {
  * @return {string}
  */
 export function getNavPageNumHtml(index, numLeafs, pageNum, pageType, maxPageNum) {
-  if (pageNum[0] != 'n') {
-    let pageStr = `Page ${pageNum}`;
-    if (maxPageNum) {
-      pageStr += ` of ${maxPageNum}`;
-    }
-    return pageStr;
-  } else {
-    return `${index + 1}&nbsp;/&nbsp;${numLeafs}`;
+  const pageIsAsserted = pageNum[0] != 'n';
+
+  if (!pageIsAsserted) {
+    const pageIndex = index + 1;
+    return `Page (${pageIndex} of ${numLeafs})`; // Page (8 of 10)
   }
+
+  const bookLengthLabel = maxPageNum ? ` of ${maxPageNum}` : '';
+  return `Page ${pageNum}${bookLengthLabel}`;
 }

--- a/tests/BookReader/Navbar/Navbar.test.js
+++ b/tests/BookReader/Navbar/Navbar.test.js
@@ -9,7 +9,7 @@ import BookReader from '../../../src/js/BookReader.js';
 describe('getNavPageNumHtml', () => {
   const f = getNavPageNumHtml;
   test('handle n-prefixed page numbers', () => {
-    expect(f(3, 40, 'n3', '', 40)).toBe('4&nbsp;/&nbsp;40');
+    expect(f(3, 40, 'n3', '', 40)).toBe('Page (4 of 40)');
   });
 
   test('handle regular page numbers', () => {


### PR DESCRIPTION
### Testing:

- go to an asserted page: `https://deploy-preview-558--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=goody#page/48/mode/2up` => page label in nav: `Page 48 of 156`
- go to a non-asserted page: `https://deploy-preview-558--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=B-001-014-456#page/n75/mode/2up` => page label in nav: `Page (76 of 132)`

https://webarchive.jira.com/browse/WEBDEV-4017