### PR TITLE
Thumbnail draw with prefetched images ++

### DIFF
--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -981,9 +981,7 @@ BookReader.prototype.lazyLoadImage = function ($imgPlaceholder) {
   const $img = this.imageCache.image(leaf, reduce);
 
   // replace with the new img
-  const $parentContainer = $($imgPlaceholder).parent();
-  $parentContainer.append($img);
-  $($imgPlaceholder).remove();
+  $(imgPlaceholder).replaceWith($img);
 };
 
 /**

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -856,7 +856,7 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
   for (let i = 1; i < this.thumbRowBuffer + 1; i++) {
     if (lastRow + i < leafMap.length) { rowsToDisplay.push(lastRow + i); }
   }
-  for (let i = 1; i < this.thumbRowBuffer + 1; i++) {
+  for (let i = 1; i < this.thumbRowBuffer; i++) {
     if (firstRow - i >= 0) { rowsToDisplay.push(firstRow - i); }
   }
   rowsToDisplay.sort();

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -982,14 +982,14 @@ BookReader.prototype.lazyLoadThumbnails = function() {
  *
  * @param {$lazyLoadImgPlaceholder} - $imgPlaceholder
  */
-BookReader.prototype.lazyLoadImage = function ($imgPlaceholder) {
-  const leaf =  $($imgPlaceholder).data('leaf');
-  const reduce =  $($imgPlaceholder).data('reduce');
+BookReader.prototype.lazyLoadImage = function (imgPlaceholder) {
+  const leaf =  $(imgPlaceholder).data('leaf');
+  const reduce =  $(imgPlaceholder).data('reduce');
   const $img = this.imageCache.image(leaf, reduce);
-  const $parent = $($imgPlaceholder).parent();
+  const $parent = $(imgPlaceholder).parent();
   /* March 16, 2021 (isa) - manually append & remove, `replaceWith` currently loses closure scope */
   $($parent).append($img);
-  $($imgPlaceholder).remove();
+  $(imgPlaceholder).remove();
 };
 
 /**

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -959,14 +959,9 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
 };
 
 BookReader.prototype.lazyLoadThumbnails = function() {
-  const self = this;
-
   const batchImageRequestByRow = ($images) => {
     utils.wait().then(() => {
-      $images.each(function loadEachImg() {
-        const $imgPlaceholder = this;
-        self.lazyLoadImage($imgPlaceholder)
-      });
+      $images.each((index, $imgPlaceholder) => this.lazyLoadImage($imgPlaceholder));
     })
   };
 

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -755,7 +755,6 @@ BookReader.prototype.bindGestures = function(jElement) {
  * @typedef {Object} $lazyLoadImgPlaceholder * jQuery element with data attributes: leaf, reduce
  */
 BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
-  console.log("ASK: drawLeafsThumbnail", new Date());
   const { floor } = Math;
   const { book } = this._models;
   const viewWidth = this.refs.$brContainer.prop('scrollWidth') - 20; // width minus buffer
@@ -859,13 +858,8 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
     if (firstRow - i >= 0) { rowsToDisplay.push(firstRow - i); }
   }
 
