### PR TITLE
sharing panel - add subfile awareness

### DIFF
--- a/src/BookNavigator/BookNavigator.js
+++ b/src/BookNavigator/BookNavigator.js
@@ -135,7 +135,7 @@ export class BookNavigator extends LitElement {
         bookContainerSelector: this.pageContainerSelector,
         bookreader: this.bookreader,
       }),
-      share: new SharingProvider(this.book.metadata, this.baseHost, this.itemType),
+      share: new SharingProvider(this.book.metadata, this.baseHost, this.itemType, this.bookreader.options.subPrefix),
       bookmarks: new BookmarksProvider(this.bookmarksOptions, this.bookreader),
     };
 

--- a/src/BookNavigator/volumes/volumes-provider.js
+++ b/src/BookNavigator/volumes/volumes-provider.js
@@ -38,7 +38,7 @@ export default class VolumesProvider {
   }
 
   get headerIcon() {
-    return this.isSortAscending ? this.sortAscendingIcon : this.sortDescendingIcon;
+    return this.isSortAscending ? this.sortDescendingIcon : this.sortAscendingIcon;
   }
 
   sortVolumes() {

--- a/src/BookNavigator/volumes/volumes-provider.js
+++ b/src/BookNavigator/volumes/volumes-provider.js
@@ -55,7 +55,7 @@ export default class VolumesProvider {
     } else {
       this.isFirstLoad = false;
     }
-    const volumesOrderBy = this.isSortAscending ? "ascending" : "descending";
+    const volumesOrderBy = this.isSortAscending ? 'asc' : 'desc';
     this.multipleFilesClicked(volumesOrderBy);
   }
 

