### PR TITLE
feat(text-selection): clickable URLs in OCR text layer

### DIFF
--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -216,3 +216,18 @@
     background-color: hsla(45, 80%, 66%, 0.6);
     color: transparent;
 }
+
+// Clickable URLs detected in the OCR text layer
+.BRtextLayer a.BRurlLink {
+    // Text stays transparent (overlaid on the page image); show an underline for discoverability
+    text-decoration: underline;
+    text-decoration-color: hsla(210, 74%, 50%, 0.6);
+    text-decoration-thickness: 1px;
+    pointer-events: all;
+    cursor: pointer;
+
+    &:hover {
+        text-decoration-color: hsla(210, 74%, 40%, 1);
+        text-decoration-thickness: 2px;
+    }
+}

--- a/src/plugins/plugin.text_selection.js
+++ b/src/plugins/plugin.text_selection.js
@@ -261,7 +261,19 @@ export class TextSelectionPlugin extends BookReaderPlugin {
 
         const wordEl = document.createElement('span');
         wordEl.setAttribute("class", "BRwordElement");
-        wordEl.textContent = currWord.textContent.trim();
+        const wordText = currWord.textContent.trim();
+        const urlHref = extractUrl(wordText);
+        if (urlHref) {
+          const a = document.createElement('a');
+          a.href = urlHref;
+          a.target = '_blank';
+          a.rel = 'noopener noreferrer';
+          a.classList.add('BRurlLink');
+          a.textContent = wordText;
+          wordEl.appendChild(a);
+        } else {
+          wordEl.textContent = wordText;
+        }
 
         if (wordIndex > 0) {
           const space = document.createElement('span');
@@ -560,6 +572,20 @@ function recursivelyAddCoords(xmlEl) {
   if (Math.abs(boundingCoords[0]) != Infinity) {
     $(xmlEl).attr('coords', boundingCoords.join(','));
   }
+}
+
+/**
+ * If text looks like a URL, return a normalized href; otherwise return null.
+ * Strips trailing punctuation that OCR commonly attaches to URLs.
+ * @param {string} text
+ * @returns {string|null}
+ */
+function extractUrl(text) {
+  const stripped = text.replace(/[.,;:!?)\]]+$/, '');
+  if (stripped.length < 5) return null;
+  if (/^https?:\/\/.{3,}/i.test(stripped)) return stripped;
+  if (/^www\.\w{2,}/i.test(stripped)) return `https://${stripped}`;
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Detects words in the OCR text layer that look like URLs and makes them
clickable links, so readers can follow links printed in scanned books.

## How it works

In `renderParagraph`, each word's text is tested against `extractUrl()`.
If it matches, an `<a class="BRurlLink">` is nested **inside** the
`BRwordElement` span rather than wrapping it — this preserves the
existing layout/letter-spacing machinery which relies on `wordEl` being
a direct child of `BRlineElement`.

**`extractUrl(text)`** (new helper):
- Strips trailing OCR punctuation (`. , ; : ! ? ) ]`) before testing
- Requires `http://` or `https://` with ≥3 chars of path/domain, **or**
  `www.<word>` with ≥2 chars (normalised to `https://`)
- Returns `null` for anything too short (<5 chars) or non-matching
- Rejects bare `http` / `www.` tokens that OCR emits at line-breaks

**Security**: all links get `target="_blank" rel="noopener noreferrer"`.

**Visual indicator**: `text-decoration-color` gives a blue underline that
is visible even though the text layer itself is transparent.

## What was dropped from the original PR

The original branch (2021–2022) also included an entity-popup system
that pulled named entities from a Google Spreadsheet and showed
Wikipedia summaries + OL book carousels. That system depended on a
Google Sheets JSON API that Google discontinued, and the popup UI was
still a rough draft. It has been omitted here — the URL feature is
self-contained and ready to ship.

## Changes

- `src/plugins/plugin.text_selection.js`: `extractUrl()` helper + word
  wrapping in `renderParagraph`
- `src/css/_TextSelection.scss`: `.BRtextLayer a.BRurlLink` styles

## Testing

Open any archive.org book that contains printed URLs or web addresses in
the scanned text. With the text layer enabled, URLs should appear with
a faint blue underline and be clickable.