### PR TITLE
Faster serve dev (>10x!)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,12 @@
     "setupFiles": [
       "./env-setup.js"
     ],
+    "roots": [
+      "<rootDir>/src/",
+      "<rootDir>/tests/"
+    ],
     "testPathIgnorePatterns": [
-      "tests/e2e"
+      "<rootDir>/tests/e2e/"
     ]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "lint": "npx eslint src/js tests",
     "lint:fix": "npx eslint --fix src/js tests",
     "serve": "npx http-server . --port 8000",
-    "serve-live": "npx live-server . --port 8000 --ignore=coverage,tests,src",
+    "serve-live": "npx live-server . --port 8000 --watch=index.html,BookReader,BookReaderDemo",
     "serve-dev": "npx concurrently --kill-others npm:serve-live npm:build-*:watch",
     "test": "npx jest",
     "test:e2e": "env BASE_URL=http://127.0.0.1:8000/BookReaderDemo/ npx testcafe",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "build-assets": "npx cpx \"src/assets/**/*\" BookReader && npx svgo -f BookReader/icons && npx svgo -f BookReader/images",
     "build-assets:watch": "npx cpx --watch --verbose \"src/assets/**/*\" BookReader",
     "build-js": "npx webpack && node scripts/copy-modules.js",
-    "build-js:watch": "npx webpack --watch",
+    "build-js:watch": "npx webpack --mode=development --watch",
     "build-css": "npx sass --no-source-map ./src/css/BookReader.scss ./BookReader/BookReader.css",
     "build-css:watch": "npx sass --watch --no-source-map ./src/css/BookReader.scss ./BookReader/BookReader.css",
     "lint": "npx eslint src/js tests",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,10 +2,33 @@
 const path = require('path');
 const webpack = require('webpack');
 
+/** @type {webpack.Configuration} */
+const shared = {
+  mode: 'production',
+
+  watchOptions: {
+    ignored: ['BookReader/**', 'node_modules/**', 'tests/**']
+  },
+
+  target: ['web', 'es5'],
+
+  module: {
+    rules: [
+      { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader" }
+    ]
+  },
+
+  output: {
+    filename: '[name]',
+    path: path.resolve(__dirname, 'BookReader'),
+  },
+};
+
 /** @type {webpack.Configuration[]} */
 module.exports = [
   {
-    mode: 'production',
+    ...shared,
+
     // Output file -> srcfile
     entry: {
       // BookReader
@@ -41,18 +64,10 @@ module.exports = [
       })
     ],
 
-    module: {
-      rules: [
-        { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader" }
-      ]
-    },
-
     output: {
       filename: '[name]',
       path: path.resolve(__dirname, 'BookReader'),
     },
-
-    target: ['web', 'es5'],
 
     // Accurate source maps at the expense of build time.
     // The source map is intentionally exposed
@@ -63,29 +78,18 @@ module.exports = [
   // jQuery gets its own build, so that it can be used as an "external" in
   // everything else.
   {
-    mode: 'production',
+    ...shared,
+
     entry: {
       'jquery-1.10.1.js': { import: './src/js/jquery-wrapper.js' },
     },
-
-    module: {
-      rules: [
-        { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader" }
-      ]
-    },
-
-    output: {
-      filename: '[name]',
-      path: path.resolve(__dirname, 'BookReader'),
-    },
-
-    target: ['web', 'es5'],
   },
 
   // jQuery plugins/extensions
   // All of these will be replaced with just imports in v5
   {
-    mode: 'production',
+    ...shared,
+
     // Output file -> srcfile
     entry: {
       'jquery-ui-1.12.0.min.js': { import: './src/js/jquery-ui-wrapper.js' },
@@ -107,18 +111,5 @@ module.exports = [
         jQuery: 'jquery',
       })
     ],
-
-    module: {
-      rules: [
-        { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader" }
-      ]
-    },
-
-    output: {
-      filename: '[name]',
-      path: path.resolve(__dirname, 'BookReader'),
-    },
-
-    target: ['web', 'es5'],
   },
 ];


### PR DESCRIPTION
- Use webpack dev mode for dev server
- Make live-server only watch the files it needs to watch
- Make webpack ignore built files
- Speed up jest --watch by making it only watch src/tests dirs (My VSCode jest extension no longer crashes!)

Making a JS change went from ~10-20s to cause a refresh to ~600ms :) 