### PR TITLE
Feature/pow2 reduce

### DIFF
--- a/src/js/BookReader/ReduceSet.js
+++ b/src/js/BookReader/ReduceSet.js
@@ -1,0 +1,26 @@
+/**
+ * @typedef {object} ReduceSet Set of valid numbers for a reduce variable.
+ * @property {(n: number) => number} floor
+ * @property {(n: number) => number} decr Return the predecessor of the given element
+ */
+
+/** @type {ReduceSet} */
+export const IntegerReduceSet = {
+  floor: Math.floor,
+  decr(n) { return n - 1; }
+};
+
+/** @type {ReduceSet} */
+export const Pow2ReduceSet = {
+  floor(n) {
+    return 2 ** (Math.floor(Math.log2(Math.max(1, n))));
+  },
+  decr(n) {
+    return 2 ** (Math.log2(n) - 1);
+  }
+}
+
+export const NAMED_REDUCE_SETS = {
+  pow2: Pow2ReduceSet,
+  integer: IntegerReduceSet,
+};

--- a/src/js/BookReader/options.js
+++ b/src/js/BookReader/options.js
@@ -45,6 +45,9 @@ export const DEFAULT_OPTIONS = {
    */
   imagesBaseURL: '/BookReader/images/',
 
+  /** @type {'pow2' | 'integer'} What reduces are valid for getURI. */
+  reduceSet: 'pow2',
+
   /**
    * Zoom levels
    * @type {ReductionFactor[]}

--- a/tests/BookReader.test.js
+++ b/tests/BookReader.test.js
@@ -196,13 +196,6 @@ test('_getPageURISrcset with the most elements in srcset', () => {
   expect(br._getPageURISrcset(5, 35, undefined)).toBe("correctURL.png&scale=16 2x, correctURL.png&scale=8 4x, correctURL.png&scale=4 8x, correctURL.png&scale=2 16x, correctURL.png&scale=1 32x");
 });
 
-test('_getPageURISrcset with undefined reduce param', () => {
-  br._models.book.getNumLeafs = jest.fn(() => 30);
-  br._models.book.getPageURI = jest.fn((index, scale, rotate) => "correctURL.png&scale=" + scale);
-  br.init();
-  expect(br._getPageURISrcset(5, undefined, undefined)).toBe("correctURL.png&scale=16 2x, correctURL.png&scale=8 4x, correctURL.png&scale=4 8x, correctURL.png&scale=2 16x, correctURL.png&scale=1 32x");
-});
-
 describe('quantizeReduce', () => {
   const quantizeReduce = BookReader.prototype.quantizeReduce;
   const SAMPLE_FACTORS = [

--- a/tests/BookReader/ImageCache.test.js
+++ b/tests/BookReader/ImageCache.test.js
@@ -1,6 +1,7 @@
 import sinon from 'sinon';
 import { BookModel } from '../../src/js/BookReader/BookModel.js';
 import { ImageCache } from '../../src/js/BookReader/ImageCache.js';
+import { Pow2ReduceSet } from '../../src/js/BookReader/ReduceSet.js';
 /** @typedef {import('../../src/js/BookReader/options.js').BookReaderOptions} BookReaderOptions */
 
 afterEach(() => {
@@ -29,14 +30,16 @@ const SAMPLE_DATA = [
 describe('Image Cache', () => {
   describe('`image` call', () => {
     test('calling `image` will create an image if none is cached', () => {
-      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA }));
+      const reduceSet = Pow2ReduceSet;
+      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA, reduceSet }), reduceSet);
       ic.cache = {};
       ic.image(1, 5);
       expect(Object.keys(ic.cache).length).toBe(1);
       expect(ic.cache['1'].length).toBe(1);
     });
     test('will pull from cache if image of a good quality has been stored', () => {
-      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA }));
+      const reduceSet = Pow2ReduceSet;
+      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA, reduceSet }), reduceSet);
       const serveImgElSpy = sinon.spy(ic, '_serveImageElement');
       ic.cache = CACHE_MOCK;
       ic.image(1, 5);
@@ -46,31 +49,36 @@ describe('Image Cache', () => {
 
   describe('`imageLoaded` call', () => {
     test('returns true if image in cache', () => {
-      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA }));
+      const reduceSet = Pow2ReduceSet;
+      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA, reduceSet }), reduceSet);
       ic.cache = CACHE_MOCK;
       const isImgLoaded = ic.imageLoaded(1, 3);
       expect(isImgLoaded).toBe(true);
     });
     test('returns true if image reducer in cache is good enough', () => {
-      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA }));
+      const reduceSet = Pow2ReduceSet;
+      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA, reduceSet }), reduceSet);
       ic.cache = CACHE_MOCK;
       const isImgLoaded = ic.imageLoaded(1, 5);
       expect(isImgLoaded).toBe(true);
     });
     test('returns false if no image in cache', () => {
-      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA }));
+      const reduceSet = Pow2ReduceSet;
+      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA, reduceSet }), reduceSet);
       ic.cache = CACHE_MOCK;
       const isImgLoaded = ic.imageLoaded(2, 3);
       expect(isImgLoaded).toBe(false);
     });
     test('returns false if reducer to check is better than cache', () => {
-      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA }));
+      const reduceSet = Pow2ReduceSet;
+      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA, reduceSet }), reduceSet);
       ic.cache = CACHE_MOCK;
       const isImgLoaded = ic.imageLoaded(1, 2);
       expect(isImgLoaded).toBe(false);
     });
     test('returns false if image has not loaded', () => {
-      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA }));
+      const reduceSet = Pow2ReduceSet;
+      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA, reduceSet }), reduceSet);
       ic.cache = { 1: [{ reduce: 4, loaded: false }] };
       const isImgLoaded = ic.imageLoaded(1, 2);
       expect(isImgLoaded).toBe(false);
