### PR TITLE
More image caching

### DIFF
--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -140,7 +140,7 @@ BookReader.prototype.setup = function(options) {
 
   this.displayedIndices = [];
   this.imgs = {};
-  this.prefetchedImgs = {}; //an object with numeric keys cooresponding to page index
+  this.prefetchedImgs = {}; //an object with numeric keys cooresponding to page index, reduce
 
   this.animating = false;
   this.flipSpeed = options.flipSpeed;
@@ -1682,44 +1682,83 @@ BookReader.prototype._scrollAmount = function() {
   return parseInt(0.9 * this.refs.$brContainer.prop('clientHeight'));
 };
 
-BookReader.prototype.prefetchImg = function(index) {
-  var pageURI = this._getPageURI(index, this.reduce);
+/**
+ * Used by 2up
+ * Fetches the image for requested index & saves in `this.prefetchedImgs`
+ * Does not re-request if image is in the 
+ *
+ * @param {Number} index 
+ */
+BookReader.prototype.prefetchImg = async function(index, fetchNow = false) {
+  let pageURI = this._getPageURI(index, this.reduce);
   const pageURISrcset = this.options.useSrcSet ? this._getPageURISrcset(index, this.reduce) : [];
 
   // Load image if not loaded or URI has changed (e.g. due to scaling)
-  var loadImage = false;
+  let loadImage = false;
+  const wasPrefetchedSmaller = this.prefetchedImgs[index]?.reduce > this.reduce;
   if (undefined == this.prefetchedImgs[index]) {
     loadImage = true;
-  } else if (pageURI != this.prefetchedImgs[index].uri) {
+  } else if (wasPrefetchedSmaller) {
+    console.log("PREFETCH: curr reduce rate > br.reduce - index, this.prefetchedImgs[index]?.reduce, this.br.reduce: ", index, this.prefetchedImgs[index]?.reduce, this.reduce);
+    loadImage = true;
+  } else if (!wasPrefetchedSmaller && (pageURI != this.prefetchedImgs[index]?.uri)) {
     loadImage = true;
   }
 
-  if (loadImage) {
-    const pageContainer = this._createPageContainer(index);
-    $('<img />', {
-      'class': 'BRpageimage',
-      'alt': 'Book page image',
-      src: pageURI,
-      srcset: pageURISrcset,
-    }).data('reduce', this.reduce).appendTo(pageContainer);
-    if (index < 0 || index > (this._models.book.getNumLeafs() - 1) ) {
-      // Facing page at beginning or end, or beyond
-      pageContainer.addClass('BRemptypage');
+  if (!loadImage) {
+    return;
+  }
+
+  if (wasPrefetchedSmaller) {
+    console.log('wasPrefetchedSmaller', index, this.prefetchedImgs['index']);
+    $(this.prefetchedImgs[index]).find('img').attr('src', '');
+  }
+    
+  const $pageContainer = this._createPageContainer(index);
+  const $imgShell = this._modes.mode2Up.createPageImgShell(index, pageURI, this.reduce, $pageContainer);
+
+  /** set uri in img tag to start request & save in `this.prefetchedImgs` */
+  const fetchImageAndRegister = () => {
+    const $imgEl = $($imgShell).find('img');
+    $imgEl.attr('src', pageURI);
+    if (pageURISrcset.length) {
+      $imgEl.attr('srcSet', pageURISrcset);
     }
-    pageContainer[0].uri = pageURI; // browser may rewrite src so we stash raw URI here
-    this.prefetchedImgs[index] = pageContainer[0];
+    $($imgEl).load(() => {
+      console.log('** PREFETCH LOADED: index, this.reduce', index, this.reduce);
+    })
+    this.prefetchedImgs[index] = $imgShell;
+  };
+
+  if (fetchNow || (index == this.twoPage.currentIndexL) || (index == this.twoPage.currentIndexR)) {
+    console.log("*** PREFETCH NOW: - index, this.reduce ", index, this.reduce);
+    fetchImageAndRegister();
+  } else {
+    // stagger request
+    const time = 500;
+    setTimeout(() => {
+      console.log(`*** PREFETCH ${time}: staggered - index, this.reduce`, index, this.reduce);
+      fetchImageAndRegister();
+    }, time);
   }
 };
 
+/** used in 2up */
 BookReader.prototype.pruneUnusedImgs = function() {
+  console.log('___ PRUNE ___', this.br.reduce);
+  const prefetchIsCapped = Object.keys(this.prefetchedImgs).length == 50;
   for (var key in this.prefetchedImgs) {
     if ((key != this.twoPage.currentIndexL) && (key != this.twoPage.currentIndexR)) {
       $(this.prefetchedImgs[key]).remove();
     }
     if ((key < this.twoPage.currentIndexL - 4) || (key > this.twoPage.currentIndexR + 4)) {
-      delete this.prefetchedImgs[key];
+      if (prefetchIsCapped || (this.prefetchedImgs[key]?.reduce > this.reduce)) {
+        console.log("PREFETCH IS CAPPED or reduction rate is small -- key, prefetchIsCapped, this.prefetchedImgs[key]?.reduce", key, prefetchIsCapped, this.prefetchedImgs[key]?.reduce);
+        delete this.prefetchedImgs[key];
+      }
     }
   }
+  console.log('___ END PRUNE ___', this.br.reduce);
 };
 
 /************************/

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -1728,11 +1728,11 @@ BookReader.prototype.prefetchImg = async function(index, fetchNow = false) {
     if (pageURISrcset.length) {
       $imgEl.attr('srcSet', pageURISrcset);
     }
-    $($imgEl).load(() => {
-      console.log('** PREFETCH DONE: index, this.reduce', index, this.reduce);
-    }).error(() => {
-      console.log('** PREFETCH ERROR: index, this.reduce', index, this.reduce);
-    })
+    // $($imgEl).load(() => {
+    //   console.log('** PREFETCH DONE: index, this.reduce', index, this.reduce);
+    // }).error(() => {
+    //   console.log('** PREFETCH ERROR: index, this.reduce', index, this.reduce);
+    // })
     this.prefetchedImgs[index] = $imgShell;
   };
 

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -1700,8 +1700,8 @@ BookReader.prototype.prefetchImg = function(index) {
       'class': 'BRpageimage',
       'alt': 'Book page image',
       src: pageURI,
-      srcset: pageURISrcset
-    }).appendTo(pageContainer);
+      srcset: pageURISrcset,
+    }).data('reduce', this.reduce).appendTo(pageContainer);
     if (index < 0 || index > (this._models.book.getNumLeafs() - 1) ) {
       // Facing page at beginning or end, or beyond
       pageContainer.addClass('BRemptypage');

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -889,12 +889,14 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
 
         const img = document.createElement("img");
         const thumbReduce = floor(book.getPageWidth(leaf) / this.thumbWidth);
-
+        // use prefetched img src first if previously requested & available img is good enough
+        const prefetchedImg = this.prefetchedImgs[leaf] || {};
+        const imageURI = prefetchedImg.reduce <= thumbReduce ? prefetchedImg.uri || this._getPageURI(leaf, thumbReduce);
         $(img).attr('src', `${this.imagesBaseURL}transparent.png`)
           .css({ width: `${leafWidth}px`, height: `${leafHeight}px` })
           .addClass('BRlazyload')
           // Store the URL of the image that will replace this one
-          .data('srcURL',  this._getPageURI(leaf, thumbReduce))
+          .data('srcURL',  imageURI)
           .attr('alt', 'Loading book image');
         pageContainer.append(img);
       }
@@ -1713,7 +1715,7 @@ BookReader.prototype.prefetchImg = async function(index, fetchNow = false) {
     console.log('wasPrefetchedSmaller', index, this.prefetchedImgs['index']);
     $(this.prefetchedImgs[index]).find('img').attr('src', '');
   }
-    
+
   const $pageContainer = this._createPageContainer(index);
   const $imgShell = this._modes.mode2Up.createPageImgShell(index, pageURI, this.reduce, $pageContainer);
 

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -1690,6 +1690,9 @@ BookReader.prototype._scrollAmount = function() {
  * Does not re-request if image is in the
  *
  * @param {Number} index
+ * @param {Boolean} fetchNow
+ *   - flag to allow for non-viewable page to be immediately requested
+ *     - this allows for "2up to prepare a page flip"
  */
 BookReader.prototype.prefetchImg = async function(index, fetchNow = false) {
   const pageURI = this._getPageURI(index, this.reduce);

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -167,6 +167,9 @@ export class Mode2Up {
       return;
     }
 
+    const startingReduce = this.br.reduce;
+    const startingIndices = this.br.displayedIndices;
+
     this.br.refs.$brContainer.empty();
     this.br.refs.$brContainer.css('overflow', 'auto');
 
@@ -179,10 +182,18 @@ export class Mode2Up {
     this.br.twoPage.currentIndexL = currentSpreadIndices[0];
     this.br.twoPage.currentIndexR = currentSpreadIndices[1];
 
-    this.calculateSpreadSize(); //sets twoPage.width, twoPage.height and others
+    this.calculateSpreadSize(); //sets this.br.reduce, twoPage.width, twoPage.height and others
 
-    this.br.pruneUnusedImgs();
-    this.br.prefetch(); // Preload images or reload if scaling has changed
+    /* check if calculations have changed that warrant a new book draw */
+    const sameReducer = startingReduce == this.br.reduce;
+    const sameStart = startingIndices == this.br.displayedIndices;
+    const hasNewDisplayPagesOrDimensions = !sameStart || (sameStart && !sameReducer);
+
+    if (drawNewSpread || hasNewDisplayPagesOrDimensions) {
+      console.log("2UP PREPARE before 1st Prune & Prefetch (!sameStart || (sameStart && !sameReducer)) ", (!sameStart || (sameStart && !sameReducer)));
+      this.br.pruneUnusedImgs();
+      this.br.prefetch(); // Preload images or reload if scaling has changed
+    }
 
     // Add the two page view
     // $$$ Can we get everything set up and then append?
@@ -229,8 +240,6 @@ export class Mode2Up {
 
     this.drawLeafs();
     this.br.updateToolbarZoom(this.br.reduce);
-
-    this.br.prefetch();
 
     if (this.br.enableSearch) {
       this.br.removeSearchHilites();
@@ -876,8 +885,8 @@ export class Mode2Up {
    * @param {number} prevR
    */
   prepareFlipLeftToRight(prevL, prevR) {
-    this.br.prefetchImg(prevL);
-    this.br.prefetchImg(prevR);
+    this.br.prefetchImg(prevL, true);
+    this.br.prefetchImg(prevR, true);
 
     const height  = this.book._getPageHeight(prevL);
     const width   = this.book._getPageWidth(prevL);
@@ -924,8 +933,8 @@ export class Mode2Up {
    */
   prepareFlipRightToLeft(nextL, nextR) {
     // Prefetch images
-    this.br.prefetchImg(nextL);
-    this.br.prefetchImg(nextR);
+    this.br.prefetchImg(nextL, true);
+    this.br.prefetchImg(nextR, true);
 
     let height = this.book._getPageHeight(nextR);
     let width = this.book._getPageWidth(nextR);
@@ -1206,11 +1215,6 @@ export class Mode2Up {
     const { book } = this;
     const { currentIndexL, currentIndexR } = this.br.twoPage;
     const ADJACENT_PAGES_TO_LOAD = 2;
-
-    // prefetch images in view first
-
-    // stagger the later ones.
-
     // currentIndexL can be -1; getPage returns the last page of the book
     // when given -1, so need to prevent that.
     let lowPage = book.getPage(max(0, min(currentIndexL, currentIndexR)));
@@ -1229,12 +1233,14 @@ export class Mode2Up {
   }
 
   /**
-   * 
-   * @param {*} index 
-   * @param {*} pageURI 
-   * @param {*} reduce 
-   * @param {*} $pageContainer 
-   * 
+   * Given a jQuery element as a container,
+   * it will create the nested image element & return updated container
+   *
+   * @param {Number} index
+   * @param {String} pageURI
+   * @param {Number} reduce
+   * @param {Object} $pageContainer - jQuery element
+   *
    * @return $pageContainer
    */
   createPageImgShell(index, pageURI, reduce, $pageContainer) {

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -110,10 +110,10 @@ export class Mode2Up {
     const currentImagesAreLarger = this.br.reduce <= idealReductionFactor;
     const leftDisplayed = prefetchedImgs[displayedIndices[0]] || {};
     const rightDisplayed = prefetchedImgs[displayedIndices[1]] || {};
-    const LeftImgIsPrefetchedToScale = leftDisplayed && (leftDisplayed.reduce <= idealReductionFactor);
-    const RightImgIsPrefetchedToScale = rightDisplayed && (rightDisplayed.reduce <= idealReductionFactor);
+    const leftImgIsPrefetchedToScale = leftDisplayed && (leftDisplayed.reduce <= idealReductionFactor);
+    const rightImgIsPrefetchedToScale = rightDisplayed && (rightDisplayed.reduce <= idealReductionFactor);
 
-    return !currentImagesAreLarger || !(LeftImgIsPrefetchedToScale && RightImgIsPrefetchedToScale);
+    return !currentImagesAreLarger || !(leftImgIsPrefetchedToScale && rightImgIsPrefetchedToScale);
   }
 
   /**

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -110,8 +110,8 @@ export class Mode2Up {
     const currentImagesAreLarger = this.br.reduce <= idealReductionFactor;
     const leftDisplayed = prefetchedImgs[displayedIndices[0]] || {};
     const rightDisplayed = prefetchedImgs[displayedIndices[1]] || {};
-    const LeftImgIsPrefetchedToScale = leftDisplayed && (leftDisplayed.reduce <= this.br.reduce);
-    const RightImgIsPrefetchedToScale = rightDisplayed && (rightDisplayed.reduce <= this.br.reduce);
+    const LeftImgIsPrefetchedToScale = leftDisplayed && (leftDisplayed.reduce <= idealReductionFactor);
+    const RightImgIsPrefetchedToScale = rightDisplayed && (rightDisplayed.reduce <= idealReductionFactor);
 
     return !currentImagesAreLarger || !(LeftImgIsPrefetchedToScale && RightImgIsPrefetchedToScale);
   }

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -99,11 +99,12 @@ export class Mode2Up {
   /**
    * Checks to see if the images/pages in view
    * are of equal or better quality
+   * If not, we return yes
    *
    * @returns {Boolean}
    */
   get shouldRedrawSpread() {
-    const { prefetchedImgs, twoPage, displayedIndices } = this.br;
+    const { prefetchedImgs, displayedIndices } = this.br;
     const { reduce: idealReductionFactor } = this.getIdealSpreadSize( this.br.twoPage.currentIndexL, this.br.twoPage.currentIndexR );
 
     const currentImagesAreLarger = this.br.reduce <= idealReductionFactor;
@@ -111,12 +112,6 @@ export class Mode2Up {
     const rightDisplayed = prefetchedImgs[displayedIndices[1]] || {};
     const LeftImgIsPrefetchedToScale = leftDisplayed && (leftDisplayed.reduce <= this.br.reduce);
     const RightImgIsPrefetchedToScale = rightDisplayed && (rightDisplayed.reduce <= this.br.reduce);
-    console.log('should redraw?');
-    console.log('~~~~~ LeftImgIsPrefetchedToScale', LeftImgIsPrefetchedToScale, leftDisplayed.reduce);
-    console.log('~~~~~ LeftImgIsPrefetchedToScale', RightImgIsPrefetchedToScale, rightDisplayed.reduce);
-    console.log("BR REDUCE - ", this.br.reduce);
-    console.log('end should redraw?', !currentImagesAreLarger || !(LeftImgIsPrefetchedToScale && RightImgIsPrefetchedToScale));
-    // const pagesInViewArePrefetched = prefetchedImgs[twoPage.currentIndexL] && prefetchedImgs[twoPage.currentIndexR];
 
     return !currentImagesAreLarger || !(LeftImgIsPrefetchedToScale && RightImgIsPrefetchedToScale);
   }

--- a/tests/BookReader/Mode2Up.test.js
+++ b/tests/BookReader/Mode2Up.test.js
@@ -120,7 +120,8 @@ describe('shouldRedrawSpread', () => {
     br.init();
     const reduceStub = 10;
     br.reduce = reduceStub;
-    br._modes.mode2Up.getIdealSpreadSize = () => { return { reduce: 11 }};
+    br._modes.mode2Up.getIdealSpreadSize = () => { return { reduce: 111111 }};
+
     const shouldRedrawSpread = br._modes.mode2Up.shouldRedrawSpread;
     expect(shouldRedrawSpread).toBe(false);
   });
@@ -259,7 +260,7 @@ describe('prepareTwoPageView', () => {
       const updateBrClasses = sinon.spy(br, 'updateBrClasses');
 
       br.prepareTwoPageView(undefined, undefined, true);
-      expect(prefetch.callCount).toBe(2);
+      expect(prefetch.callCount).toBe(1);
 
       expect(resizeSpread.callCount).toBe(0);
       expect(drawLeafs.callCount).toBe(1);

--- a/tests/BookReader/Mode2Up.test.js
+++ b/tests/BookReader/Mode2Up.test.js
@@ -292,9 +292,7 @@ describe('prepareTwoPageView', () => {
         expect(resizeSpread.callCount).toBe(1);
       });
     });
-
-
-    test('will only prune images if `this.displayedIndices` has changed', () => {
+    test('will prune & prefetch images if `this.displayedIndices` has changed', () => {
       let pruneCount = 0;
       let prefetchCount = 0;
       const expectedPruneCount = 1;
@@ -313,6 +311,31 @@ describe('prepareTwoPageView', () => {
       const resizeSpread = sinon.spy(br._modes.mode2Up, 'resizeSpread');
 
       br.displayedIndices = [111, 112];
+      br.prepareTwoPageView();
+
+      expect(resizeSpread.callCount).toBe(0);
+      expect(pruneCount).toBe(expectedPruneCount);
+      expect(prefetchCount).toBe(expectedPrefetchCount);
+    });
+
+    test('will prune & prefetch images idealReducer has changed to a better size', () => {
+      let pruneCount = 0;
+      let prefetchCount = 0;
+      const expectedPruneCount = 1;
+      const expectedPrefetchCount = 1;
+      const br = new BookReader({ data: SAMPLE_DATA });
+      // manual stubs bc sinon can't find its scope...
+      BookReader.prototype.pruneUnusedImgs = () => {
+        pruneCount = pruneCount + 1;
+      };
+      BookReader.prototype.prefetch = () => {
+        prefetchCount = prefetchCount + 1;
+      };
+      br.init();
+      const resizeSpread = sinon.spy(br._modes.mode2Up, 'resizeSpread');
+      const stubIdealReduce = 3;
+      br.twoPage = {};
+      br._modes.mode2Up.getIdealSpreadSize = () => ({ reduce: stubIdealReduce });
       br.prepareTwoPageView();
 
       expect(resizeSpread.callCount).toBe(0);


### PR DESCRIPTION
### Dev notes:
 we are doing our best to cancel any pending requests
 we are saving up to 50 images that 2up & thumbnail can use
 we reuse images often, and resize as much as possible.
 
### Testing:
load a book with network tab on..
flip through pages,
toggle side menu,
toggle fullscreen,
— if current image scale is better or equal, we keep the image
thumbnail view: go to thumbnail from 2up, remember your page -> inspect that page in thumbnail view, it should be the same URL + check in network tab for that URL - no secondary image request gets made

https://webarchive.jira.com/browse/WEBDEV-4255