### PR TITLE
add srcSet option to 1up

### DIFF
--- a/src/js/BookReader/Mode1Up.js
+++ b/src/js/BookReader/Mode1Up.js
@@ -103,9 +103,10 @@ export class Mode1Up {
           left: leftMargin,
         });
 
+        const pageURISrcset = this.br.options.useSrcSet ? this.br._getPageURISrcset(index, this.br.reduce, 0) : [];
         const img = $('<img />', {
           src: page.getURI(this.br.reduce, 0),
-          srcset: this.br._getPageURISrcset(index, this.br.reduce, 0),
+          srcset: pageURISrcset,
           alt: 'Book page image'
         });
         pageContainer.append(img);


### PR DESCRIPTION
To test - use incognito window:

1. go to `www-isa2.archive.org/stream/goody?ref=ol`
2. open inspector
3. go to 1up mode
4. look at image element, note srcSet is empty (like in pic)
5. go to `www-isa2.archive.org/details/goody/mode/1up`
6. steps 2 - 4 => no srcSet either.


![image](https://user-images.githubusercontent.com/7840857/107661879-8defb080-6c3e-11eb-9d79-90d648605c7f.png)
