### PR TITLE
[feat] RotateScreen: Rotate pages with a NavBar button

### DIFF
--- a/src/assets/icons/rotate.svg
+++ b/src/assets/icons/rotate.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.com/svgjs" version="1.1" width="512" height="512" x="0" y="0" viewBox="0 0 453.227 453.227" style="enable-background:new 0 0 512 512" xml:space="preserve" class=""><g>
+<g xmlns="http://www.w3.org/2000/svg">
+	<g>
+		<g>
+			<path d="M139.453,120.747L1.107,259.093L139.453,397.44L277.8,259.093L139.453,120.747z M61.373,259.093l77.973-77.973     l78.08,77.973l-77.973,77.973L61.373,259.093z" fill="#ffffff" data-original="#000000" style="" class=""/>
+			<path d="M395.88,125.44C358.333,88,309.267,69.227,260.093,69.227V0l-90.56,90.56l90.56,90.453v-69.12     c38.187,0,76.48,14.613,105.6,43.733c58.347,58.347,58.347,152.853,0,211.2c-29.12,29.12-67.413,43.733-105.6,43.733     c-20.693,0-41.28-4.373-60.48-12.907l-31.787,31.787c28.587,15.787,60.373,23.787,92.267,23.787     c49.173,0,98.24-18.773,135.787-56.213C470.867,322.027,470.867,200.427,395.88,125.44z" fill="#ffffff" data-original="#000000" style="" class=""/>
+		</g>
+	</g>
+</g>
+<g xmlns="http://www.w3.org/2000/svg">
+</g>
+<g xmlns="http://www.w3.org/2000/svg">
+</g>
+<g xmlns="http://www.w3.org/2000/svg">
+</g>
+<g xmlns="http://www.w3.org/2000/svg">
+</g>
+<g xmlns="http://www.w3.org/2000/svg">
+</g>
+<g xmlns="http://www.w3.org/2000/svg">
+</g>
+<g xmlns="http://www.w3.org/2000/svg">
+</g>
+<g xmlns="http://www.w3.org/2000/svg">
+</g>
+<g xmlns="http://www.w3.org/2000/svg">
+</g>
+<g xmlns="http://www.w3.org/2000/svg">
+</g>
+<g xmlns="http://www.w3.org/2000/svg">
+</g>
+<g xmlns="http://www.w3.org/2000/svg">
+</g>
+<g xmlns="http://www.w3.org/2000/svg">
+</g>
+<g xmlns="http://www.w3.org/2000/svg">
+</g>
+<g xmlns="http://www.w3.org/2000/svg">
+</g>
+</g></svg>

--- a/src/assets/icons/rotate.svg
+++ b/src/assets/icons/rotate.svg
@@ -1,41 +1,17 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.com/svgjs" version="1.1" width="512" height="512" x="0" y="0" viewBox="0 0 453.227 453.227" style="enable-background:new 0 0 512 512" xml:space="preserve" class=""><g>
-<g xmlns="http://www.w3.org/2000/svg">
-	<g>
-		<g>
-			<path d="M139.453,120.747L1.107,259.093L139.453,397.44L277.8,259.093L139.453,120.747z M61.373,259.093l77.973-77.973     l78.08,77.973l-77.973,77.973L61.373,259.093z" fill="#ffffff" data-original="#000000" style="" class=""/>
-			<path d="M395.88,125.44C358.333,88,309.267,69.227,260.093,69.227V0l-90.56,90.56l90.56,90.453v-69.12     c38.187,0,76.48,14.613,105.6,43.733c58.347,58.347,58.347,152.853,0,211.2c-29.12,29.12-67.413,43.733-105.6,43.733     c-20.693,0-41.28-4.373-60.48-12.907l-31.787,31.787c28.587,15.787,60.373,23.787,92.267,23.787     c49.173,0,98.24-18.773,135.787-56.213C470.867,322.027,470.867,200.427,395.88,125.44z" fill="#ffffff" data-original="#000000" style="" class=""/>
-		</g>
-	</g>
-</g>
-<g xmlns="http://www.w3.org/2000/svg">
-</g>
-<g xmlns="http://www.w3.org/2000/svg">
-</g>
-<g xmlns="http://www.w3.org/2000/svg">
-</g>
-<g xmlns="http://www.w3.org/2000/svg">
-</g>
-<g xmlns="http://www.w3.org/2000/svg">
-</g>
-<g xmlns="http://www.w3.org/2000/svg">
-</g>
-<g xmlns="http://www.w3.org/2000/svg">
-</g>
-<g xmlns="http://www.w3.org/2000/svg">
-</g>
-<g xmlns="http://www.w3.org/2000/svg">
-</g>
-<g xmlns="http://www.w3.org/2000/svg">
-</g>
-<g xmlns="http://www.w3.org/2000/svg">
-</g>
-<g xmlns="http://www.w3.org/2000/svg">
-</g>
-<g xmlns="http://www.w3.org/2000/svg">
-</g>
-<g xmlns="http://www.w3.org/2000/svg">
-</g>
-<g xmlns="http://www.w3.org/2000/svg">
-</g>
-</g></svg>
+<svg  viewBox="0 0 21 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
+    <title>Rotate Screen</title>
+    <desc>An icon to indicate screen rotation.</desc>
+    <g id="Icons" stroke="none" stroke-width="0" fill="none" fill-rule="evenodd">
+        <g id="Rounded" transform="translate(-644.000000, -421.000000)">
+            <g id="Action" transform="translate(100.000000, 100.000000)">
+                <g id="-Round-/-Action-/-settings_backup_restore" transform="translate(544.000000, 318.000000)">
+                    <g>
+                        <polygon id="Path" points="0 0 24 0 24 24 0 24"></polygon>
+                        <path d="M14,12 C14,10.9 13.1,10 12,10 C10.9,10 10,10.9 10,12 C10,13.1 10.9,14 12,14 C13.1,14 14,13.1 14,12 Z M12.26,3 C7.17,2.86 3,6.95 3,12 L1.21,12 C0.76,12 0.54,12.54 0.86,12.85 L3.65,15.64 C3.85,15.84 4.16,15.84 4.36,15.64 L7.15,12.85 C7.46,12.54 7.24,12 6.79,12 L5,12 C5,8.1 8.18,4.95 12.1,5 C15.82,5.05 18.95,8.18 19,11.9 C19.05,15.81 15.9,19 12,19 C10.75,19 9.58,18.66 8.56,18.09 C8.17,17.87 7.69,17.95 7.38,18.27 C6.92,18.73 7.01,19.52 7.58,19.84 C8.89,20.57 10.39,21 12,21 C17.05,21 21.14,16.83 21,11.74 C20.87,7.05 16.95,3.13 12.26,3 Z" id="🔹Icon-Color" fill="#fff"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/css/_icons.scss
+++ b/src/css/_icons.scss
@@ -113,3 +113,9 @@
   height: 12px;
   background-image: url("icons/close-circle.svg");
 }
