### PR TITLE
Add node_modules caching to GitHub Actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,6 +18,15 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 14.x
+    - uses: actions/cache@v2
+      with:
+        # Caching node_modules isn't recommended because it can break across
+        # Node versions and won't work with npm ci (See https://github.com/actions/cache/blob/main/examples.md#node---npm )
+        # But we pin the node version, and we don't update it that often anyways. And 
+        # we don't use `npm ci` specifically to try to get faster CI flows. So caching
+        # `node_modules` directly.
+        path: 'node_modules'
+        key: ${{ runner.os }}-node-${{ hashFiles('package*.json') }}
     - run: npm install
     - run: npm run build
     - run: npm run lint


### PR DESCRIPTION
Shaves off ~30 seconds off CI.

First time: npm i took 37s (4m29 total)
Second time: npm i took 10s (3m6 total)