### PR TITLE
Split CI into 3 jobs

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
@@ -20,9 +19,19 @@ jobs:
         node-version: 14.x
     - run: npm install
     - run: npm run build
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
     - run: npm run lint
     - run: npm run test
     - run: npm run codecov
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
     # Travis machines usually have 2 cores (see https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system )
     # Quarantine mode (sigh) to catch unstable tests (see https://devexpress.github.io/testcafe/documentation/guides/basic-guides/run-tests.html#quarantine-mode )
     - run: BASE_URL=http://127.0.0.1:8000/BookReaderDemo/ npx testcafe --concurrency 2 --quarantine-mode


### PR DESCRIPTION
E2E tests always take the longest, so let's run them concurrently with the other tests and on a separate GitHub Actions Job.