### PR TITLE
Fix: Load order + rm tiny image requests during loading

### DIFF
--- a/src/BookNavigator/BookNavigator.js
+++ b/src/BookNavigator/BookNavigator.js
@@ -269,6 +269,7 @@ export class BookNavigator extends LitElement {
     });
     window.addEventListener('BRJSIA:PostInit', ({ detail }) => {
       const { isRestricted, downloadURLs } = detail;
+      this.bookReaderLoaded = true;
       this.downloadableTypes = downloadURLs;
       this.model.setRestriction(isRestricted);
     });


### PR DESCRIPTION
 Remove loading indicator after JSIA init

The slow part of loading is the loading of the BR JSIA ; once that's done we're good. This also fixes an issue with requests being made for very tiny images during load.

Note there is a petabox-side change which delays the `br.init()` to remove the small image requests; it seems like otherwise it's happening too soon.

