### PR TITLE
bookmarks login add a.o no-sampling ping & update ia demo basehost param

### DIFF
--- a/src/BookNavigator/bookmarks/bookmarks-loginCTA.js
+++ b/src/BookNavigator/bookmarks/bookmarks-loginCTA.js
@@ -25,7 +25,7 @@ class BookmarksLogin extends LitElement {
 
     return html`
       <p>A free account is required to save and access bookmarks.</p>
-      <a class="ia-button link primary" href=${this.url}>Log in</a>
+      <a class="ia-button link primary" href="${this.url}">Log in</a>
     `;
   }
 }

--- a/src/BookNavigator/bookmarks/bookmarks-provider.js
+++ b/src/BookNavigator/bookmarks/bookmarks-provider.js
@@ -13,7 +13,7 @@ customElements.define('icon-bookmark', IAIconBookmark);
 
 export default class BookmarksProvider {
   constructor(options, bookreader) {
-    const boundOptions = Object.assign(this, options);
+    const boundOptions = Object.assign(this, options, {loginClicked: this.bookmarksLoginClicked});
     this.component = document.createElement('ia-bookmarks');
     this.component.bookreader = bookreader;
     this.component.options = boundOptions;
@@ -41,5 +41,15 @@ export default class BookmarksProvider {
     const bookmarksLength = Object.keys(detail.bookmarks).length;
     this.updateMenu(bookmarksLength);
     this.onBookmarksChanged(detail.bookmarks);
+  }
+
+  bookmarksLoginClicked() {
+    if (window.archive_analytics) {
+      window.archive_analytics?.send_event_no_sampling(
+        'BookReader',
+        `BookmarksLogin`,
+        window.location.path,
+      );
+    }
   }
 }

--- a/src/BookNavigator/bookmarks/ia-bookmarks.js
+++ b/src/BookNavigator/bookmarks/ia-bookmarks.js
@@ -432,6 +432,14 @@ class IABookmarks extends LitElement {
   }
 
   /**
+   * call `loginClicked` callback
+   */
+  loginClick() {
+    const { loginClicked = () => {} } = this.options;
+    loginClicked();
+  }
+
+  /**
    * Tells us if we should allow user to add bookmark via menu panel
    * returns { Boolean }
    */
@@ -483,7 +491,7 @@ class IABookmarks extends LitElement {
     `;
     return html`
       <section class="bookmarks">
-        ${this.displayMode === 'login' ? html`<bookmarks-login .url=${loginUrl}></bookmarks-login>` : bookmarks}
+        ${this.displayMode === 'login' ? html`<bookmarks-login @click=${this.loginClick} .url=${loginUrl}></bookmarks-login>` : bookmarks}
       </section>
     `;
   }


### PR DESCRIPTION
Adding a.o bean counter for bookmarks login clicks
+ update demo to pass proper `baseHost` param

Testing:
go to staging server using incognito browser & open network tab -> open side menu -> go to bookmarks -> login -> confirm no sampling event firing