### PR TITLE
fix: prevent keyboard shortcut when target is `input`

### DIFF
--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -1920,8 +1920,9 @@ BookReader.prototype.stopFlipAnimations = function() {
  * @param {Event}
  * @return {boolean}
  */
-BookReader.prototype.keyboardNavigationIsDisabled = function(event) {
-  return event.target.tagName == "INPUT";
+
+BookReader.prototype.keyboardNavigationIsDisabled = function() {
+  return document.activeElement.tagName == "INPUT";
 };
 
 /**


### PR DESCRIPTION
fixes #371

Tested it using @shaneriley's [method](https://github.com/internetarchive/bookreader/issues/371#issuecomment-664587467)
