### PR TITLE
booknav: only resize bookreader if it is not animating on first update

### DIFF
--- a/src/BookNavigator/BookNavigator.js
+++ b/src/BookNavigator/BookNavigator.js
@@ -69,8 +69,11 @@ export class BookNavigator extends LitElement {
       return;
     }
     const isFirstSideMenuUpdate = changed.has('sideMenuOpen') && (changed.get('sideMenuOpen') === undefined);
-    if (!isFirstSideMenuUpdate && changed.has('sideMenuOpen')) {
+    if (!isFirstSideMenuUpdate) {
       // realign image
+      if (this.bookreader.animating) {
+        return;
+      }
       this.bookreader.resize();
       const curIndex = this.bookreader.currentIndex();
       this.bookreader.jumpToIndex(curIndex);

--- a/tests/karma/BookNavigator/book-navigator.test.js
+++ b/tests/karma/BookNavigator/book-navigator.test.js
@@ -111,4 +111,22 @@ describe('<book-navigator>', () => {
     expect(el.bookreader.currentIndex.callCount).to.equal(2);
     expect(el.bookreader.jumpToIndex.callCount).to.equal(2);
   });
+  it('does not resize bookreader if animating', async () => {
+    const el = fixtureSync(container());
+    const brStub = {
+      animating: true, // <-- testing for this
+      resize: sinon.fake(),
+      currentIndex: sinon.fake(),
+      jumpToIndex: sinon.fake()
+    }
+    el.bookreader = brStub;
+    await elementUpdated(el);
+
+    el.sideMenuOpen = true;
+    await elementUpdated(el);
+
+    expect(el.bookreader.resize.callCount).to.equal(0);
+    expect(el.bookreader.currentIndex.callCount).to.equal(0);
+    expect(el.bookreader.jumpToIndex.callCount).to.equal(0);
+  });
 });


### PR DESCRIPTION
Problem:
- when a page request starts with a search & no page provided in the params, page turning breaks.

Solution:
- do not resize if bookreader is animating

Testing:
- ...