### PR TITLE
Fix BookReader erroring on older iOS

### DIFF
--- a/src/js/BookReader.js
+++ b/src/js/BookReader.js
@@ -21,7 +21,12 @@ This file is part of BookReader.
 */
 // effect.js gives acces to extra easing function (e.g. easeInOutExpo)
 import 'jquery-ui/ui/effect.js';
+
+// Needed by touch-punch
+import 'jquery-ui/ui/widget.js';
+import 'jquery-ui/ui/widgets/mouse.js';
 import 'jquery-ui-touch-punch';
+
 import './dragscrollable-br.js';
 import PACKAGE_JSON from '../../package.json';
 import * as utils from './BookReader/utils.js';


### PR DESCRIPTION
Was getting a "e.ui.mouse.prototype" is undefined error (or something)
on iOS (tested 8-12, errored on all), preventing me from testing there.
Turns out we need some more pieces from jquery-ui for touch-punch.

Oooh, this also fixed it on FF Mobile!
Build file went up ~5kb.

Testing: Confirm https://deploy-preview-731--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=theworksofplato01platiala working on iOS 11 . 