### PR TITLE
Move `pageChanged` event name into events.js

### DIFF
--- a/src/js/BookReader/Mode2Up.js
+++ b/src/js/BookReader/Mode2Up.js
@@ -1,6 +1,6 @@
 // @ts-check
-import { clamp } from './utils.js';
 import { EVENTS } from './events.js';
+import { clamp } from './utils.js';
 
 /** @typedef {import('../BookReader.js').default} BookReader */
 /** @typedef {import('./BookModel.js').BookModel} BookModel */
@@ -59,7 +59,7 @@ export class Mode2Up {
     this.setMouseHandlers();
     this.br.displayedIndices = this.displayedIndices;
     this.br.updateToolbarZoom(this.br.reduce);
-    this.br.trigger('pageChanged');
+    this.br.trigger('events.pageChanged');
   }
 
   /**
@@ -689,7 +689,7 @@ export class Mode2Up {
         this.br.refs.$brContainer.removeClass("BRpageFlipping");
         this.br.textSelectionPlugin?.stopPageFlip(this.br.refs.$brContainer);
         this.centerView();
-        this.br.trigger('pageChanged');
+        this.br.trigger('events.pageChanged');
 
         // get next previous batch immediately      this.br.pruneUnusedImgs();
         if (!this.br.prefetchedImgs[newIndexL - 2]) {
@@ -840,7 +840,7 @@ export class Mode2Up {
         this.br.refs.$brContainer.removeClass("BRpageFlipping");
         this.br.textSelectionPlugin?.stopPageFlip(this.br.refs.$brContainer);
         this.centerView();
-        this.br.trigger('pageChanged');
+        this.br.trigger('events.pageChanged');
 
         this.br.pruneUnusedImgs();
         if (!this.br.prefetchedImgs[newIndexL + 2]) {

--- a/src/js/BookReader/events.js
+++ b/src/js/BookReader/events.js
@@ -6,6 +6,7 @@ export const EVENTS = {
   PostInit: 'PostInit',
   stop: 'stop',
   resize: 'resize',
+  pageChanged = 'pageChanged',
   // nav events:
   navToggled: 'navToggled',
   // menu click events

--- a/src/js/plugins/search/view.js
+++ b/src/js/plugins/search/view.js
@@ -484,7 +484,7 @@ class SearchView {
     this.updateResultsCount(results.matches.length);
     this.toggleSearchPending(false);
     if (options.goToFirstResult) {
-      $(document).one('BookReader:pageChanged', () => {
+      $(document).one('BookReader:events.pageChanged', () => {
         this.br.resize();
       });
     } else {
@@ -534,7 +534,7 @@ class SearchView {
       .on(`${namespace}SearchCallbackError`, this.handleSearchCallbackError.bind(this))
       .on(`${namespace}SearchCallbackBookNotIndexed`, this.handleSearchCallbackBookNotIndexed.bind(this))
       .on(`${namespace}SearchCallbackEmpty`, this.handleSearchCallbackEmpty.bind(this))
-      .on(`${namespace}pageChanged`, this.updateSearchNavigation.bind(this));
+      .on(`${namespace}events.pageChanged`, this.updateSearchNavigation.bind(this));
 
     this.dom.searchTray.addEventListener('submit', this.submitHandler.bind(this));
     this.dom.toolbarSearch.querySelector('form').addEventListener('submit', this.submitHandler.bind(this));


### PR DESCRIPTION
In reference to #460

Ongoing through the code, just update events 'list' to include new field: pageChanged = 'pageChanged' then replace pageChanged to events.pageChanged for new reference and lastly event BookReader:pageChanged is emitted when changing the page.
