### PR TITLE
Remove word "Page" from navbar

### DIFF
--- a/src/BookReader/Navbar/Navbar.js
+++ b/src/BookReader/Navbar/Navbar.js
@@ -331,9 +331,9 @@ export function getNavPageNumHtml(index, numLeafs, pageNum, pageType, maxPageNum
 
   if (!pageIsAsserted) {
     const pageIndex = index + 1;
-    return `Page (${pageIndex} of ${numLeafs})`; // Page (8 of 10)
+    return `(${pageIndex} of ${numLeafs})`; // Page (8 of 10)
   }
 
   const bookLengthLabel = maxPageNum ? ` of ${maxPageNum}` : '';
-  return `Page ${pageNum}${bookLengthLabel}`;
+  return `${pageNum}${bookLengthLabel}`;
 }

--- a/tests/BookReader/Navbar/Navbar.test.js
+++ b/tests/BookReader/Navbar/Navbar.test.js
@@ -5,15 +5,15 @@ import BookReader from '../../../src/BookReader.js';
 describe('getNavPageNumHtml', () => {
   const f = getNavPageNumHtml;
   test('handle n-prefixed page numbers', () => {
-    expect(f(3, 40, 'n3', '', 40)).toBe('Page (4 of 40)');
+    expect(f(3, 40, 'n3', '', 40)).toBe('(4 of 40)');
   });
 
   test('handle regular page numbers', () => {
-    expect(f(3, 40, '14', '', 40)).toBe('Page 14 of 40');
+    expect(f(3, 40, '14', '', 40)).toBe('14 of 40');
   });
 
   test('handle no max page', () => {
-    expect(f(3, 40, '14', '', null)).toBe('Page 14');
+    expect(f(3, 40, '14', '', null)).toBe('14');
   });
 });
 


### PR DESCRIPTION
Make the mobile scroller a little less cramped.

<img src="https://user-images.githubusercontent.com/6251786/120564461-f96db180-c3d8-11eb-9447-32567933c316.png" width="300">