@@ -79,13 +87,15 @@ describe('Image Cache', () => {
 
   describe('`getBestLoadedReduce` call', () => {
     test('handles empty cache', () => {
-      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA }));
+      const reduceSet = Pow2ReduceSet;
+      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA, reduceSet }), reduceSet);
       ic.cache = {};
       expect(ic.getBestLoadedReduce(0)).toBeNull();
     });
 
     test('handles empty page-level cache', () => {
-      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA }));
+      const reduceSet = Pow2ReduceSet;
+      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA, reduceSet }), reduceSet);
       ic.cache = { 0: [] };
       expect(ic.getBestLoadedReduce(0)).toBeNull();
       ic.cache = { 0: [{ reduce: 10, loaded: false }] };
@@ -93,13 +103,15 @@ describe('Image Cache', () => {
     });
 
     test('chooses highest quality sufficient image', () => {
-      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA }));
+      const reduceSet = Pow2ReduceSet;
+      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA, reduceSet }), reduceSet);
       ic.cache = { 0: [{ reduce: 1, loaded: true }, { reduce: 4, loaded: true }, { reduce: 10, loaded: true }] };
       expect(ic.getBestLoadedReduce(0, 5)).toBe(10);
     });
 
     test('chooses closest image if no lower images', () => {
-      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA }));
+      const reduceSet = Pow2ReduceSet;
+      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA, reduceSet }), reduceSet);
       ic.cache = { 0: [{ reduce: 1, loaded: true }, { reduce: 4, loaded: true }] };
       expect(ic.getBestLoadedReduce(0, 5)).toBe(4);
     });
@@ -107,7 +119,8 @@ describe('Image Cache', () => {
 
   describe('`_serveImageElement` call', () => {
     test('returns jQuery image element', () => {
-      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA }));
+      const reduceSet = Pow2ReduceSet;
+      const ic = new ImageCache(new BookModel({ data: SAMPLE_DATA, reduceSet }), reduceSet);
       const img = ic._serveImageElement(0);
       expect($(img).length).toBe(1);
       expect($(img)[0].classList.contains('BRpageimage')).toBe(true);
@@ -115,20 +128,22 @@ describe('Image Cache', () => {
     });
 
     test('does not set srcset when useSrcSet=false', () => {
+      const reduceSet = Pow2ReduceSet;
       const ic = new ImageCache(
-        new BookModel({ data: SAMPLE_DATA }),
-        { useSrcSet: false },
+        new BookModel({ data: SAMPLE_DATA, reduceSet }),
+        { useSrcSet: false, reduceSet },
       );
       const $img = ic._serveImageElement(0);
       expect($img[0].hasAttribute('srcset')).toBe(false);
     });
 
-    test('sets srcset when useSrcSet=false', () => {
+    test('sets srcset when useSrcSet=true', () => {
+      const reduceSet = Pow2ReduceSet;
       const ic = new ImageCache(
-        new BookModel({ data: SAMPLE_DATA }),
-        { useSrcSet: true },
+        new BookModel({ data: SAMPLE_DATA, reduceSet }),
+        { useSrcSet: true, reduceSet },
       );
-      const $img = ic._serveImageElement(0);
+      const $img = ic._serveImageElement(0, 9);
       expect($img.attr('srcset')).toBeTruthy();
     });
   });

--- a/tests/BookReader/ReduceSet.test.js
+++ b/tests/BookReader/ReduceSet.test.js
@@ -1,0 +1,38 @@
+import {IntegerReduceSet, Pow2ReduceSet} from '../../src/js/BookReader/ReduceSet.js';
+
+describe('IntegerReduceSet', () => {
+  test('floor', () => {
+    const f = IntegerReduceSet.floor;
+    expect(f(1)).toBe(1);
+    expect(f(3)).toBe(3);
+    expect(f(3.1)).toBe(3);
+    expect(f(3.5)).toBe(3);
+    expect(f(3.9)).toBe(3);
+  });
+
+  test('decr', () => {
+    const f = IntegerReduceSet.decr;
+    expect(f(1)).toBe(0);
+    expect(f(3)).toBe(2);
+    expect(f(0)).toBe(-1);
+  });
+});
+
+describe('Pow2ReduceSet', () => {
+  test('floor', () => {
+    const f = Pow2ReduceSet.floor;
+    expect(f(1)).toBe(1);
+    expect(f(3)).toBe(2);
+    expect(f(3.5)).toBe(2);
+    expect(f(4.1)).toBe(4);
+    expect(f(8)).toBe(8);
+  });
+
+  test('decr', () => {
+    const f = Pow2ReduceSet.decr;
+    expect(f(1)).toBe(0.5);
+    expect(f(2)).toBe(1);
+    expect(f(4)).toBe(2);
+    expect(f(8)).toBe(4);
+  });
+});


### PR DESCRIPTION
Before/After of ImageCache.cache when zooming in 3 times in 2up mode:

![image](https://user-images.githubusercontent.com/6251786/113787459-0fc4fd00-9709-11eb-976d-f100a2a966c1.png)

The cache now knows to only care about pow2 values.