### PR TITLE
ImageCache & 2up's integration

### DIFF
--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -1702,28 +1702,31 @@ BookReader.prototype._scrollAmount = function() {
  */
 BookReader.prototype.prefetchImg = async function(index, fetchNow = false) {
 
+  /** main function that creates page container */
   const fetchImageAndRegister = () => {
     const $image = this.imageCache.image(index, this.reduce);
     const $pageContainer = this._createPageContainer(index, this._modes.mode2Up.baseLeafCss);
-    console.log('____ prefetchImg _____$image to append', $image);
     $($image).appendTo($pageContainer);
+
+    const isEmptyPage = index < 0 || index > (this.book.getNumLeafs() - 1);
+    if (isEmptyPage) {
+      // Facing page at beginning or end, or beyond
+      $pageContainer.addClass('BRemptypage');
+    }
 
     /** store uri & reducer */
     $pageContainer[0].uri = $image.uri;
     $pageContainer[0].reduce = $image.reduce;
-    console.log('____ prefetchImg _____$pageContainer', $pageContainer);
     this.prefetchedImgs[index] = $pageContainer;
   };
 
   const indexIsInView = (index == this.twoPage.currentIndexL) || (index == this.twoPage.currentIndexR);
   if (fetchNow || indexIsInView) {
-    console.log("____ prefetchImg _____request now", index);
     fetchImageAndRegister();
   } else {
     // stagger request
     const time = 300;
     setTimeout(() => {
-      console.log("____ prefetchImg _____staggering request", index);
       // just fetch image, do not wrap with page container
       this.imageCache.image(index, this.reduce);
     }, time);

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -1708,7 +1708,7 @@ BookReader.prototype.prefetchImg = async function(index, fetchNow = false) {
     const $pageContainer = this._createPageContainer(index, this._modes.mode2Up.baseLeafCss);
     $($image).appendTo($pageContainer);
 
-    const isEmptyPage = index < 0 || index > (this.book.getNumLeafs() - 1);
+    const isEmptyPage = index < 0 || index > (this._models.book.getNumLeafs() - 1);
     if (isEmptyPage) {
       // Facing page at beginning or end, or beyond
       $pageContainer.addClass('BRemptypage');

--- a/src/js/BookReader/ImageCache.js
+++ b/src/js/BookReader/ImageCache.js
@@ -10,7 +10,7 @@ export class ImageCache {
     this.defaultScale = 8;
     this.maxCache = this.br.maxImageCache || 100;
 
-    this.createImage = this.createImage.bind(this);
+    this.createImage = this._createImage.bind(this);
     this.image = this.image.bind(this);
   }
 
@@ -26,8 +26,9 @@ export class ImageCache {
   image(index, reduce) {
     const $thisImage = this.cache[index];
     const currImageScale = $thisImage?.reduce;
-
+    console.log("IMAGE CACHE ----- `image` - index, currImageScale, reduce", index, currImageScale, reduce);
     if (currImageScale <= reduce) {
+      console.log("Image -- curr good enough reduce, index", reduce, index);
       return $thisImage;
     }
 
@@ -58,14 +59,17 @@ export class ImageCache {
    * @param {Number} reduce
    * @returns $image
    */
-  _createImage (index, reduce) {
+  _createImage(index, reduce) {
     const hasCache = this.cache[index];
     if (hasCache) {
+      console.log("Image --- bust cache - index, ", index);
       this._bustImageCache(index);
     }
 
+    // Q: where/when do we delete an image?
+
     const src = this.br._getPageURI(index, reduce);
-    const srcSet = this.options.useSrcSet ? this.br._getPageURISrcset(index, reduce) : [];
+    const srcSet = this.br.options.useSrcSet ? this.br._getPageURISrcset(index, reduce) : [];
     const $img = $('<img />', {
       'class': 'BRpageimage',
       'alt': 'Book page image',
@@ -74,6 +78,8 @@ export class ImageCache {
     }).data('reduce', reduce);
 
     this.cache[index] = { ...$img, reduce, uri: src };
+    console.log("Image --- create, reduce", reduce, this.cache[index]);
+
     return this.cache[index];
   }
 }

--- a/src/js/BookReader/ImageCache.js
+++ b/src/js/BookReader/ImageCache.js
@@ -8,7 +8,6 @@ export class ImageCache {
     this.br = br;
     this.cache = {};
     this.defaultScale = 8;
-    this.maxCache = this.br.maxImageCache || 100;
 
     this.createImage = this._createImage.bind(this);
     this.image = this.image.bind(this);

--- a/src/js/BookReader/ImageCache.js
+++ b/src/js/BookReader/ImageCache.js
@@ -26,9 +26,7 @@ export class ImageCache {
   image(index, reduce) {
     const $thisImage = this.cache[index];
     const currImageScale = $thisImage?.reduce;
-    console.log("IMAGE CACHE ----- `image` - index, currImageScale, reduce", index, currImageScale, reduce);
     if (currImageScale <= reduce) {
-      console.log("Image -- curr good enough reduce, index", reduce, index);
       return $thisImage;
     }
 
@@ -54,7 +52,8 @@ export class ImageCache {
   /**
    * @private
    * Creates an image & stashes in cache
-   *  Will bust cache iff
+   * - Use only to create an image as it will
+   *    bust cache if requested index has one stashed
    *
    * @param {String|Number} index - page index
    * @param {Number} reduce
@@ -63,11 +62,8 @@ export class ImageCache {
   _createImage(index, reduce) {
     const hasCache = this.cache[index];
     if (hasCache) {
-      console.log("Image --- bust cache - index, ", index);
       this._bustImageCache(index);
     }
-
-    // Q: where/when do we delete an image?
 
     const src = this.br._getPageURI(index, reduce);
     const srcSet = this.br.options.useSrcSet ? this.br._getPageURISrcset(index, reduce) : [];
@@ -76,10 +72,11 @@ export class ImageCache {
       'alt': 'Book page image',
       src,
       srcSet
-    }).data('reduce', reduce);
+    }).data('reduce', reduce).load(() => {
+      this.cache[index].loaded = true;
+    });
 
     this.cache[index] = { ...$img, reduce, uri: src };
-    console.log("Image --- create, reduce", reduce, this.cache[index]);
 
     return this.cache[index];
   }

--- a/src/js/BookReader/ImageCache.js
+++ b/src/js/BookReader/ImageCache.js
@@ -46,7 +46,8 @@ export class ImageCache {
   _bustImageCache(index) {
     const $thisImage = this.cache[index];
     // allows browser to abort a pending request
-    $($thisImage).find('img').attr('src', '').attr('srcSet', []);
+
+    $($thisImage).attr('src', '').attr('srcSet', []);
     delete this.cache[index];
   }
 

--- a/src/js/BookReader/ImageCache.js
+++ b/src/js/BookReader/ImageCache.js
@@ -1,0 +1,79 @@
+/**
+ * Creates an image cache dictionary
+ * storing images in `<img>` tags so that
+ * BookReader can leverage browser caching
+ */
+export class ImageCache {
+  constructor(br) {
+    this.br = br;
+    this.cache = {};
+    this.defaultScale = 8;
+    this.maxCache = this.br.maxImageCache || 100;
+
+    this.createImage = this.createImage.bind(this);
+    this.image = this.image.bind(this);
+  }
+
+  /**
+   * Get an image
+   * Checks cache first if image is available & of equal/better scale,
+   * if not, a new image gets created
+   *
+   * @param {String|Number} index - page index
+   * @param {Number} reduce
+   * @returns $image
+   */
+  image(index, reduce) {
+    const $thisImage = this.cache[index];
+    const currImageScale = $thisImage?.reduce;
+
+    if (currImageScale <= reduce) {
+      return $thisImage;
+    }
+
+    return this._createImage(index, reduce);
+  }
+
+
+  /**
+   * @private
+   * Removes image from cache
+   * Empties `src` & `srcSet` attributes prior to cancel pending requests
+   *
+   * @param {String|Number} index - page index
+   */
+  _bustImageCache(index) {
+    const $thisImage = this.cache[index];
+    // allows browser to abort a pending request
+    $($thisImage).find('img').attr('src', '').attr('srcSet', []);
+    delete this.cache[index];
+  }
+
+  /**
+   * @private
+   * Creates an image & stashes in cache
+   *  Will bust cache iff
+   *
+   * @param {String|Number} index - page index
+   * @param {Number} reduce
+   * @returns $image
+   */
+  _createImage (index, reduce) {
+    const hasCache = this.cache[index];
+    if (hasCache) {
+      this._bustImageCache(index);
+    }
+
+    const src = this.br._getPageURI(index, reduce);
+    const srcSet = this.options.useSrcSet ? this.br._getPageURISrcset(index, reduce) : [];
+    const $img = $('<img />', {
+      'class': 'BRpageimage',
+      'alt': 'Book page image',
+      src,
+      srcSet
+    }).data('reduce', reduce);
+
+    this.cache[index] = { ...$img, reduce, uri: src };
+    return this.cache[index];
+  }
+}

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -124,7 +124,7 @@ export class Mode2Up {
     this.calculateSpreadSize();
 
     this.br.refs?.$brTwoPageView.css(this.mainContainerCss);
-    this.centerView(undefined, undefined); // let function self adjust
+    this.centerView(); // let function self adjust
 
     $(this.br.twoPage.coverDiv).css(this.spreadCoverCss); // click sheath is memoized somehow
     const $spreadLayers = this.br.refs.$brTwoPageView;
@@ -688,7 +688,7 @@ export class Mode2Up {
 
         this.br.refs.$brContainer.removeClass("BRpageFlipping");
         this.br.textSelectionPlugin?.stopPageFlip(this.br.refs.$brContainer);
-        this.centerView(undefined, undefined);
+        this.centerView();
         this.br.trigger('pageChanged');
 
         // get next previous batch immediately      this.br.pruneUnusedImgs();
@@ -839,7 +839,7 @@ export class Mode2Up {
 
         this.br.refs.$brContainer.removeClass("BRpageFlipping");
         this.br.textSelectionPlugin?.stopPageFlip(this.br.refs.$brContainer);
-        this.centerView(undefined, undefined);
+        this.centerView();
         this.br.trigger('pageChanged');
 
         this.br.pruneUnusedImgs();
@@ -1037,9 +1037,9 @@ export class Mode2Up {
 
   /**
    * Centers the point given by percentage from left,top of twopageview
-   * @param {number} percentageX
-   * @param {number} percentageY
-   */
+   * @param {number} [percentageX=0.5]
+   * @param {number} [percentageY=0.5]
+ */
   centerView(percentageX, percentageY) {
 
     if ('undefined' == typeof(percentageX)) {

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -149,7 +149,7 @@ export class Mode2Up {
    * @param {number} centerPercentageY
    * @param {Boolean} drawNewSpread
    */
-  prepareTwoPageView(centerPercentageX = 0.5, centerPercentageY = 0.5, drawNewSpread = false) {
+  prepareTwoPageView(centerPercentageX, centerPercentageY, drawNewSpread = false) {
     // Some decisions about two page view:
     //
     // Both pages will be displayed at the same height, even if they were different physical/scanned
@@ -690,8 +690,8 @@ export class Mode2Up {
         }
 
         this.br.refs.$brContainer.removeClass("BRpageFlipping");
-
         this.br.textSelectionPlugin?.stopPageFlip(this.br.refs.$brContainer);
+        this.centerView(undefined, undefined);
         this.br.trigger('pageChanged');
 
         // get next previous batch immediately      this.br.pruneUnusedImgs();
@@ -843,8 +843,8 @@ export class Mode2Up {
         }
 
         this.br.refs.$brContainer.removeClass("BRpageFlipping");
-
         this.br.textSelectionPlugin?.stopPageFlip(this.br.refs.$brContainer);
+        this.centerView(undefined, undefined);
         this.br.trigger('pageChanged');
 
         this.br.pruneUnusedImgs();
@@ -855,7 +855,7 @@ export class Mode2Up {
         if (!this.br.prefetchedImgs[newIndexR + 2]) {
           this.br.prefetchImg(newIndexR + 2);
         }
-        this.br.prun
+
         setTimeout(() => {
           // flip prefetch
           console.log("*********** PREFETCHING 2", newIndexL + 3, newIndexR + 3)
@@ -1231,7 +1231,7 @@ export class Mode2Up {
    * Fetches the currently displayed images (if not already fetching)
    * as wells as any nearby pages.
    */
-  prefetch(skipPagesInView = false) {
+  prefetch() {
     // $$$ We should check here if the current indices have finished
     //     loading (with some timeout) before loading more page images
     //     See https://bugs.edge.launchpad.net/bookreader/+bug/511391

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -47,6 +47,7 @@ export class Mode2Up {
     // $$$ we should use calculated values in this.twoPage (recalc if necessary)
     const indexL = this.br.twoPage.currentIndexL;
     const indexR = this.br.twoPage.currentIndexR;
+    this.br.pruneUnusedImgs();
 
     this.br.prefetchImg(indexL);
     $(this.br.prefetchedImgs[indexL]).css(this.leftLeafCss).appendTo($twoPageViewEl);

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -112,8 +112,6 @@ export class Mode2Up {
     const leftImgIsPrefetchedToScale = leftDisplayed && (leftDisplayed.reduce <= idealReductionFactor);
     const rightImgIsPrefetchedToScale = rightDisplayed && (rightDisplayed.reduce <= idealReductionFactor);
 
-    console.log("____ shouldRedrawSpread ____, this.br.reduce, shouldRedraw", this.br.reduce, !(leftImgIsPrefetchedToScale && rightImgIsPrefetchedToScale));
-
     return !(leftImgIsPrefetchedToScale && rightImgIsPrefetchedToScale);
   }
 
@@ -182,7 +180,6 @@ export class Mode2Up {
     const sameStart = startingIndices == this.br.displayedIndices;
     const hasNewDisplayPagesOrDimensions = !sameStart || (sameStart && !sameReducer);
 
-    console.log("2up - hasNewDisplayPagesOrDimensions", hasNewDisplayPagesOrDimensions);
     if (drawNewSpread || hasNewDisplayPagesOrDimensions) {
       this.br.pruneUnusedImgs();
       this.br.prefetch(); // Preload images or reload if scaling has changed
@@ -695,7 +692,6 @@ export class Mode2Up {
         this.br.trigger('pageChanged');
 
         // get next previous batch immediately      this.br.pruneUnusedImgs();
-        console.log("*********** PREFETCHING 1", newIndexL - 2, newIndexR - 2)
         if (!this.br.prefetchedImgs[newIndexL - 2]) {
           this.br.prefetchImg(newIndexL - 2);
         }
@@ -706,7 +702,6 @@ export class Mode2Up {
 
         setTimeout(() => {
           // flip prefetch
-          console.log("*********** PREFETCHING 2", newIndexL - 3, newIndexR - 3)
           this.br.prefetchImg(newIndexL - 3);
           this.br.prefetchImg(newIndexR - 3);
         }, 250);
@@ -848,7 +843,6 @@ export class Mode2Up {
         this.br.trigger('pageChanged');
 
         this.br.pruneUnusedImgs();
-        console.log("*********** PREFETCHING 1", newIndexL + 2, newIndexR + 2)
         if (!this.br.prefetchedImgs[newIndexL + 2]) {
           this.br.prefetchImg(newIndexL + 2);
         }
@@ -858,7 +852,6 @@ export class Mode2Up {
 
         setTimeout(() => {
           // flip prefetch
-          console.log("*********** PREFETCHING 2", newIndexL + 3, newIndexR + 3)
           this.br.prefetchImg(newIndexL + 3);
           this.br.prefetchImg(newIndexR + 3);
         }, 250);

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -1246,7 +1246,6 @@ export class Mode2Up {
     let highPage = book.getPage(max(currentIndexL, currentIndexR));
 
     for (let i = 0; i < ADJACENT_PAGES_TO_LOAD + 2; i++) {
-      console.log("PREFETCH i, lowPage, highPage", i, lowPage, highPage);
       if (lowPage) {
         this.br.prefetchImg(lowPage.index);
         lowPage = lowPage.findPrev({ combineConsecutiveUnviewables: true });

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -1048,6 +1048,7 @@ export class Mode2Up {
    * @param {number} percentageY
    */
   centerView(percentageX, percentageY) {
+
     if ('undefined' == typeof(percentageX)) {
       percentageX = 0.5;
     }
@@ -1256,37 +1257,6 @@ export class Mode2Up {
         highPage = highPage.findNext({ combineConsecutiveUnviewables: true });
       }
     }
-  }
-
-  /**
-   * Given a jQuery element as a container,
-   * it will create the nested image element & return updated container
-   *
-   * @param {Number} index
-   * @param {String} pageURI
-   * @param {Number} reduce
-   * @param {Object} $pageContainer - jQuery element
-   *
-   * @return $pageContainer
-   */
-  createPageImgShell(index, pageURI, reduce, $pageContainer) {
-
-    $pageContainer[0].uri = pageURI; // browser may rewrite src so we stash raw URI here
-    $pageContainer[0].reduce = reduce; // browser may rewrite src so we stash raw URI here
-
-    const $imgEl = $('<img />', {
-      'class': 'BRpageimage',
-      'alt': 'Book page image',
-    }).data('reduce', reduce);
-
-    $($imgEl).appendTo($pageContainer);
-
-    if (index < 0 || index > (this.book.getNumLeafs() - 1) ) {
-      // Facing page at beginning or end, or beyond
-      $pageContainer.addClass('BRemptypage');
-    }
-
-    return $pageContainer[0];
   }
 
   /* 2up Container Sizes */

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -190,7 +190,6 @@ export class Mode2Up {
     const hasNewDisplayPagesOrDimensions = !sameStart || (sameStart && !sameReducer);
 
     if (drawNewSpread || hasNewDisplayPagesOrDimensions) {
-      console.log("2UP PREPARE before 1st Prune & Prefetch (!sameStart || (sameStart && !sameReducer)) ", (!sameStart || (sameStart && !sameReducer)));
       this.br.pruneUnusedImgs();
       this.br.prefetch(); // Preload images or reload if scaling has changed
     }

--- a/tests/BookReader/ImageCache.test.js
+++ b/tests/BookReader/ImageCache.test.js
@@ -1,0 +1,97 @@
+import '../../src/js/jquery-ui-wrapper.js';
+import 'jquery.browser';
+import '../../src/js/dragscrollable-br.js';
+import 'jquery-colorbox';
+
+import sinon from 'sinon';
+import BookReader from '../../src/js/BookReader.js';
+/** @typedef {import('../../src/js/BookReader/options.js').BookReaderOptions} BookReaderOptions */
+
+beforeAll(() => {
+  global.alert = jest.fn();
+})
+afterEach(() => {
+  jest.restoreAllMocks();
+  sinon.restore();
+});
+
+/** @type {BookReaderOptions['data']} */
+const SAMPLE_DATA = [
+  [
+    { width: 123, height: 123, uri: 'https://archive.org/image0.jpg', pageNum: '1' },
+  ],
+  [
+    { width: 123, height: 123, uri: 'https://archive.org/image1.jpg', pageNum: '2' },
+    { width: 123, height: 123, uri: 'https://archive.org/image2.jpg', pageNum: '3' },
+  ],
+  [
+    { width: 123, height: 123, uri: 'https://archive.org/image3.jpg', pageNum: '4' },
+    { width: 123, height: 123, uri: 'https://archive.org/image4.jpg', pageNum: '5' },
+  ],
+  [
+    { width: 123, height: 123, uri: 'https://archive.org/image5.jpg', pageNum: '6' },
+  ],
+];
+
+
+describe('Image Cache', () => {
+  test('has image cache in bookreader instance', () => {
+    const br = new BookReader({ data: SAMPLE_DATA });
+    br.init();
+    expect(br.imageCache).toBeTruthy();
+  });
+
+  describe('`image` call', () => {
+    test('calling `image` will create an image if none is cached', () => {
+      const br = new BookReader({ data: SAMPLE_DATA });
+      br.init();
+      const createImageStub = sinon.spy(br.imageCache, '_createImage');
+      br.imageCache.image(1, 5);
+      expect(createImageStub.callCount).toBe(1);
+    });
+    test('will pull from cache if image of a good quality has been stored', () => {
+      const br = new BookReader({ data: SAMPLE_DATA });
+      br.init();
+      const createImageStub = sinon.spy(br.imageCache, '_createImage');
+      br.imageCache.cache = { 1: { reduce: 3 }};
+      br.imageCache.image(1, 5);
+      expect(createImageStub.callCount).toBe(0);
+    });
+  });
+
+  describe('`_createImage` call', () => {
+    test('adds to cache', () => {
+      const br = new BookReader({ data: SAMPLE_DATA });
+      br.init();
+      // starting spread
+      expect(Object.keys(br.imageCache.cache).length).toBe(2);
+      // add image
+      br.imageCache.image(1, 5);
+      expect(Object.keys(br.imageCache.cache).length).toBe(3);
+      expect(br.imageCache.cache[1]).toBeTruthy();
+    });
+  });
+
+  describe('`_bustImageCache` call', () => {
+    test('gets called during `_createImage` if requested image has  better scale factor', () => {
+      const br = new BookReader({ data: SAMPLE_DATA });
+      br.init();
+      br.imageCache.image(1, 5); // add new image
+      expect(br.imageCache.cache[1].reduce).toEqual(5);
+      const bustCacheStub = sinon.spy(br.imageCache, '_bustImageCache');
+
+      br.imageCache.image(1, 3); // add same image w/ better reducer
+      expect(br.imageCache.cache[1].reduce).toEqual(3);
+      expect(bustCacheStub.callCount).toBe(1);
+    })
+    test('deletes item from cache', () => {
+      const br = new BookReader({ data: SAMPLE_DATA });
+      br.init();
+      br.imageCache.image(1, 5); // add new image
+      expect(br.imageCache.cache[1]).toBeTruthy();
+
+      br.imageCache._bustImageCache(1); // add same image w/ better reducer
+      expect(br.imageCache.cache[1]).toBe(undefined);
+    })
+  });
+});


### PR DESCRIPTION
### New: ImageCache 🎉 
+ use in 2up - book draw & page flip

ImageCache sits at the bottom of an image request and manages the appropriate conditions on whether or not to fetch image:
- if image has not been fetched before => fetch, store, return
- if image requested has been fetched but the requested scale is better => bust cache, fetch, store, return
- if image requested & stored image has has an equal or "better" scale factor => return stored image

use in 2up mode:
- actual prefetch of an image is now thoroughly decoupled with the DOM draw
- `prepareTwoPageView` can now always provide the freshest page containers around an image
- flipping right & left no longer trumps the previous `br.prefetchedImgs` store when making call to prefetch next images

### Testing - in 2up mode in INCOGNITO or not signed into archive.org email:
- book of irregular page size - you can scroll horizontally to see full spread with pages of irregular shape `https://www-isa.archive.org/details/TheVoynichManuscript/page/n203`
- public book, user uploaded - `https://www-isa.archive.org/details/dli.ministry.00088/`
-  books with covers - "placeholder pages" are darkened `https://www-isa.archive.org/details/lakesuperior1850agas`
- zoom in -> new images get called -> zoom out -> same image is used, no redraw
- shrink & grow browser width -> will not call for another image IF cached image is good enough
- open & close side menu -> will not call for another image IF cached image is good enough
- you can see the image cache in global `br` instance -> `br.imageCache.cache` to see that the images each get saved at the best requested scale
  - you can see each reduction factor per image can differ from each other
- flip fast back and forth using on-page click -> no "black/empty" pages will be seen (page with spinner is expected before img load)
- use scrubber to jump around the book -> no "black/empty" pages will be seen (page with spinner is expected before img load)