### PR TITLE
Resize 2up prefetch update

### DIFF
--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -577,8 +577,10 @@ BookReader.prototype.resize = function() {
   } else {
     // We only need to prepare again in autofit (size of spread changes)
     if (this.twoPage.autofit) {
+      // most common path, esp. for archive.org books
       this.prepareTwoPageView();
     } else {
+      // used when zoomed in
       // Re-center if the scrollbars have disappeared
       var center = this.twoPageGetViewCenter();
       var doRecenter = false;
@@ -1157,9 +1159,7 @@ BookReader.prototype.nextReduce = function(currentReduce, direction, reductionFa
     if (match) return match;
   }
 
-  console.error('Could not find reduction factor for direction ' + direction);
   return reductionFactors[0];
-
 };
 
 BookReader.prototype._reduceSort = function(a, b) {

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -48,12 +48,11 @@ export class Mode2Up {
     const indexL = this.br.twoPage.currentIndexL;
     const indexR = this.br.twoPage.currentIndexR;
 
-    const { rightLeafCss, leftLeafCss } = this.spreadCSSAttributes();
     this.br.prefetchImg(indexL);
-    $(this.br.prefetchedImgs[indexL]).css(leftLeafCss).appendTo($twoPageViewEl);
+    $(this.br.prefetchedImgs[indexL]).css(this.leftLeafCss).appendTo($twoPageViewEl);
 
     this.br.prefetchImg(indexR);
-    $(this.br.prefetchedImgs[indexR]).css(rightLeafCss).appendTo($twoPageViewEl);
+    $(this.br.prefetchedImgs[indexR]).css(this.rightLeafCss).appendTo($twoPageViewEl);
 
     this.displayedIndices = [this.br.twoPage.currentIndexL, this.br.twoPage.currentIndexR];
     this.setMouseHandlers();
@@ -120,33 +119,24 @@ export class Mode2Up {
   resizeSpread() {
     this.br.resizeBRcontainer(false); // no animation
     this.calculateSpreadSize();
-    const {
-      mainContainerCss,
-      spreadCoverCss,
-      leafEdgeRCss,
-      leafEdgeLCss,
-      spineCss,
-      leftLeafCss,
-      rightLeafCss,
-    } = this.spreadCSSAttributes();
 
-    this.br.refs?.$brTwoPageView.css(mainContainerCss);
+    this.br.refs?.$brTwoPageView.css(this.mainContainerCss);
     this.centerView(undefined, undefined); // let function self adjust
 
-    $(this.br.twoPage.coverDiv).css(spreadCoverCss); // click sheath is memoized somehow
+    $(this.br.twoPage.coverDiv).css(this.spreadCoverCss); // click sheath is memoized somehow
     const $spreadLayers = this.br.refs.$brTwoPageView;
 
-    $spreadLayers.find('.BRleafEdgeR')?.css(leafEdgeRCss);
-    $spreadLayers.find('.BRleafEdgeL')?.css(leafEdgeLCss);
-    $spreadLayers.find('.BRgutter')?.css(spineCss);
+    $spreadLayers.find('.BRleafEdgeR')?.css(this.leafEdgeRCss);
+    $spreadLayers.find('.BRleafEdgeL')?.css(this.leafEdgeLCss);
+    $spreadLayers.find('.BRgutter')?.css(this.spineCss);
 
     for (const imageIdx in this.br.prefetchedImgs) {
       const image = this.br.prefetchedImgs[imageIdx];
       if (image.getAttribute('data-side') === 'L') {
-        $(image).css(leftLeafCss);
+        $(image).css(this.leftLeafCss);
       }
       if (image.getAttribute('data-side') === 'R') {
-        $(image).css(rightLeafCss);
+        $(image).css(this.rightLeafCss);
       }
     }
   }
@@ -200,10 +190,8 @@ export class Mode2Up {
     this.br.refs.$brContainer.dragscrollable({preventDefault:true});
     this.br.bindGestures(this.br.refs.$brContainer);
 
-    const { mainContainerCss, spreadCoverCss, leafEdgeRCss, leafEdgeLCss, spineCss } = this.spreadCSSAttributes();
-
     // $$$ calculate container size first
-    this.br.refs?.$brTwoPageView.css(mainContainerCss);
+    this.br.refs?.$brTwoPageView.css(this.mainContainerCss);
 
     // This will trump the incoming coordinates
     // in order to center book when zooming out
@@ -218,18 +206,18 @@ export class Mode2Up {
 
     // then set
     this.br.twoPage.coverDiv = document.createElement('div');
-    $(this.br.twoPage.coverDiv).attr('class', 'BRbookcover').css(spreadCoverCss).appendTo(this.br.refs.$brTwoPageView);
+    $(this.br.twoPage.coverDiv).attr('class', 'BRbookcover').css(this.spreadCoverCss).appendTo(this.br.refs.$brTwoPageView);
 
     this.leafEdgeR = document.createElement('div');
     this.leafEdgeR.className = 'BRleafEdgeR';
-    $(this.leafEdgeR).css(leafEdgeRCss).appendTo(this.br.refs.$brTwoPageView);
+    $(this.leafEdgeR).css(this.leafEdgeRCss).appendTo(this.br.refs.$brTwoPageView);
 
     this.leafEdgeL = document.createElement('div');
     this.leafEdgeL.className = 'BRleafEdgeL';
-    $(this.leafEdgeL).css(leafEdgeLCss).appendTo(this.br.refs.$brTwoPageView);
+    $(this.leafEdgeL).css(this.leafEdgeLCss).appendTo(this.br.refs.$brTwoPageView);
 
     const div = document.createElement('div');
-    $(div).attr('class', 'BRgutter').css(spineCss).appendTo(this.br.refs.$brTwoPageView);
+    $(div).attr('class', 'BRgutter').css(this.spineCss).appendTo(this.br.refs.$brTwoPageView);
 
     this.preparePopUp();
 
@@ -1232,94 +1220,95 @@ export class Mode2Up {
     }
   }
 
-  /**
-   * Calculates and returns leaf spread attributes
-   * + Sets [some] this.br.twoPage properties
-   * @returns  {{
-   *  mainContainerCss: Object,
-   *  spreadCoverCss: Object,
-   *  spineCss: Object,
-   *  leftLeafCss: Object,
-   *  leafEdgeLCss: Object,
-   *  rightLeafCss: Object,
-   *  leafEdgeRCss: Object,
-   * }}
-   */
-  spreadCSSAttributes() {
-    // $$$ we should use calculated values in this.twoPage (recalc if necessary)
-    const indexL = this.br.twoPage.currentIndexL;
-    const indexR = this.br.twoPage.currentIndexR;
-    const top = this.top();
+  /* 2up Container Sizes */
 
-    this.br.twoPage.gutter = this.gutter();
-    this.br.twoPage.scaledWL = this.getPageWidth(indexL);
-    this.br.twoPage.scaledWR = this.getPageWidth(indexR);
-
-    const baseLeafCss = {
+  /** main positions for inner containers */
+  get baseLeafCss() {
+    return {
       position: 'absolute',
       right: '',
       top: `${top}px`,
       zIndex: 2,
     };
-    const heightCss = {
-      height: `${this.br.twoPage.height}px`, // $$$ height forced the same for both pages
-    }
+  }
 
-    const leftLeafCss = {
-      ...baseLeafCss,
-      ...heightCss,
+  /** main height for inner containers */
+  get heightCss() {
+    return {
+      height: `${this.br.twoPage.height}px`, // $$$ height forced the same for both pages
+    };
+  }
+
+  /** Left Page sizing */
+  get leftLeafCss() {
+    return {
+      ...this.baseLeafCss,
+      ...this.heightCss,
       left: `${this.br.twoPage.gutter - this.br.twoPage.scaledWL}px`,
       width: `${this.br.twoPage.scaledWL}px`,
-    };
-    const leafEdgeLCss = {
-      ...heightCss,
+    }
+  }
+
+  /** Left side book thickness */
+  get leafEdgeLCss() {
+    return {
+      ...this.heightCss,
       width: `${this.br.twoPage.leafEdgeWidthL}px`,
       left: `${this.br.twoPage.bookCoverDivLeft + this.br.twoPage.coverInternalPadding}px`,
       top: `${this.br.twoPage.bookCoverDivTop + this.br.twoPage.coverInternalPadding}px`,
       border: this.br.twoPage.leafEdgeWidthL === 0 ? 'none' : null
     };
+  }
 
-    const rightLeafCss = {
-      ...baseLeafCss,
-      ...heightCss,
+  /** Right Page sizing */
+  get rightLeafCss() {
+    return {
+      ...this.baseLeafCss,
+      ...this.heightCss,
       left: `${this.br.twoPage.gutter}px`,
       width: `${this.br.twoPage.scaledWR}px`,
-    };
-    const leafEdgeRCss = {
-      ...heightCss,
+    }
+  }
+
+  /** Right side book thickness */
+  get leafEdgeRCss() {
+    return {
+      ...this.heightCss,
       width: `${this.br.twoPage.leafEdgeWidthR}px`,
       left: `${this.br.twoPage.scaledWL + this.br.twoPage.scaledWR + this.br.twoPage.leafEdgeWidthL}px`,
       top: `${this.br.twoPage.bookCoverDivTop + this.br.twoPage.coverInternalPadding}px`,
       border: this.br.twoPage.leafEdgeWidthR === 0 ? 'none' : null
     };
+  }
 
-    const mainContainerCss = {
+  /** main container sizing */
+  get mainContainerCss() {
+    return {
       height: `${this.br.twoPage.totalHeight}px`,
       width: `${this.br.twoPage.totalWidth}px`,
       position: 'absolute'
     };
-    const spreadCoverCss = {
+  }
+
+  /** book cover sizing */
+  get spreadCoverCss() {
+    return {
       width: `${this.br.twoPage.bookCoverDivWidth}px`,
       height: `${this.br.twoPage.bookCoverDivHeight}px`,
       visibility: 'visible'
-    }
-    const spineCss = {
+    };
+  }
+
+  /** book spine sizing */
+  get spineCss() {
+    return {
       width: `${this.br.twoPage.bookSpineDivWidth}px`,
       height: `${this.br.twoPage.bookSpineDivHeight}px`,
       left: `${this.br.twoPage.gutter - (this.br.twoPage.bookSpineDivWidth / 2)}px`,
       top: `${this.br.twoPage.bookSpineDivTop}px`
     };
-
-    return {
-      mainContainerCss,
-      spreadCoverCss,
-      spineCss,
-      leftLeafCss,
-      leafEdgeLCss,
-      rightLeafCss,
-      leafEdgeRCss,
-    };
   }
+  /** end CSS */
 }
 
 /**

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -102,7 +102,7 @@ export class Mode2Up {
    *
    * @returns {Boolean}
    */
-  shouldRedrawSpread() {
+  get shouldRedrawSpread() {
     const { prefetchedImgs, twoPage } = this.br;
     const { reduce: idealReductionFactor } = this.getIdealSpreadSize( this.br.twoPage.currentIndexL, this.br.twoPage.currentIndexR );
 
@@ -158,7 +158,7 @@ export class Mode2Up {
     // even as the page sizes change.  To e.g. keep the middle of the book in the middle of the BRcontent
     // div requires adjusting the offset of BRtwpageview and/or scrolling in BRcontent.
 
-    if (!drawNewSpread && !this.shouldRedrawSpread()) {
+    if (!drawNewSpread && !this.shouldRedrawSpread) {
       this.resizeSpread();
       return;
     }

--- a/tests/BookReader/Mode2Up.test.js
+++ b/tests/BookReader/Mode2Up.test.js
@@ -51,6 +51,44 @@ describe('zoom', () => {
   });
 });
 
+describe('prefetch', () => {
+  test('loads nearby pages', () => {
+    const br = new BookReader({ data: SAMPLE_DATA });
+    br.init();
+    const spy = sinon.spy(br, 'prefetchImg');
+    br.prefetch();
+    expect(spy.callCount).toBeGreaterThan(2);
+  });
+
+  test('works when at start of book', () => {
+    const br = new BookReader({ data: SAMPLE_DATA });
+    br.init();
+    br.jumpToIndex(-1);
+    const spy = sinon.spy(br, 'prefetchImg');
+    br.prefetch();
+    expect(spy.callCount).toBeGreaterThan(2);
+  });
+
+  test('works when at end of book', () => {
+    const br = new BookReader({ data: SAMPLE_DATA });
+    br.init();
+    br.jumpToIndex(SAMPLE_DATA.flat().length - 1);
+    const spy = sinon.spy(br, 'prefetchImg');
+    br.prefetch();
+    expect(spy.callCount).toBeGreaterThan(2);
+  });
+
+
+  test('skips consecutive unviewables', () => {
+    const data = deepCopy(SAMPLE_DATA);
+    data[1].forEach(page => page.viewable = false);
+    const br = new BookReader({ data });
+    br.init();
+    br.prefetch();
+    expect(br.prefetchedImgs).not.toContain(2);
+  });
+});
+
 describe('draw 2up leaves', () => {
   test('calls `drawLeafs` on init as default', () => {
     const br = new BookReader({ data: SAMPLE_DATA });
@@ -104,93 +142,143 @@ describe('resizeSpread', () => {
     const resizeBRcontainer = sinon.spy(br, 'resizeBRcontainer');
     const calculateSpreadSize = sinon.spy(br._modes.mode2Up, 'calculateSpreadSize');
     const drawLeafs = sinon.spy(br._modes.mode2Up, 'drawLeafs');
-    const spreadCSSAttributes = sinon.spy(br._modes.mode2Up, 'spreadCSSAttributes');
     const centerView = sinon.spy(br._modes.mode2Up, 'centerView');
 
     br._modes.mode2Up.resizeSpread();
+    expect(drawLeafs.callCount).toBe(0);  // no draw
     expect(resizeBRcontainer.callCount).toBe(1);
     expect(calculateSpreadSize.callCount).toBe(1);
     expect(centerView.callCount).toBe(1);
-    expect(spreadCSSAttributes.callCount).toBe(1);
-    expect(drawLeafs.callCount).toBe(0);  // no draw
   });
 });
 
-describe('spreadCSSAttributes', () => {
-  test('returns container size for 2up spread', () => {
+describe('2up Container sizing', () => {
+  test('baseLeafCss', () => {
     const br = new BookReader({ data: SAMPLE_DATA });
     br.init();
-
     br.calculateSpreadSize();
-    const twoUpContainerSizes = br._modes.mode2Up.spreadCSSAttributes();
-    expect(Object.keys(twoUpContainerSizes)).toEqual([
-      'mainContainerCss',
-      'spreadCoverCss',
-      'spineCss',
-      'leftLeafCss',
-      'leafEdgeLCss',
-      'rightLeafCss',
-      'leafEdgeRCss'
-    ]);
+    expect(Object.keys(br._modes.mode2Up.baseLeafCss)).toEqual(['position', 'right', 'top', 'zIndex']);
+  });
+  test('heightCss', () => {
+    const br = new BookReader({ data: SAMPLE_DATA });
+    br.init();
+    br.calculateSpreadSize();
+    const heightStub = 1000;
+    br.twoPage.height = heightStub;
+    expect(Object.keys(br._modes.mode2Up.heightCss)).toEqual(['height']);
+    expect(br._modes.mode2Up.heightCss).toEqual({height: `${heightStub}px`});
+  });
+  describe('left side', () => {
+    const br = new BookReader({ data: SAMPLE_DATA });
+    br.init();
+    br.calculateSpreadSize();
+
+    test('leftLeafCss', () => {
+      expect(Object.keys(br._modes.mode2Up.leftLeafCss)).toEqual([
+        'position',
+        'right',
+        'top',
+        'zIndex',
+        'height',
+        'left',
+        'width',
+      ]);
+    });
+    test('leafEdgeLCss', () => {
+      expect(Object.keys(br._modes.mode2Up.leafEdgeLCss)).toEqual([
+        'height',
+        'width',
+        'left',
+        'top',
+        'border'
+      ]);
+    });
+  });
+  describe('right side', () => {
+    const br = new BookReader({ data: SAMPLE_DATA });
+    br.init();
+    br.calculateSpreadSize();
+
+    test('rightLeafCss', () => {
+      expect(Object.keys(br._modes.mode2Up.rightLeafCss)).toEqual([
+        'position',
+        'right',
+        'top',
+        'zIndex',
+        'height',
+        'left',
+        'width',
+      ]);
+    });
+    test('leafEdgeRCss', () => {
+      expect(Object.keys(br._modes.mode2Up.leafEdgeRCss)).toEqual([
+        'height',
+        'width',
+        'left',
+        'top',
+        'border'
+      ]);
+    });
+  });
+  describe('full width container, overlay + spine', () => {
+    test('mainContainerCss', () => {
+      const br = new BookReader({ data: SAMPLE_DATA });
+      br.init();
+      br.calculateSpreadSize();
+
+      expect(Object.keys(br._modes.mode2Up.mainContainerCss)).toEqual(['height', 'width', 'position']);
+    });
+    test('spreadCoverCss', () => {
+      const br = new BookReader({ data: SAMPLE_DATA });
+      br.init();
+      br.calculateSpreadSize();
+      expect(Object.keys(br._modes.mode2Up.spreadCoverCss)).toEqual(['width', 'height', 'visibility']);
+    });
+    test('spineCss', () => {
+      const br = new BookReader({ data: SAMPLE_DATA });
+      br.init();
+      br.calculateSpreadSize();
+      expect(Object.keys(br._modes.mode2Up.spineCss)).toEqual(['width', 'height', 'left', 'top']);
+    });
   });
 });
 
 describe('prepareTwoPageView', () => {
-  test('always draws new spread if `drawNewSpread` is true ', () => {
-    const br = new BookReader({ data: SAMPLE_DATA });
-    br.init();
-    const drawLeafs = sinon.spy(br._modes.mode2Up, 'drawLeafs');
-    const spreadCSSAttributes = sinon.spy(br._modes.mode2Up, 'spreadCSSAttributes');
-    br.prepareTwoPageView(undefined, undefined, true);
-    expect(drawLeafs.callCount).toBe(1);
-    expect(spreadCSSAttributes.callCount).toBe(2);
-  });
+  describe('drawing spread', () => {
+    test('always draws new spread if `drawNewSpread` is true ', () => {
+      const br = new BookReader({ data: SAMPLE_DATA });
+      br.init();
+      const drawLeafs = sinon.spy(br._modes.mode2Up, 'drawLeafs');
+      const resizeSpread = sinon.spy(br._modes.mode2Up, 'resizeSpread');
+      const calculateSpreadSize = sinon.spy(br._modes.mode2Up, 'calculateSpreadSize');
+      const pruneUnusedImgs = sinon.spy(br, 'pruneUnusedImgs');
+      const prefetch = br.prefetch = sinon.spy();
+      const bindGestures = sinon.spy(br, 'bindGestures');
+      const centerView = sinon.spy(br._modes.mode2Up, 'centerView');
+      const preparePopUp = sinon.spy(br._modes.mode2Up, 'preparePopUp');
+      const updateBrClasses = sinon.spy(br, 'updateBrClasses');
 
-  test('resizes spread if no redraw is necessary', () => {
-    const br = new BookReader({ data: SAMPLE_DATA });
-    br.init();
-    const drawLeafs = sinon.spy(br._modes.mode2Up, 'drawLeafs');
-    const resizeSpread = sinon.spy(br._modes.mode2Up, 'resizeSpread');
-    br.prepareTwoPageView();
-    expect(drawLeafs.callCount).toBe(0);
-    expect(resizeSpread.callCount).toBe(1);
-  });
-});
+      br.prepareTwoPageView(undefined, undefined, true);
+      expect(prefetch.callCount).toBe(2);
 
-describe('prefetch', () => {
-  test('loads nearby pages', () => {
-    const br = new BookReader({ data: SAMPLE_DATA });
-    br.init();
-    const spy = sinon.spy(br, 'prefetchImg');
-    br.prefetch();
-    expect(spy.callCount).toBeGreaterThan(2);
-  });
+      expect(resizeSpread.callCount).toBe(0);
+      expect(drawLeafs.callCount).toBe(1);
+      expect(calculateSpreadSize.callCount).toBe(1);
+      expect(pruneUnusedImgs.callCount).toBe(1);
+      expect(bindGestures.callCount).toBe(1);
+      expect(centerView.callCount).toBe(1);
+      expect(preparePopUp.callCount).toBe(1);
+      expect(updateBrClasses.callCount).toBe(1);
+    });
 
-  test('works when at start of book', () => {
-    const br = new BookReader({ data: SAMPLE_DATA });
-    br.init();
-    br.jumpToIndex(-1);
-    const spy = sinon.spy(br, 'prefetchImg');
-    br.prefetch();
-    expect(spy.callCount).toBeGreaterThan(2);
-  });
-
-  test('works when at end of book', () => {
-    const br = new BookReader({ data: SAMPLE_DATA });
-    br.init();
-    br.jumpToIndex(SAMPLE_DATA.flat().length - 1);
-    const spy = sinon.spy(br, 'prefetchImg');
-    br.prefetch();
-    expect(spy.callCount).toBeGreaterThan(2);
-  });
-
-
-  test('skips consecutive unviewables', () => {
-    const data = deepCopy(SAMPLE_DATA);
-    data[1].forEach(page => page.viewable = false);
-    const br = new BookReader({ data });
-    br.init();
-    br.prefetch();
-    expect(br.prefetchedImgs).not.toContain(2);
+    test('resizes spread if no redraw is necessary', () => {
+      const br = new BookReader({ data: SAMPLE_DATA });
+      br.init();
+      const drawLeafs = sinon.spy(br._modes.mode2Up, 'drawLeafs');
+      const resizeSpread = sinon.spy(br._modes.mode2Up, 'resizeSpread');
+      br.prepareTwoPageView();
+      expect(drawLeafs.callCount).toBe(0);
+      expect(resizeSpread.callCount).toBe(1);
+    });
   });
 });

--- a/tests/BookReader/Mode2Up.test.js
+++ b/tests/BookReader/Mode2Up.test.js
@@ -121,7 +121,7 @@ describe('shouldRedrawSpread', () => {
     const reduceStub = 10;
     br.reduce = reduceStub;
     br._modes.mode2Up.getIdealSpreadSize = () => { return { reduce: 11 }};
-    const shouldRedrawSpread = br._modes.mode2Up.shouldRedrawSpread();
+    const shouldRedrawSpread = br._modes.mode2Up.shouldRedrawSpread;
     expect(shouldRedrawSpread).toBe(false);
   });
   test('returns TRUE if current images are smaller && if pages in view are prefetched', () => {
@@ -130,7 +130,7 @@ describe('shouldRedrawSpread', () => {
     const reduceStub = 11;
     br.reduce = reduceStub;
     br._modes.mode2Up.getIdealSpreadSize = () => { return { reduce: 10 }};
-    const shouldRedrawSpread = br._modes.mode2Up.shouldRedrawSpread();
+    const shouldRedrawSpread = br._modes.mode2Up.shouldRedrawSpread;
     expect(shouldRedrawSpread).toBe(true);
   });
 });

--- a/tests/BookReader/Mode2Up.test.js
+++ b/tests/BookReader/Mode2Up.test.js
@@ -36,13 +36,18 @@ const SAMPLE_DATA = [
 
 
 describe('zoom', () => {
-  test('stops animations when zooming', () => {
-    const br = new BookReader({ data: SAMPLE_DATA });
-    br.init();
+  const br = new BookReader({ data: SAMPLE_DATA });
+  br.init();
 
-    const stopAnim = sinon.spy(br, 'stopFlipAnimations');
-    br._modes.mode2Up.zoom(1);
+  const stopAnim = sinon.spy(br, 'stopFlipAnimations');
+  const resizeSpread = sinon.spy(br._modes.mode2Up, 'resizeSpread');
+  br._modes.mode2Up.zoom('in');
+
+  test('stops animations when zooming', () => {
     expect(stopAnim.callCount).toBe(1);
+  });
+  test('always redraws when zooming', () => {
+    expect(resizeSpread.callCount).toBe(0);
   });
 });
 
@@ -69,6 +74,87 @@ describe('draw 2up leaves', () => {
     expect(br.displayedIndices.length).toBe(2); // is array
     expect(br.displayedIndices).toEqual([-1, 0]); // default to starting index on right, placeholder for left
   })
+});
+
+describe('shouldRedrawSpread', () => {
+  test('returns FALSE if current images are larger && if pages in view are prefetched', () => {
+    const br = new BookReader({ data: SAMPLE_DATA });
+    br.init();
+    const reduceStub = 10;
+    br.reduce = reduceStub;
+    br._modes.mode2Up.getIdealSpreadSize = () => { return { reduce: 11 }};
+    const shouldRedrawSpread = br._modes.mode2Up.shouldRedrawSpread();
+    expect(shouldRedrawSpread).toBe(false);
+  });
+  test('returns TRUE if current images are smaller && if pages in view are prefetched', () => {
+    const br = new BookReader({ data: SAMPLE_DATA });
+    br.init();
+    const reduceStub = 11;
+    br.reduce = reduceStub;
+    br._modes.mode2Up.getIdealSpreadSize = () => { return { reduce: 10 }};
+    const shouldRedrawSpread = br._modes.mode2Up.shouldRedrawSpread();
+    expect(shouldRedrawSpread).toBe(true);
+  });
+});
+
+describe('resizeSpread', () => {
+  test('only resizes spread', () => {
+    const br = new BookReader({ data: SAMPLE_DATA });
+    br.init();
+    const resizeBRcontainer = sinon.spy(br, 'resizeBRcontainer');
+    const calculateSpreadSize = sinon.spy(br._modes.mode2Up, 'calculateSpreadSize');
+    const drawLeafs = sinon.spy(br._modes.mode2Up, 'drawLeafs');
+    const spreadCSSAttributes = sinon.spy(br._modes.mode2Up, 'spreadCSSAttributes');
+    const centerView = sinon.spy(br._modes.mode2Up, 'centerView');
+
+    br._modes.mode2Up.resizeSpread();
+    expect(resizeBRcontainer.callCount).toBe(1);
+    expect(calculateSpreadSize.callCount).toBe(1);
+    expect(centerView.callCount).toBe(1);
+    expect(spreadCSSAttributes.callCount).toBe(1);
+    expect(drawLeafs.callCount).toBe(0);  // no draw
+  });
+});
+
+describe('spreadCSSAttributes', () => {
+  test('returns container size for 2up spread', () => {
+    const br = new BookReader({ data: SAMPLE_DATA });
+    br.init();
+
+    br.calculateSpreadSize();
+    const twoUpContainerSizes = br._modes.mode2Up.spreadCSSAttributes();
+    expect(Object.keys(twoUpContainerSizes)).toEqual([
+      'mainContainerCss',
+      'spreadCoverCss',
+      'spineCss',
+      'leftLeafCss',
+      'leafEdgeLCss',
+      'rightLeafCss',
+      'leafEdgeRCss'
+    ]);
+  });
+});
+
+describe('prepareTwoPageView', () => {
+  test('always draws new spread if `drawNewSpread` is true ', () => {
+    const br = new BookReader({ data: SAMPLE_DATA });
+    br.init();
+    const drawLeafs = sinon.spy(br._modes.mode2Up, 'drawLeafs');
+    const spreadCSSAttributes = sinon.spy(br._modes.mode2Up, 'spreadCSSAttributes');
+    br.prepareTwoPageView(undefined, undefined, true);
+    expect(drawLeafs.callCount).toBe(1);
+    expect(spreadCSSAttributes.callCount).toBe(2);
+  });
+
+  test('resizes spread if no redraw is necessary', () => {
+    const br = new BookReader({ data: SAMPLE_DATA });
+    br.init();
+    const drawLeafs = sinon.spy(br._modes.mode2Up, 'drawLeafs');
+    const resizeSpread = sinon.spy(br._modes.mode2Up, 'resizeSpread');
+    br.prepareTwoPageView();
+    expect(drawLeafs.callCount).toBe(0);
+    expect(resizeSpread.callCount).toBe(1);
+  });
 });
 
 describe('prefetch', () => {


### PR DESCRIPTION
Goal: During resize: only resize the 2up spread IF the next-calculated reduction factor is the same or "worse" than the images that have already been drawn.

Dev notes:
- parse out in-line style generation to be reused during redraw & resizing
- add check to confirm if one should redraw or resize
- add bypass so that it always redraws when zooming

![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/7840857/109186052-6a9c2980-7745-11eb-9d74-267d767a34e3.gif)


`https://webarchive.jira.com/browse/WEBDEV-4200`