-  console.log("***** ROWS TO DISPLAY", rowsToDisplay);
-  console.log("***** this.displayedRows", this.displayedRows);
-  console.log("***** leafMap", leafMap);
-
   // Create the thumbnail divs and images (lazy loaded)
   for (const row of rowsToDisplay) {
-    console.log('row, leafMap[row]', row, leafMap[row] );
     if (utils.notInArray(row, this.displayedRows)) {
       if (!leafMap[row]) { continue; }
       for (const { num: leaf, left: leafLeft } of leafMap[row]?.leafs) {
@@ -912,7 +906,6 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
         const baseCSS = { width: `${leafWidth}px`, height: `${leafHeight}px` };
         if (this.imageCache.imageLoaded(leaf)) {
           // send to page
-          console.log("SEND TO PAGE")
           $pageContainer.append($(this.imageCache.image(leaf, thumbReduce)).css(baseCSS));
         } else {
           // lazy load
@@ -971,7 +964,6 @@ BookReader.prototype.lazyLoadThumbnails = function() {
   const batchImageRequestByRow = ($images) => {
     utils.wait().then(() => {
       $images.each(function loadEachImg() {
-        // really borky closure
         const $imgPlaceholder = this;
         self.lazyLoadImage($imgPlaceholder)
       });
@@ -979,24 +971,9 @@ BookReader.prototype.lazyLoadThumbnails = function() {
   };
 
   this.displayedRows.forEach((row) => {
-    console.log('foo', row);
     const $imagesInRow = this.refs.$brPageViewEl.find(`[data-row="${row}"]`);
-    console.log('imagesInRow', $imagesInRow);
     batchImageRequestByRow($imagesInRow);
   });
-
-
-  // const imagesToLoad = this.refs.$brPageViewEl
-  //   .find('img.BRlazyload')
-  // // .filter(':lt(' + toLoad + ')');
-  // console.log("ASK: lazyLoadThumbnails - imagesToLoad", imagesToLoad);
-  // console.log()
-
-  // imagesToLoad.each(function loadEachImg() {
-  // // really borky closure
-  //   const $imgPlaceholder = this;
-  //   self.lazyLoadImage($imgPlaceholder);
-  // });
 };
 
 /**
@@ -1013,7 +990,6 @@ BookReader.prototype.lazyLoadImage = function ($imgPlaceholder) {
   const $parentContainer = $($imgPlaceholder).parent();
   $parentContainer.append($img);
   $($imgPlaceholder).remove();
-  console.log("lazy loaded image: idx", leaf);
 };
 
 /**

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -959,10 +959,9 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
 };
 
 BookReader.prototype.lazyLoadThumbnails = function() {
-  const batchImageRequestByRow = ($images) => {
-    utils.wait().then(() => {
-      $images.each((index, $imgPlaceholder) => this.lazyLoadImage($imgPlaceholder));
-    })
+  const batchImageRequestByRow = async ($images) => {
+    await utils.sleep(500);
+    $images.each((index, $imgPlaceholder) => this.lazyLoadImage($imgPlaceholder));
   };
 
   this.displayedRows.forEach((row) => {

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -1363,6 +1363,7 @@ BookReader.prototype.switchMode = function(
     this.prepareOnePageView();
   } else if (this.constModeThumb == mode) {
     this.reduce = this.quantizeReduce(this.reduce, this.reductionFactors);
+    this.displayedRows = []; /* Forces gallery redraw when switching modes */
     this.prepareThumbnailView();
   } else {
     // $$$ why don't we save autofit?

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -902,9 +902,10 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
         this.refs.$brPageViewEl.append($pageContainer);
         imagesToDisplay.push(leaf);
 
-        const thumbReduce = floor(book.getPageWidth(leaf) / this.thumbWidth);
-        // use prefetched img src first if previously requested & available img is good enough
-        // dip into cache so we don't set off a request
+        /* get thumbnail's reducer */
+        const idealReduce = floor(book.getPageWidth(leaf) / this.thumbWidth);
+        const nearestFactor2 = 2 * Math.round(idealReduce / 2);
+        const thumbReduce = nearestFactor2;
 
         const baseCSS = { width: `${leafWidth}px`, height: `${leafHeight}px` };
         if (this.imageCache.imageLoaded(leaf)) {

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -821,6 +821,7 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
 
   let leafTop = 0;
   let leafBottom = 0;
+  let rowsInView = [];
   const rowsToDisplay = [];
   const imagesToDisplay = [];
 
@@ -847,6 +848,7 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
     if (leafTop > leafMap[i].top) { leafMap[i].top = leafTop; }
     leafTop = leafBottom;
   }
+  rowsInView = [...rowsToDisplay];
 
   // create a buffer of preloaded rows before and after the visible rows
   const firstRow = rowsToDisplay[0];
@@ -857,6 +859,7 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
   for (let i = 1; i < this.thumbRowBuffer + 1; i++) {
     if (firstRow - i >= 0) { rowsToDisplay.push(firstRow - i); }
   }
+  rowsToDisplay.sort();
 
   // Create the thumbnail divs and images (lazy loaded)
   for (const row of rowsToDisplay) {
@@ -960,7 +963,7 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
 
 BookReader.prototype.lazyLoadThumbnails = function() {
   const batchImageRequestByRow = async ($images) => {
-    await utils.sleep(500);
+    await utils.sleep(300);
     $images.each((index, $imgPlaceholder) => this.lazyLoadImage($imgPlaceholder));
   };
 
@@ -979,9 +982,10 @@ BookReader.prototype.lazyLoadImage = function ($imgPlaceholder) {
   const leaf =  $($imgPlaceholder).data('leaf');
   const reduce =  $($imgPlaceholder).data('reduce');
   const $img = this.imageCache.image(leaf, reduce);
-
-  // replace with the new img
-  $($imgPlaceholder).replaceWith($img);
+  const $parent = $($imgPlaceholder).parent();
+  /* March 16, 2021 (isa) - manually append & remove, `replaceWith` currently loses closure scope */
+  $($parent).append($img);
+  $($imgPlaceholder).remove();
 };
 
 /**

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -865,7 +865,7 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
   for (const row of rowsToDisplay) {
     if (utils.notInArray(row, this.displayedRows)) {
       if (!leafMap[row]) { continue; }
-      for (const { num: leaf, left: leafLeft } of leafMap[row]?.leafs) {
+      for (const { num: leaf, left: leafLeft } of leafMap[row].leafs) {
         const leafWidth = this.thumbWidth;
         const leafHeight = floor((book.getPageHeight(leaf) * this.thumbWidth) / book.getPageWidth(leaf));
         const leafTop = leafMap[row].top;
@@ -928,13 +928,16 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
       }
     }
   }
+  console.log("IMGS TO DISPLAY", imagesToDisplay);
+  console.log('rowsInView', rowsInView);
+  console.log('this.displayedRows', this.displayedRows);
 
   // Remove thumbnails that are not to be displayed
   for (const row of this.displayedRows) {
     if (utils.notInArray(row, rowsToDisplay)) {
-      for (const { num: index } of leafMap[row].leafs) {
-        if (!imagesToDisplay.includes(index)) {
-          this.$(`.pagediv${index}`).remove();
+      for (const { num: index } of leafMap[row]?.leafs) {
+        if (!imagesToDisplay?.includes(index)) {
+          this.$(`.pagediv${index}`)?.remove();
         }
       }
     }
@@ -1363,7 +1366,6 @@ BookReader.prototype.switchMode = function(
     this.prepareOnePageView();
   } else if (this.constModeThumb == mode) {
     this.reduce = this.quantizeReduce(this.reduce, this.reductionFactors);
-    this.displayedRows = []; /* Forces gallery redraw when switching modes */
     this.prepareThumbnailView();
   } else {
     // $$$ why don't we save autofit?
@@ -1505,7 +1507,7 @@ BookReader.prototype.prepareThumbnailView = function() {
   // utils.disableSelect(this.$('#BRpageview'));
   this.thumbWidth = this.getThumbnailWidth(this.thumbColumns);
   this.reduce = this._models.book.getPageWidth(0) / this.thumbWidth;
-
+  this.displayedRows = [];
   // Draw leafs with current index directly in view (no animating to the index)
   this.drawLeafsThumbnail( this.currentIndex() );
   this.updateBrClasses();

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -981,7 +981,7 @@ BookReader.prototype.lazyLoadImage = function ($imgPlaceholder) {
   const $img = this.imageCache.image(leaf, reduce);
 
   // replace with the new img
-  $(imgPlaceholder).replaceWith($img);
+  $($imgPlaceholder).replaceWith($img);
 };
 
 /**
@@ -1086,9 +1086,12 @@ BookReader.prototype.zoomThumb = function(direction) {
  * @param {number}
  */
 BookReader.prototype.getThumbnailWidth = function(thumbnailColumns) {
+  const DEFAULT_THUMBNAIL_WIDTH = 100;
+
   var padding = (thumbnailColumns + 1) * this.thumbPadding;
   var width = (this.refs.$brPageViewEl.width() - padding) / (thumbnailColumns + 0.5); // extra 0.5 is for some space at sides
-  return parseInt(width);
+  const idealThumbnailWidth = parseInt(width);
+  return idealThumbnailWidth > 0 ? idealThumbnailWidth : DEFAULT_THUMBNAIL_WIDTH;
 };
 
 /**
@@ -1494,10 +1497,7 @@ BookReader.prototype.prepareThumbnailView = function() {
   // $$$ keep select enabled for now since disabling it breaks keyboard
   //     nav in FF 3.6 (https://bugs.edge.launchpad.net/bookreader/+bug/544666)
   // utils.disableSelect(this.$('#BRpageview'));
-  const defaultThumbnailWidth = 100;
-
-  const idealReduce = this.getThumbnailWidth(this.thumbColumns);
-  this.thumbWidth = idealReduce > 0 ? idealReduce : defaultThumbnailWidth;
+  this.thumbWidth = this.getThumbnailWidth(this.thumbColumns);
   this.reduce = this._models.book.getPageWidth(0) / this.thumbWidth;
 
   // Draw leafs with current index directly in view (no animating to the index)

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -908,7 +908,7 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
         const thumbReduce = nearestFactor2;
 
         const baseCSS = { width: `${leafWidth}px`, height: `${leafHeight}px` };
-        if (this.imageCache.imageLoaded(leaf)) {
+        if (this.imageCache.imageLoaded(leaf, thumbReduce)) {
           // send to page
           $pageContainer.append($(this.imageCache.image(leaf, thumbReduce)).css(baseCSS));
         } else {

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -1116,6 +1116,7 @@ BookReader.prototype.zoomThumb = function(direction) {
   }
 
   if (this.thumbColumns != oldColumns) {
+    this.displayedRows = [];  /* force a gallery redraw */
     this.prepareThumbnailView();
   }
 };

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -1501,8 +1501,6 @@ BookReader.prototype.prepareThumbnailView = function() {
   this.thumbWidth = this.getThumbnailWidth(this.thumbColumns);
   this.reduce = this._models.book.getPageWidth(0) / this.thumbWidth;
 
-  this.displayedRows = [];
-
   // Draw leafs with current index directly in view (no animating to the index)
   this.drawLeafsThumbnail( this.currentIndex() );
   this.updateBrClasses();

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -750,6 +750,9 @@ BookReader.prototype.bindGestures = function(jElement) {
  * Draws the thumbnail view
  * @param {number} optional If seekIndex is defined, the view will be drawn
  *    with that page visible (without any animated scrolling).
+ *
+ * Creates place holder for image to load after gallery has been drawn
+ * @typedef {Object} $lazyLoadImgPlaceholder * jQuery element with data attributes: leaf, reduce
  */
 BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
   const { floor } = Math;

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -928,9 +928,6 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
       }
     }
   }
-  console.log("IMGS TO DISPLAY", imagesToDisplay);
-  console.log('rowsInView', rowsInView);
-  console.log('this.displayedRows', this.displayedRows);
 
   // Remove thumbnails that are not to be displayed
   for (const row of this.displayedRows) {

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -821,7 +821,6 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
 
   let leafTop = 0;
   let leafBottom = 0;
-  let rowsInView = [];
   const rowsToDisplay = [];
   const imagesToDisplay = [];
 
@@ -848,7 +847,7 @@ BookReader.prototype.drawLeafsThumbnail = function(seekIndex) {
     if (leafTop > leafMap[i].top) { leafMap[i].top = leafTop; }
     leafTop = leafBottom;
   }
-  rowsInView = [...rowsToDisplay];
+  // at this point, `rowsToDisplay` now has all the rows in view
 
   // create a buffer of preloaded rows before and after the visible rows
   const firstRow = rowsToDisplay[0];

--- a/src/js/BookReader/ImageCache.js
+++ b/src/js/BookReader/ImageCache.js
@@ -33,6 +33,15 @@ export class ImageCache {
   }
 
   /**
+   * Checks if image has been loaded
+   * @param {String|Number} index - page index
+   * @returns {Boolean}
+   */
+  imageLoaded(index) {
+    return !!this.cache[index]?.loaded;
+  }
+
+  /**
    * @private
    * Removes image from cache
    * Empties `src` & `srcSet` attributes prior to cancel pending requests

--- a/src/js/BookReader/ImageCache.js
+++ b/src/js/BookReader/ImageCache.js
@@ -53,7 +53,6 @@ export class ImageCache {
   /**
    * Checks if image's cache status
    * @param {String|Number} index - page index
-   * @returns {{ index: Number, inCache: (Object|undefined), reduce: Number, loaded: Boolean }}
    */
   imageStatus(index) {
     return {

--- a/src/js/BookReader/ImageCache.js
+++ b/src/js/BookReader/ImageCache.js
@@ -33,37 +33,6 @@ export class ImageCache {
   }
 
   /**
-   * Checks if image has been loaded
-   * @param {String|Number} index - page index
-   * @returns {Boolean}
-   */
-  imageLoaded(index) {
-    return !!this.cache[index]?.loaded;
-  }
-
-  /**
-   * Checks if image's reduce
-   * @param {String|Number} index - page index
-   * @returns {Number} reduce
-   */
-  imageReduce(index) {
-    return this.cache[index]?.reduce;
-  }
-
-  /**
-   * Checks if image's cache status
-   * @param {String|Number} index - page index
-   */
-  imageStatus(index) {
-    return {
-      index,
-      inCache: this.cache[index],
-      reduce: this.imageReduce(index),
-      loaded: this.imageLoaded(index)
-    }
-  }
-
-  /**
    * @private
    * Removes image from cache
    * Empties `src` & `srcSet` attributes prior to cancel pending requests

--- a/src/js/BookReader/ImageCache.js
+++ b/src/js/BookReader/ImageCache.js
@@ -32,10 +32,17 @@ export class ImageCache {
   /**
    * Checks if image has been loaded
    * @param {String|Number} index - page index
+   * @param {Number} reduce
    * @returns {Boolean}
    */
-  imageLoaded(index) {
-    return !!this.cache[index]?.loaded;
+  imageLoaded(index, reduce) {
+    const cacheImg = this.cache[index];
+    if (!cacheImg) {
+      return false;
+    }
+    const { reduce: cachedReduce, loaded } = cacheImg;
+    const cacheImgReducedWellEnough = cachedReduce <= reduce;
+    return cacheImgReducedWellEnough && loaded;
   }
 
   /**

--- a/src/js/BookReader/ImageCache.js
+++ b/src/js/BookReader/ImageCache.js
@@ -8,9 +8,6 @@ export class ImageCache {
     this.br = br;
     this.cache = {};
     this.defaultScale = 8;
-
-    this.createImage = this._createImage.bind(this);
-    this.image = this.image.bind(this);
   }
 
   /**
@@ -20,13 +17,13 @@ export class ImageCache {
    *
    * @param {String|Number} index - page index
    * @param {Number} reduce
-   * @returns $image
+   * @returns {Element} $image
    */
   image(index, reduce) {
     const $thisImage = this.cache[index];
     const currImageScale = $thisImage?.reduce;
     if (currImageScale <= reduce) {
-      return $thisImage;
+      return this._serveImageElement(index);
     }
 
     return this._createImage(index, reduce);
@@ -49,9 +46,6 @@ export class ImageCache {
    * @param {String|Number} index - page index
    */
   _bustImageCache(index) {
-    const $thisImage = this.cache[index];
-    // allows browser to abort a pending request
-    $($thisImage).attr('src', '').attr('srcSet', []);
     delete this.cache[index];
   }
 
@@ -70,20 +64,31 @@ export class ImageCache {
     if (hasCache) {
       this._bustImageCache(index);
     }
-
     const src = this.br._getPageURI(index, reduce);
     const srcSet = this.br.options.useSrcSet ? this.br._getPageURISrcset(index, reduce) : [];
-    const $img = $('<img />', {
+    this.cache[index] = { reduce, uri: src, srcSet, loaded: false }
+    return this._serveImageElement(index);
+  }
+
+  /**
+   * @private
+   * Generates an image element on the fly from image info in cache
+   *
+   * @param {String|Number} index - page index
+   * @returns {Element} jQuery <img> element with base image classes
+   */
+  _serveImageElement(index) {
+    const { uri, srcSet, reduce } = this.cache[index];
+
+    const $img = $('<img />',{
       'class': 'BRpageimage',
       'alt': 'Book page image',
-      src,
+      src: uri,
       srcSet
-    }).data('reduce', reduce).load(() => {
-      this.cache[index].loaded = true;
-    });
-
-    this.cache[index] = { ...$img, reduce, uri: src };
-
-    return this.cache[index];
+    })
+      .attr('style', '')
+      .data('reduce', reduce)
+      .load(() => this.cache[index].loaded = true);
+    return $img;
   }
 }

--- a/src/js/BookReader/ImageCache.js
+++ b/src/js/BookReader/ImageCache.js
@@ -41,10 +41,20 @@ export class ImageCache {
     return !!this.cache[index]?.loaded;
   }
 
+  /**
+   * Checks if image's reduce
+   * @param {String|Number} index - page index
+   * @returns {Number} reduce
+   */
   imageReduce(index) {
     return this.cache[index]?.reduce;
   }
 
+  /**
+   * Checks if image's cache status
+   * @param {String|Number} index - page index
+   * @returns {{ index: Number, inCache: (Object|undefined), reduce: Number, loaded: Boolean }}
+   */
   imageStatus(index) {
     return {
       index,

--- a/src/js/BookReader/ImageCache.js
+++ b/src/js/BookReader/ImageCache.js
@@ -32,6 +32,27 @@ export class ImageCache {
     return this._createImage(index, reduce);
   }
 
+  /**
+   * Checks if image has been loaded
+   * @param {String|Number} index - page index
+   * @returns {Boolean}
+   */
+  imageLoaded(index) {
+    return !!this.cache[index]?.loaded;
+  }
+
+  imageReduce(index) {
+    return this.cache[index]?.reduce;
+  }
+
+  imageStatus(index) {
+    return {
+      index,
+      inCache: this.cache[index],
+      reduce: this.imageReduce(index),
+      loaded: this.imageLoaded(index)
+    }
+  }
 
   /**
    * @private
@@ -43,7 +64,6 @@ export class ImageCache {
   _bustImageCache(index) {
     const $thisImage = this.cache[index];
     // allows browser to abort a pending request
-
     $($thisImage).attr('src', '').attr('srcSet', []);
     delete this.cache[index];
   }

--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -677,6 +677,8 @@ export class Mode2Up {
         this.br.pruneUnusedImgs();
         this.br.animating = false;
 
+        this.resizeSpread();
+
         if (this.br.enableSearch) this.br.updateSearchHilites();
 
         this.setMouseHandlers();
@@ -827,6 +829,7 @@ export class Mode2Up {
         this.br.pruneUnusedImgs();
         this.br.animating = false;
 
+        this.resizeSpread();
 
         if (this.br.enableSearch) this.br.updateSearchHilites();
 

--- a/src/js/BookReader/options.js
+++ b/src/js/BookReader/options.js
@@ -19,7 +19,7 @@ export const DEFAULT_OPTIONS = {
 
   /** thumbnail mode */
   /** number of rows to pre-cache out a view */
-  thumbRowBuffer: 2,
+  thumbRowBuffer: 1,
   thumbColumns: 6,
   /** number of thumbnails to load at once */
   thumbMaxLoading: 4,

--- a/src/js/BookReader/options.js
+++ b/src/js/BookReader/options.js
@@ -280,7 +280,7 @@ export const DEFAULT_OPTIONS = {
    * @type {Boolean}
    * On init, by default, we want to use srcSet for images
    */
-  useSrcSet: true,
+  useSrcSet: false,
 };
 
 /** @typedef {'width' | 'height' | 'auto' | 'none'} AutoFitValues */

--- a/src/js/BookReader/utils.js
+++ b/src/js/BookReader/utils.js
@@ -161,10 +161,10 @@ export function PolyfilledCustomEvent(eventName, {bubbles = false, cancelable = 
 }
 
 /**
- * Promise based wait - resolves at default 500ms
+ * Promise based sleep - resolves at default 500ms
  * @param {Number} wait time in milliseconds
  */
-export function wait(ms = 500) {
+export function sleep(ms = 500) {
   return new Promise((res) => {
     setTimeout(() => res(true), ms);
   });

--- a/src/js/BookReader/utils.js
+++ b/src/js/BookReader/utils.js
@@ -165,5 +165,5 @@ export function PolyfilledCustomEvent(eventName, {bubbles = false, cancelable = 
  * @param {Number} wait time in milliseconds
  */
 export function sleep(ms = 500) {
-  return new Promise(res => setTimeout(res, ms));
+  return new Promise(res => setTimeout(res(true), ms));
 }

--- a/src/js/BookReader/utils.js
+++ b/src/js/BookReader/utils.js
@@ -165,7 +165,5 @@ export function PolyfilledCustomEvent(eventName, {bubbles = false, cancelable = 
  * @param {Number} wait time in milliseconds
  */
 export function sleep(ms = 500) {
-  return new Promise((res) => {
-    setTimeout(() => res(true), ms);
-  });
+  return new Promise(res => setTimeout(res, ms));
 }

--- a/src/js/BookReader/utils.js
+++ b/src/js/BookReader/utils.js
@@ -160,6 +160,10 @@ export function PolyfilledCustomEvent(eventName, {bubbles = false, cancelable = 
   return event;
 }
 
+/**
+ * Promise based wait - resolves at default 500ms
+ * @param {Number} wait time in milliseconds
+ */
 export function wait(ms = 500) {
   return new Promise((res) => {
     setTimeout(() => res(true), ms);

--- a/src/js/BookReader/utils.js
+++ b/src/js/BookReader/utils.js
@@ -159,3 +159,9 @@ export function PolyfilledCustomEvent(eventName, {bubbles = false, cancelable = 
   event.initCustomEvent(eventName, bubbles, cancelable, detail);
   return event;
 }
+
+export function wait(ms = 500) {
+  return new Promise((res) => {
+    setTimeout(() => res(true), ms);
+  });
+}

--- a/tests/BookReader/ImageCache.test.js
+++ b/tests/BookReader/ImageCache.test.js
@@ -113,6 +113,15 @@ describe('Image Cache', () => {
       const img = br.imageCache.image(0, 5);
       expect(serveImgElStub.callCount).toBe(1);
       expect($(img).length).toBe(1);
+    });
+  });
+
+  describe('`_serveImageElement` call', () => {
+    test('returns jQuery image element', () => {
+      const br = new BookReader({ data: SAMPLE_DATA });
+      br.init();
+      const img = br.imageCache._serveImageElement(0);
+      expect($(img).length).toBe(1);
       expect($(img)[0].classList.contains('BRpageimage')).toBe(true);
       expect($(img).attr('src')).toBe(FIRST_PAGE_MOCK.uri);
     });

--- a/tests/BookReader/utils.test.js
+++ b/tests/BookReader/utils.test.js
@@ -8,6 +8,7 @@ import {
   escapeHTML,
   polyfillCustomEvent,
   PolyfilledCustomEvent,
+  sleep,
 } from '../../src/js/BookReader/utils.js';
 
 test('clamp function returns Math.min(Math.max(value, min), max)', () => {
@@ -90,5 +91,19 @@ describe('PolyfilledCustomEvent', () => {
     new PolyfilledCustomEvent('foo');
     expect(createEventSpy.callCount).toBe(1);
     expect(initCustomEventSpy.callCount).toBe(1);
+  });
+});
+
+describe('sleep', () => {
+  test('can set sleep in ms', async () => {
+    jest.useFakeTimers();
+
+    const sleepTimeMS = 11;
+    await sleep(sleepTimeMS);
+
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenLastCalledWith(undefined, sleepTimeMS);
+
+    jest.clearAllTimers();
   });
 });


### PR DESCRIPTION
### Thumbnail draw fixes
- uses image cache dictionary to use best fetched image url
  - value can be seen during the following actions:
    - switching modes from 2up -> thumbnail/gallery
    - browser width resize while in thumbnail/gallery mode
    - scrolling quickly up & down through thumbnail/gallery mode
- reduces "row buffer" on draw
- image reducer is factor of 2, to reduce calls with odd number factors that aren't respected by image service
![thumbnail image reuse)](https://user-images.githubusercontent.com/7840857/111576084-06312080-876d-11eb-9f91-4eaf5b76e2c1.gif)


### Image Cache dictionary updates
- no longer saving image element
- serves image element on the fly
- `imageLoaded` checks against given index & reducer
- unit tests

### Util.sleep
- new promise based sleep function
- unit test

### Bonus:  2up mode resizes book on flip
- this accounts for books of irregular widths, ensuring that:
  - a spread can be scrolled horizontally if needed
  - a spread that doesn't need to be scrolled doesn't have a scrollable container
  
![2up mode horizontal scroll](https://user-images.githubusercontent.com/7840857/111576631-15fd3480-876e-11eb-8a14-bacd331499de.gif)
