### PR TITLE
progress bar moves right to left for RTL books

### DIFF
--- a/src/css/_BRnav.scss
+++ b/src/css/_BRnav.scss
@@ -262,6 +262,9 @@
   float: left;
   flex: 1 auto;
 }
+.BRnavposRL{
+  transform: rotate(180deg);
+}
 .BRpager.ui-slider  {
   position: relative;
   height: 8px;

--- a/src/js/BookReader/Navbar/Navbar.js
+++ b/src/js/BookReader/Navbar/Navbar.js
@@ -126,7 +126,7 @@ export class Navbar {
           <nav class="BRcontrols">
             <ul class="controls">
               <li class="scrubber">
-                <div class="BRnavpos">
+                <div class="BRnavpos ${isRTL ? 'BRnavposRL' : ''}">
                   <div class="BRpager"></div>
                   <div class="BRnavline"></div>
                 </div>


### PR DESCRIPTION
resolves internetarchive/bookreader#580
Rotated the progress bar by 180 degrees for RTL books. 
![](https://i.imgur.com/9jDPzhc.png)