+
+.icon-rotatescreen {
+  width: 20px;
+  height: 20px;
+  background-image: url("icons/rotate.svg");
+}

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -151,6 +151,8 @@ BookReader.prototype.setup = function(options) {
   this.twoPagePopUp = null;
   this.leafEdgeTmp  = null;
 
+  this.currentOrientationDeg = 0
+
   /**
      * Represents the first displayed index
      * In 2up mode it will be the left page
@@ -702,7 +704,7 @@ BookReader.prototype.drawLeafs = function() {
  */
 BookReader.prototype._createPageContainer = function(index, styles) {
   const { pageSide } = this._models.book.getPage(index);
-  const css = Object.assign({ position: 'absolute' }, styles);
+  const css = Object.assign({ position: 'absolute' }, styles, { transform: `rotate(${this.currentOrientationDeg}deg)` });
   const modeClasses = {
     [this.constMode1up]: '1up',
     [this.constMode2up]: '2up',
@@ -1587,6 +1589,32 @@ BookReader.prototype.prev = function() {
   }
 };
 
+/**
+ * Rotates screen by 90 degree
+ */
+BookReader.prototype.rotate = function() {
+  if (this.currentOrientationDeg == 0) {
+    this.currentOrientationDeg = 90
+  } else {
+    this.currentOrientationDeg += 90
+  }
+  if (this.currentOrientationDeg >= 360) {
+    this.currentOrientationDeg = 0
+  }
+
+  switch (this.mode) {
+  case 1:
+    this.refs.$brPageViewEl.empty()
+    this._modes.mode1Up.drawLeafs()
+    break
+  case 2:
+    console.log('2 page')
+    this.refs.$brTwoPageView.empty()
+    this._modes.mode2Up.drawLeafs()
+    break
+  }
+}
+
 BookReader.prototype.first = function() {
   this.jumpToIndex(this.firstDisplayableIndex());
 };
@@ -2019,6 +2047,10 @@ BookReader.prototype.bindNavigationHandlers = function() {
         this.toggleFullscreen();
       }
     },
+    rotatescreen: () => {
+      this.trigger(BookReader.eventNames.orientationChanged)
+      self.rotate()
+    }
   };
 
   jIcons.filter('.fit').bind('fit', function() {

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -704,7 +704,7 @@ BookReader.prototype.drawLeafs = function() {
  */
 BookReader.prototype._createPageContainer = function(index, styles) {
   const { pageSide } = this._models.book.getPage(index);
-  const css = Object.assign({ position: 'absolute' }, styles, { transform: `rotate(${this.currentOrientationDeg}deg)` });
+  const css = Object.assign({ position: 'absolute' }, styles, this.mode !== 2 ? ({ transform: `rotate(${this.currentOrientationDeg}deg)` }) : {});
   const modeClasses = {
     [this.constMode1up]: '1up',
     [this.constMode2up]: '2up',
@@ -715,6 +715,9 @@ BookReader.prototype._createPageContainer = function(index, styles) {
     css,
   }).attr('data-side', pageSide).append($('<div />', { 'class': 'BRscreen' }));
   container.toggleClass('protected', this.protected);
+  if (this.mode === 2) {
+    this._rotate2up()
+  }
 
   return container;
 };
@@ -1590,6 +1593,17 @@ BookReader.prototype.prev = function() {
 };
 
 /**
+ * 2PageMode Rotation
+ * @private
+ */
+BookReader.prototype._rotate2up = function() {
+  const $brTwoPageView = this.refs.$brTwoPageView
+  if ($brTwoPageView) {
+    $brTwoPageView[0].style.transform = `rotate(${this.currentOrientationDeg}deg)`
+  }
+}
+
+/**
  * Rotates screen by 90 degree
  */
 BookReader.prototype.rotate = function() {
@@ -1609,8 +1623,7 @@ BookReader.prototype.rotate = function() {
     this._modes.mode1Up.drawLeafs()
     break
   case 2:
-    this.refs.$brTwoPageView.empty()
-    this._modes.mode2Up.drawLeafs()
+    this._rotate2up()
     break
   }
 }

--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -1604,11 +1604,11 @@ BookReader.prototype.rotate = function() {
 
   switch (this.mode) {
   case 1:
-    this.refs.$brPageViewEl.empty()
+    var $brPageElView = $('.BRpageview')
+    $brPageElView.empty()
     this._modes.mode1Up.drawLeafs()
     break
   case 2:
-    console.log('2 page')
     this.refs.$brTwoPageView.empty()
     this._modes.mode2Up.drawLeafs()
     break

--- a/src/js/BookReader/Mode1Up.js
+++ b/src/js/BookReader/Mode1Up.js
@@ -146,7 +146,7 @@ export class Mode1Up {
       this.br.updateFirstIndex(firstProperPage.index);
 
       for (const {page, top, bottom} of pagesToDisplay) {
-        if (!this.br.displayedIndices.includes(page.index)) {
+        if (this.br.displayedIndices.includes(page.index)) {
           const height = bottom - top;
           const width = this.physicalInchesToDisplayPixels(page.widthInches);
           const reduce = page.width / width;

--- a/src/js/BookReader/Navbar/Navbar.js
+++ b/src/js/BookReader/Navbar/Navbar.js
@@ -42,17 +42,8 @@ export class Navbar {
 
   /** @private */
   _renderControls() {
-    return [
-      'bookLeft',
-      'bookRight',
-      'onePage',
-      'twoPage',
-      'thumbnail',
-      'viewmode',
-      'zoomOut',
-      'zoomIn',
-      'fullScreen',
-    ].map((mode) => (
+    const controlls = Object.keys(this.br.options.controls)
+    return controlls.map((mode) => (
       this.controlFor(mode)
     )).join('');
   }

--- a/src/js/BookReader/events.js
+++ b/src/js/BookReader/events.js
@@ -17,4 +17,5 @@ export const EVENTS = {
   /* currently 3 represents thumbnail view */
   '3PageViewSelected': '3PageViewSelected',
   mobileNavOpen: 'mobileNavOpen',
+  orientationChanged: 'orientationChanged',
 };

--- a/src/js/BookReader/options.js
+++ b/src/js/BookReader/options.js
@@ -264,6 +264,11 @@ export const DEFAULT_OPTIONS = {
       className: 'full',
       iconClassName: 'fullscreen'
     },
+    rotateScreen: {
+      label: 'Rotate Screen',
+      visible: true,
+      className: 'rotatescreen'
+    }
   },
 
   /**

--- a/src/js/BookReader/options.js
+++ b/src/js/BookReader/options.js
@@ -267,7 +267,8 @@ export const DEFAULT_OPTIONS = {
     rotateScreen: {
       label: 'Rotate Screen',
       visible: true,
-      className: 'rotatescreen'
+      className: 'rotatescreen',
+      iconClassName: 'rotatescreen'
     }
   },
 


### PR DESCRIPTION
As mentioned in #610 
I've managed to insert button and make it work by adding a function `rotatescreen` at [here](https://github.com/internetarchive/bookreader/blob/master/src/js/BookReader.js#L2059)

<del>Now I wanted some guidance to accomplish this task. Please give some light to initiate with this feature.</del>

<del> **What I've tried** </del>
<del>I fetched `self.refs.$brPageViewEl || self.refs.$brTwoPageView` and tried to add CSS property `transform: rotate(xdeg)` (where `x` is a number)
But issue is, It is resetting the css once I try to `zoomIn` or `zoomOut` 
Also, the visual view is not the one which I desired. It is hiding the upper(Left) page in `2pageview` mode and with `1pageview` mode, the scrolling is completely opposite. </del>

<del>Please give some guidance to work on this issue. Thanks.</del>

Edit: (26 March): Feature works very fine now. 
this PR fixes #610 