--- a/src/BookNavigator/volumes/volumes.js
+++ b/src/BookNavigator/volumes/volumes.js
@@ -20,7 +20,7 @@ export class Volumes extends LitElement {
 
   firstUpdated() {
     const activeFile = this.shadowRoot.querySelector('.content.active');
-
+    // allow for css animations to run before scrolling to active file
     setTimeout(() => {
       // scroll active file into view if needed
       // note: `scrollIntoViewIfNeeded` handles auto-scroll gracefully for Chrome, Safari
@@ -32,7 +32,6 @@ export class Volumes extends LitElement {
 
       // Todo: support `scrollIntoView` or `parentContainer.crollTop = x` for FF & "IE 11"
       // currently, the hard `position: absolutes` misaligns subpanel when `scrollIntoView` is applied :(
-
     }, 350);
   }
 

--- a/src/BookNavigator/volumes/volumes.js
+++ b/src/BookNavigator/volumes/volumes.js
@@ -18,6 +18,24 @@ export class Volumes extends LitElement {
     this.viewableFiles = [];
   }
 
+  firstUpdated() {
+    const activeFile = this.shadowRoot.querySelector('.content.active');
+
+    setTimeout(() => {
+      // scroll active file into view if needed
+      // note: `scrollIntoViewIfNeeded` handles auto-scroll gracefully for Chrome, Safari
+      // Firefox does not have this capability yet as it does not support `scrollIntoViewIfNeeded`
+      if (activeFile?.scrollIntoViewIfNeeded) {
+        activeFile?.scrollIntoViewIfNeeded(true);
+        return;
+      }
+
+      // Todo: support `scrollIntoView` or `parentContainer.crollTop = x` for FF & "IE 11"
+      // currently, the hard `position: absolutes` misaligns subpanel when `scrollIntoView` is applied :(
+
+    }, 350);
+  }
+
   volumeItemWithImageTitle(item) {
     return html`
       <li class="content active">

--- a/src/ItemNavigator/providers/sharing.js
+++ b/src/ItemNavigator/providers/sharing.js
@@ -9,7 +9,6 @@ export default class {
     const { identifier, creator, title } = metadata;
     const encodedSubPrefix = encodeURIComponent(subPrefix);
     const urlIdentifier = subPrefix && (subPrefix !== identifier) ? `${identifier}/${encodedSubPrefix}` : identifier;
-    console.log("** SHARING", urlIdentifier, subPrefix);
     this.itemType = baseItemType;
     const label = `Share this ${this.reconcileItemType}`;
     this.icon = html`<ia-icon icon="share" style="width: var(--iconWidth); height: var(--iconHeight);"></ia-icon>`;

--- a/src/ItemNavigator/providers/sharing.js
+++ b/src/ItemNavigator/providers/sharing.js
@@ -9,6 +9,7 @@ export default class {
     const { identifier, creator, title } = metadata;
     const encodedSubPrefix = encodeURIComponent(subPrefix);
     const urlIdentifier = subPrefix && (subPrefix !== identifier) ? `${identifier}/${encodedSubPrefix}` : identifier;
+    this.idPath = urlIdentifier;
     this.itemType = baseItemType;
     const label = `Share this ${this.reconcileItemType}`;
     this.icon = html`<ia-icon icon="share" style="width: var(--iconWidth); height: var(--iconHeight);"></ia-icon>`;

--- a/src/ItemNavigator/providers/sharing.js
+++ b/src/ItemNavigator/providers/sharing.js
@@ -5,17 +5,21 @@ import { IASharingOptions } from '@internetarchive/ia-sharing-options';
 customElements.define('ia-sharing-options', IASharingOptions);
 
 export default class {
-  constructor(metadata = {}, baseHost, baseItemType) {
+  constructor(metadata = {}, baseHost, baseItemType, subPrefix = '') {
+    const { identifier, creator, title } = metadata;
+    const encodedSubPrefix = encodeURIComponent(subPrefix);
+    const urlIdentifier = subPrefix && (subPrefix !== identifier) ? `${identifier}/${encodedSubPrefix}` : identifier;
+    console.log("** SHARING", urlIdentifier, subPrefix);
     this.itemType = baseItemType;
     const label = `Share this ${this.reconcileItemType}`;
     this.icon = html`<ia-icon icon="share" style="width: var(--iconWidth); height: var(--iconHeight);"></ia-icon>`;
     this.label = label;
     this.id = 'share';
     this.component = html`<ia-sharing-options
-      identifier="${metadata.identifier}"
+      identifier="${urlIdentifier}"
       type="book"
-      creator="${metadata.creator}"
-      description="${metadata.title}"
+      creator="${creator}"
+      description="${title}"
       baseHost="${baseHost}"
     ></ia-sharing-options>`;
   }

--- a/tests/karma/BookNavigator/sharing/sharing-provider.test.js
+++ b/tests/karma/BookNavigator/sharing/sharing-provider.test.js
@@ -1,0 +1,40 @@
+import { expect } from '@open-wc/testing';
+import sinon from 'sinon';
+import sharingProvider from '../../../../src/ItemNavigator/providers/sharing.js';
+
+afterEach(() => {
+  sinon.restore();
+});
+
+const mdStub = {
+  identifier: 'stubby-id'
+};
+
+const baseHostStub = 'foo.org';
+const itemType = 'texts';
+const subPrefix = 'beep-boop_12 4 5';
+
+describe('Sharing Provider', () => {
+  describe('constructor', () => {
+    const provider = new sharingProvider(mdStub, baseHostStub, itemType, subPrefix);
+
+    expect(provider.id).to.equal('share');
+    expect(provider.icon).to.exist;
+    expect(provider.label).to.equal('Share this item');
+    expect(provider.itemType).to.equal(itemType);
+    expect(provider.idPath).to.exist;
+    expect(provider.component).to.exist;
+  });
+
+  describe('handles subprefix', () => {
+    it('encodes the subprefix if it has one', () => {
+      const provider = new sharingProvider(mdStub, baseHostStub, itemType, subPrefix);
+      const encodedSubprefix = encodeURIComponent(subPrefix);
+      expect(provider.idPath).to.equal(`${mdStub.identifier}/${encodedSubprefix}`);
+    });
+    it('does not add subprefix to path if subprefix is item id', () => {
+      const provider = new sharingProvider(mdStub, baseHostStub, itemType, mdStub.identifier);
+      expect(provider.idPath).to.equal(mdStub.identifier);
+    });
+  });
+});


### PR DESCRIPTION
### Testing
1. go to: https://www-isa2.archive.org/details/tijdschrift-de-as/de_AS_104-105%20-%20België/page/19/mode/2up
2. open multiple-files panel using shortcut -> menu opens & active file can be seen in view. 👍 
3. scroll to any file & select => page refreshes to display the new subfile
4. open multiple-files panel using shortcut -> menu opens & active file can be seen in view. 👍 
5. open sharing panel -> share file with your chosen provider -> note that the url has `/details/<id>/<encodedFilePath>`
6. copy & paste that url in a new window -> takes you to /details page with subfile.

### Updates:
- **Scroll active file into view at first panel open - helps when list is long**
  - opting for first update as of now so that we do not conflict with list sort behavior
  - UI issue: `scrollIntoView` is borking the menu panel styling by lifting up the parent container as it scrolls.  From debugging, this is a possible result of many layers of `position: absolute` in the side menu.
    - ✅ `scrollIntoViewIfNeeded` actually handles the auto scroll gracefully but is not supported by FF.
      - we will start with this so that we can provide some UX support when dealing with a long subfile list.
      - the fix for `scrollIntoView` must be isolated so that we can fix it at the root & reorder elemental style at the side panel level.  
  - ![ezgif com-gif-maker (13)](https://user-images.githubusercontent.com/7840857/121648349-44786c00-ca4c-11eb-8a1a-ff162c66b26d.gif)

- **Sharing panel now has subprefix awareness**
  - ![image](https://user-images.githubusercontent.com/7840857/121646988-bc459700-ca4a-11eb-981a-a9fce713cfce.png)
