### PR TITLE
2up draw - reduction factors + making sure actual numbers are used when calculating

### DIFF
--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -1680,9 +1680,9 @@ BookReader.prototype._scrollAmount = function() {
   return parseInt(0.9 * this.refs.$brContainer.prop('clientHeight'));
 };
 
-BookReader.prototype.prefetchImg = function(index, optionalReduction) {
-  var pageURI = this._getPageURI(index, optionalReduction);
-  const pageURISrcset = this.options.useSrcSet ? this._getPageURISrcset(index) : [];
+BookReader.prototype.prefetchImg = function(index) {
+  var pageURI = this._getPageURI(index, this.reduce);
+  const pageURISrcset = this.options.useSrcSet ? this._getPageURISrcset(index, this.reduce) : [];
 
   // Load image if not loaded or URI has changed (e.g. due to scaling)
   var loadImage = false;

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -119,7 +119,7 @@ BookReader.prototype.setup = function(options) {
 
   // Private properties below. Configuration should be done with options.
   /** @type {number} TODO: Make private */
-  this.reduce = 4;
+  this.reduce = 8; /* start very small */
   this.defaults = options.defaults;
   this.padding = options.padding;
 
@@ -1314,10 +1314,15 @@ BookReader.prototype.getPrevReadMode = function(mode) {
  * @param {number}
  * @param {object} [options]
  * @param {boolean} [options.suppressFragmentChange = false]
+ * @param {boolean} [options.onInit = false] - this
  */
 BookReader.prototype.switchMode = function(
   mode,
-  { suppressFragmentChange = false } = {}
+  {
+    suppressFragmentChange = false,
+    init = false,
+    pageFound = false
+  } = {}
 ) {
   // Skip checks before init() complete
   if (this.init.initComplete) {
@@ -1355,8 +1360,12 @@ BookReader.prototype.switchMode = function(
   } else {
     // $$$ why don't we save autofit?
     // this.twoPage.autofit = null; // Take zoom level from other mode
-    this.twoPageCalculateReductionFactors();
-    this.reduce = this.quantizeReduce(this.reduce, this.twoPage.reductionFactors);
+    // spread indices not set, so let's set them
+    if (init || !pageFound) {
+      this.setSpreadIndices();
+    }
+
+    this.twoPageCalculateReductionFactors(); // this sets this.twoPage && this.reduce
     this.prepareTwoPageView();
     this.twoPageCenterView(0.5, 0.5); // $$$ TODO preserve center
   }
@@ -1671,8 +1680,8 @@ BookReader.prototype._scrollAmount = function() {
   return parseInt(0.9 * this.refs.$brContainer.prop('clientHeight'));
 };
 
-BookReader.prototype.prefetchImg = function(index) {
-  var pageURI = this._getPageURI(index);
+BookReader.prototype.prefetchImg = function(index, optionalReduction) {
+  var pageURI = this._getPageURI(index, optionalReduction);
   const pageURISrcset = this.options.useSrcSet ? this._getPageURISrcset(index) : [];
 
   // Load image if not loaded or URI has changed (e.g. due to scaling)
@@ -1855,7 +1864,9 @@ exposeOverrideableMethod(Mode2Up, '_modes.mode2Up', 'jumpIndexForRightEdgePageX'
 /** @deprecated unused outside Mode2Up */
 BookReader.prototype.prefetch = Mode2Up.prototype.prefetch;
 exposeOverrideableMethod(Mode2Up, '_modes.mode2Up', 'prefetch', 'prefetch');
-
+/** @deprecated unused outside Mode2Up */
+BookReader.prototype.setSpreadIndices = Mode2Up.prototype.setSpreadIndices;
+exposeOverrideableMethod(Mode2Up, '_modes.mode2Up', 'setSpreadIndices', 'setSpreadIndices');
 /**
  * Immediately stop flip animations.  Callbacks are triggered.
  */

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -44,7 +44,7 @@ export class Mode2Up {
     this.br.twoPage.scaledWL = this.getPageWidth(indexL);
     this.br.twoPage.gutter = this.gutter();
 
-    this.br.prefetchImg(indexL);
+    this.br.prefetchImg(indexL, this.br.reduce);
     $(this.br.prefetchedImgs[indexL]).css({
       position: 'absolute',
       left: `${this.br.twoPage.gutter - this.br.twoPage.scaledWL}px`,
@@ -59,7 +59,7 @@ export class Mode2Up {
 
     // $$$ should use getwidth2up?
     this.br.twoPage.scaledWR = this.getPageWidth(indexR);
-    this.br.prefetchImg(indexR);
+    this.br.prefetchImg(indexR, this.br.reduce);
     $(this.br.prefetchedImgs[indexR]).css({
       position: 'absolute',
       left: `${this.br.twoPage.gutter}px`,
@@ -275,6 +275,13 @@ export class Mode2Up {
     }
   }
 
+  setSpreadIndices() {
+    const targetLeaf = clamp(this.br.firstIndex, this.br.firstDisplayableIndex(), this.br.lastDisplayableIndex());
+    const currentSpreadIndices = this.book.getSpreadIndices(targetLeaf);
+    this.br.twoPage.currentIndexL = currentSpreadIndices[0];
+    this.br.twoPage.currentIndexR = currentSpreadIndices[1];
+  }
+
   /**
    * Calculates 2-page spread dimensions based on this.br.twoPage.currentIndexL and
    * this.br.twoPage.currentIndexR
@@ -292,14 +299,13 @@ export class Mode2Up {
       // set based on reduction factor
       spreadSize = this.getSpreadSizeFromReduce(firstIndex, secondIndex, this.br.reduce);
     }
-
     // Both pages together
-    this.br.twoPage.height = spreadSize.height;
-    this.br.twoPage.width = spreadSize.width;
+    this.br.twoPage.height = spreadSize.height || 0;
+    this.br.twoPage.width = spreadSize.width || 0;
 
     // Individual pages
-    this.br.twoPage.scaledWL = this.getPageWidth(firstIndex);
-    this.br.twoPage.scaledWR = this.getPageWidth(secondIndex);
+    this.br.twoPage.scaledWL = this.getPageWidth(firstIndex) || 0;
+    this.br.twoPage.scaledWR = this.getPageWidth(secondIndex) || 0;
 
     // Leaf edges
     this.br.twoPage.edgeWidth = spreadSize.totalLeafEdgeWidth; // The combined width of both edges
@@ -343,8 +349,7 @@ export class Mode2Up {
     this.br.twoPage.bookSpineDivLeft = this.br.twoPage.middle - (this.br.twoPage.bookSpineDivWidth >> 1);
     this.br.twoPage.bookSpineDivTop = this.br.twoPage.bookCoverDivTop;
 
-
-    this.br.reduce = spreadSize.reduce; // $$$ really set this here?
+    this.br.reduce = spreadSize.reduce < 0 ? this.br.reduce : spreadSize.reduce; // $$$ really set this here?
   }
 
   /**
@@ -389,17 +394,17 @@ export class Mode2Up {
     const heightOutsidePages = 2 * (this.br.twoPage.coverInternalPadding + this.br.twoPage.coverExternalPadding);
 
     ideal.width = (this.br.refs.$brContainer.width() - widthOutsidePages) >> 1;
-    ideal.width -= 10; // $$$ fudge factor
-    ideal.height = this.br.refs.$brContainer.height() - heightOutsidePages;
+    ideal.width = ideal.width > 10 ? ideal.width - 10 : 1; // $$$ fudge factor
 
-    ideal.height -= 15; // fudge factor
+    ideal.height = this.br.refs.$brContainer.height() - heightOutsidePages;
+    ideal.height = ideal.height > 15 ? ideal.height - 15 : 1; // $$$ fudge factor
 
     if (ideal.height / ratio <= ideal.width) {
       //use height
-      ideal.width = Math.floor(ideal.height / ratio);
+      ideal.width = Math.floor(ideal.height / ratio) || 1;
     } else {
       //use width
-      ideal.height = Math.floor(ideal.width * ratio);
+      ideal.height = Math.floor(ideal.width * ratio) || 1;
     }
 
     // $$$ check this logic with large spreads
@@ -855,8 +860,8 @@ export class Mode2Up {
    * @param {number} prevR
    */
   prepareFlipLeftToRight(prevL, prevR) {
-    this.br.prefetchImg(prevL);
-    this.br.prefetchImg(prevR);
+    this.br.prefetchImg(prevL, this.br.reduce);
+    this.br.prefetchImg(prevR, this.br.reduce);
 
     const height  = this.book._getPageHeight(prevL);
     const width   = this.book._getPageWidth(prevL);
@@ -903,8 +908,8 @@ export class Mode2Up {
    */
   prepareFlipRightToLeft(nextL, nextR) {
     // Prefetch images
-    this.br.prefetchImg(nextL);
-    this.br.prefetchImg(nextR);
+    this.br.prefetchImg(nextL, this.br.reduce);
+    this.br.prefetchImg(nextR, this.br.reduce);
 
     let height = this.book._getPageHeight(nextR);
     let width = this.book._getPageWidth(nextR);
@@ -1192,12 +1197,12 @@ export class Mode2Up {
     let highPage = book.getPage(max(currentIndexL, currentIndexR));
     for (let i = 0; i < ADJACENT_PAGES_TO_LOAD + 1; i++) {
       if (lowPage) {
-        this.br.prefetchImg(lowPage.index);
+        this.br.prefetchImg(lowPage.index, this.br.reduce);
         lowPage = lowPage.findPrev({ combineConsecutiveUnviewables: true });
       }
 
       if (highPage) {
-        this.br.prefetchImg(highPage.index);
+        this.br.prefetchImg(highPage.index, this.br.reduce);
         highPage = highPage.findNext({ combineConsecutiveUnviewables: true });
       }
     }

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -44,7 +44,7 @@ export class Mode2Up {
     this.br.twoPage.scaledWL = this.getPageWidth(indexL);
     this.br.twoPage.gutter = this.gutter();
 
-    this.br.prefetchImg(indexL, this.br.reduce);
+    this.br.prefetchImg(indexL);
     $(this.br.prefetchedImgs[indexL]).css({
       position: 'absolute',
       left: `${this.br.twoPage.gutter - this.br.twoPage.scaledWL}px`,
@@ -59,7 +59,7 @@ export class Mode2Up {
 
     // $$$ should use getwidth2up?
     this.br.twoPage.scaledWR = this.getPageWidth(indexR);
-    this.br.prefetchImg(indexR, this.br.reduce);
+    this.br.prefetchImg(indexR);
     $(this.br.prefetchedImgs[indexR]).css({
       position: 'absolute',
       left: `${this.br.twoPage.gutter}px`,
@@ -860,8 +860,8 @@ export class Mode2Up {
    * @param {number} prevR
    */
   prepareFlipLeftToRight(prevL, prevR) {
-    this.br.prefetchImg(prevL, this.br.reduce);
-    this.br.prefetchImg(prevR, this.br.reduce);
+    this.br.prefetchImg(prevL);
+    this.br.prefetchImg(prevR);
 
     const height  = this.book._getPageHeight(prevL);
     const width   = this.book._getPageWidth(prevL);
@@ -908,8 +908,8 @@ export class Mode2Up {
    */
   prepareFlipRightToLeft(nextL, nextR) {
     // Prefetch images
-    this.br.prefetchImg(nextL, this.br.reduce);
-    this.br.prefetchImg(nextR, this.br.reduce);
+    this.br.prefetchImg(nextL);
+    this.br.prefetchImg(nextR);
 
     let height = this.book._getPageHeight(nextR);
     let width = this.book._getPageWidth(nextR);
@@ -1197,12 +1197,12 @@ export class Mode2Up {
     let highPage = book.getPage(max(currentIndexL, currentIndexR));
     for (let i = 0; i < ADJACENT_PAGES_TO_LOAD + 1; i++) {
       if (lowPage) {
-        this.br.prefetchImg(lowPage.index, this.br.reduce);
+        this.br.prefetchImg(lowPage.index);
         lowPage = lowPage.findPrev({ combineConsecutiveUnviewables: true });
       }
 
       if (highPage) {
-        this.br.prefetchImg(highPage.index, this.br.reduce);
+        this.br.prefetchImg(highPage.index);
         highPage = highPage.findNext({ combineConsecutiveUnviewables: true });
       }
     }


### PR DESCRIPTION
Problem:
If container DOM is not set, the reduction factors of 2up mode are calculating against `NaN` and breaks all the things.

Solution:
- remove redundant `this.reduce` calculation
- pass `this.reduce` through to image url creation.


To Test: go to www-isa.archive.org/details/goody
open dev tools
refresh
look at BookReaderImages.php requests
confirm that the URL does not have scale=1