### PR TITLE
Fullscreen toggle - wrap in animation flags so BookNav knows that core is animating

### DIFF
--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -1128,10 +1128,11 @@ BookReader.prototype.enterFullscreen = function(bindKeyboardControls = true) {
   }
 
   this.isFullscreenActive = true;
-
+  this.animating = true;
   this.refs.$brContainer.animate({opacity: 1}, 'fast', 'linear',() => {
     this.resize();
     this.jumpToIndex(currentIndex);
+    this.animating = false;
   });
 
   this.textSelectionPlugin?.stopPageFlip(this.refs.$brContainer);
@@ -1159,9 +1160,10 @@ BookReader.prototype.exitFullScreen = function() {
 
   this.isFullscreenActive = false;
   this.updateBrClasses();
-
+  this.animating = true;
   this.refs.$brContainer.animate({opacity: 1}, 'fast', 'linear', () => {
     this.resize();
+    this.animating = false;
   });
   this.textSelectionPlugin?.stopPageFlip(this.refs.$brContainer);
   this.trigger(BookReader.eventNames.fullscreenToggled);


### PR DESCRIPTION
Problem:
During 1up mode, when toggling fullscreen, booknav's resize caller is breaking fullscreen animation mid-way through.  Result is Black page - the actual page is there, just unseen

Solution:
set animation flags during fullscreen animation

Tech note: - animation sets `opacity` directly to `BRContainer` and gradually changes it from 0 - 1. In order to ensure that there isn't a race condition, we need to set `this.animating` flag at the beginning & unset at the end of the animation.

