### PR TITLE
Add jsonp support to textsel fetches + Netlify CORS support

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[headers]]
+  # Define which paths this specific [[headers]] block will cover.
+  for = "/BookReader/*"
+    [headers.values]
+    Access-Control-Allow-Origin = "*"

--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -1,4 +1,6 @@
 .textSelectionSVG {
+    z-index: 2;
+
     // Make it so right-clicking on "blank" part of svg sends events to the image (for saving)
     pointer-events: none;
     .BRwordElement { pointer-events: all; }

--- a/src/plugins/plugin.text_selection.js
+++ b/src/plugins/plugin.text_selection.js
@@ -13,6 +13,8 @@ export const DEFAULT_OPTIONS = {
   fullDjvuXmlUrl: null,
   /** @type {StringWithVars} The URL to fetch a single page of the DJVU xml. Supports options.vars. Also has {{pageIndex}} */
   singlePageDjvuXmlUrl: null,
+  /** Whether to fetch the XML as a jsonp */
+  jsonp: false,
 };
 /** @typedef {typeof DEFAULT_OPTIONS} TextSelectionPluginOptions */
 
@@ -74,7 +76,8 @@ export class TextSelectionPlugin {
     this.djvuPagesPromise = $.ajax({
       type: "GET",
       url: applyVariables(this.options.fullDjvuXmlUrl, this.optionVariables),
-      dataType: "html",
+      dataType: this.options.jsonp ? "jsonp" : "html",
+      cache: true,
       error: (e) => undefined
     }).then((res) => {
       try {
@@ -99,7 +102,8 @@ export class TextSelectionPlugin {
       const res = await $.ajax({
         type: "GET",
         url: applyVariables(this.options.singlePageDjvuXmlUrl, this.optionVariables, { pageIndex: index }),
-        dataType: "html",
+        dataType: this.options.jsonp ? "jsonp" : "html",
+        cache: true,
         error: (e) => undefined,
       });
       try {


### PR DESCRIPTION
CORS endpoint isn't enabled for protected endpoints, so need to use JSONP.

Note in a completely unrelated change I added cors support to netlify so we can pull from the netlify build from archive.org review apps!