### PR TITLE
exit fullscreen - switch to 2up if available

### DIFF
--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -1463,7 +1463,9 @@ BookReader.prototype.exitFullScreen = function() {
   $(document).unbind('keyup', this._fullscreenCloseHandler);
 
   var windowWidth = $(window).width();
-  if (windowWidth <= this.onePageMinBreakpoint) {
+
+  const canShow2up = this.options.controls.twoPage.visible;
+  if (canShow2up && (windowWidth <= this.onePageMinBreakpoint)) {
     this.switchMode(this.constMode2up);
   }
 


### PR DESCRIPTION
Problem: even if 2up is not available, when exiting fullscreen, bookreader will put book at 2up mode

Solution: check to see if 2up mode is available before switching modes