### PR TITLE
Subfiles sort updates: sort icons, labelling, open on load

### DIFF
--- a/src/BookNavigator/BookNavigator.js
+++ b/src/BookNavigator/BookNavigator.js
@@ -118,7 +118,7 @@ export class BookNavigator extends LitElement {
           const wideEnoughToOpenMenu = this.brWidth >= 640;
           if (wideEnoughToOpenMenu && !searchUpdates?.searchCanceled) {
             /* open side search menu */
-            this.updateSearchSideMenu('open');
+            this.updateSideMenu('search', 'open');
           }
         },
         this.bookreader,
@@ -147,6 +147,7 @@ export class BookNavigator extends LitElement {
           this.bookreader = brInstance;
         }
         this.updateMenuContents();
+        this.updateSideMenu('volumes', 'open');
       });
       this.addMenuShortcut('volumes');
     }
@@ -176,13 +177,17 @@ export class BookNavigator extends LitElement {
   }
 
   /**
-   * Open side search menu
+   * Open side menu
+   * @param {string} menuId
    * @param {('open'|'close'|'toggle')} action
    */
-  updateSearchSideMenu(action = 'open') {
+  updateSideMenu(menuId = '', action = 'open') {
+    if (!menuId || !action) {
+      return;
+    }
     const event = new CustomEvent(
       events.updateSideMenu, {
-        detail: { menuId: 'search', action },
+        detail: { menuId, action },
       },
     );
     this.dispatchEvent(event);

--- a/src/BookNavigator/assets/icon_sort_asc.js
+++ b/src/BookNavigator/assets/icon_sort_asc.js
@@ -1,0 +1,5 @@
+import { html } from 'lit-html';
+
+export default html`
+<svg name="sort-asc" height="18" viewBox="0 0 18 18" width="18" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="m2.32514544 8.30769231.7756949-2.08468003h2.92824822l.75630252 2.08468003h1.01809955l-2.70523594-6.92307693h-1.01809955l-2.69553976 6.92307693zm3.41305753-2.86037492h-2.34647705l1.17323853-3.22883h.01939237z" fill="#fff" fill-rule="nonzero"/><path d="m7.1689722 16.6153846v-.7756949h-4.4117647l4.29541047-5.3716871v-.77569491h-5.06140918v.77569491h3.97543633l-4.30510666 5.3716871v.7756949z" fill="#fff" fill-rule="nonzero"/><path d="m10.3846154 11.0769231 2.7692308 5.5384615 2.7692307-5.5384615m-2.7692307 4.1538461v-13.15384612" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.661538" transform="matrix(1 0 0 -1 0 18.692308)"/></g></svg>
+`;

--- a/src/BookNavigator/assets/icon_sort_ascending.js
+++ b/src/BookNavigator/assets/icon_sort_ascending.js
@@ -1,5 +1,0 @@
-import { html } from 'lit-html';
-
-export default html`
-<svg name="sort-ascending" height="18" viewBox="0 0 18 18" width="18" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="m2.32514544 8.30769231.7756949-2.08468003h2.92824822l.75630252 2.08468003h1.01809955l-2.70523594-6.92307693h-1.01809955l-2.69553976 6.92307693zm3.41305753-2.86037492h-2.34647705l1.17323853-3.22883h.01939237z" fill="#fff" fill-rule="nonzero"/><path d="m7.1689722 16.6153846v-.7756949h-4.4117647l4.29541047-5.3716871v-.77569491h-5.06140918v.77569491h3.97543633l-4.30510666 5.3716871v.7756949z" fill="#fff" fill-rule="nonzero"/><path d="m10.3846154 11.0769231 2.7692308 5.5384615 2.7692307-5.5384615m-2.7692307 4.1538461v-13.15384612" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.661538"/></g></svg>
-`;

--- a/src/BookNavigator/assets/icon_sort_desc.js
+++ b/src/BookNavigator/assets/icon_sort_desc.js
@@ -1,0 +1,5 @@
+import { html } from 'lit-html';
+
+export default html`
+<svg name="sort-desc" height="18" viewBox="0 0 18 18" width="18" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="m2.32514544 8.30769231.7756949-2.08468003h2.92824822l.75630252 2.08468003h1.01809955l-2.70523594-6.92307693h-1.01809955l-2.69553976 6.92307693zm3.41305753-2.86037492h-2.34647705l1.17323853-3.22883h.01939237z" fill="#fff" fill-rule="nonzero"/><path d="m7.1689722 16.6153846v-.7756949h-4.4117647l4.29541047-5.3716871v-.77569491h-5.06140918v.77569491h3.97543633l-4.30510666 5.3716871v.7756949z" fill="#fff" fill-rule="nonzero"/><path d="m10.3846154 11.0769231 2.7692308 5.5384615 2.7692307-5.5384615m-2.7692307 4.1538461v-13.15384612" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.661538"/></g></svg>
+`;

--- a/src/BookNavigator/assets/icon_sort_descending.js
+++ b/src/BookNavigator/assets/icon_sort_descending.js
@@ -1,5 +1,0 @@
-import { html } from 'lit-html';
-
-export default html`
-<svg name="sort-descending" height="18" viewBox="0 0 18 18" width="18" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="m2.32514544 8.30769231.7756949-2.08468003h2.92824822l.75630252 2.08468003h1.01809955l-2.70523594-6.92307693h-1.01809955l-2.69553976 6.92307693zm3.41305753-2.86037492h-2.34647705l1.17323853-3.22883h.01939237z" fill="#fff" fill-rule="nonzero"/><path d="m7.1689722 16.6153846v-.7756949h-4.4117647l4.29541047-5.3716871v-.77569491h-5.06140918v.77569491h3.97543633l-4.30510666 5.3716871v.7756949z" fill="#fff" fill-rule="nonzero"/><path d="m10.3846154 11.0769231 2.7692308 5.5384615 2.7692307-5.5384615m-2.7692307 4.1538461v-13.15384612" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.661538" transform="matrix(1 0 0 -1 0 18.692308)"/></g></svg>
-`;

--- a/src/BookNavigator/volumes/volumes-provider.js
+++ b/src/BookNavigator/volumes/volumes-provider.js
@@ -1,7 +1,7 @@
 import { html } from 'lit-element';
 
-import sortAscendingIcon from '../assets/icon_sort_ascending.js';
-import sortDescendingIcon from '../assets/icon_sort_descending.js';
+import sortDescIcon from '../assets/icon_sort_desc.js';
+import sortAscIcon from '../assets/icon_sort_asc.js';
 import sortNeutralIcon from '../assets/icon_sort_neutral.js';
 import volumesIcon from '../assets/icon_volumes.js';
 
@@ -35,10 +35,10 @@ export default class VolumesProvider {
         <button class="sort-by neutral-icon" aria-label="Sort volumes in initial order" @click=${() => this.sortVolumes("title_asc")}>${sortNeutralIcon}</button>
       `,
       title_asc: html`
-        <button class="sort-by asc-icon" aria-label="Sort volumes in ascending order" @click=${() => this.sortVolumes("title_desc")}>${sortAscendingIcon}</button>
+        <button class="sort-by asc-icon" aria-label="Sort volumes in ascending order" @click=${() => this.sortVolumes("title_desc")}>${sortAscIcon}</button>
       `,
       title_desc: html`
-        <button class="sort-by desc-icon" aria-label="Sort volumes in descending order" @click=${() => this.sortVolumes("orig_sort")}>${sortDescendingIcon}</button>
+        <button class="sort-by desc-icon" aria-label="Sort volumes in descending order" @click=${() => this.sortVolumes("orig_sort")}>${sortDescIcon}</button>
       `,
     };
 

--- a/src/BookNavigator/volumes/volumes.js
+++ b/src/BookNavigator/volumes/volumes.js
@@ -59,7 +59,7 @@ export class Volumes extends LitElement {
         <div class="separator"></div>
         <div class="content${activeClass}">
           <a href="https://${this.hostUrl}${item.url_path}">
-            <p class="item-title">${item.orig_sort + 1} ${item.title}</p>
+            <p class="item-title">${item.title}</p>
           </a>
         </div>
       </li>

--- a/tests/karma/BookNavigator/book-navigator.test.js
+++ b/tests/karma/BookNavigator/book-navigator.test.js
@@ -136,4 +136,49 @@ describe('<book-navigator>', () => {
     expect(el.bookreader.currentIndex.callCount).to.equal(0);
     expect(el.bookreader.jumpToIndex.callCount).to.equal(0);
   });
+
+  describe(`this.updateSideMenu`, () => {
+    it('emits custom event', async () => {
+      const el = fixtureSync(container());
+      const brStub = {
+        resize: sinon.fake(),
+        currentIndex: sinon.fake(),
+        jumpToIndex: sinon.fake(),
+        options: { enableMultipleBooks: true }
+      };
+      el.bookreader = brStub;
+      await elementUpdated(el);
+
+      let initEventFired = false;
+      let eventDetails = {};
+      el.addEventListener('updateSideMenu', (e) => {
+        eventDetails = e.detail;
+        initEventFired = true;
+      });
+
+      el.updateSideMenu('foo', 'open');
+      expect(initEventFired).to.equal(true);
+      expect(eventDetails.menuId).to.equal('foo');
+      expect(eventDetails.action).to.equal('open');
+    });
+    it('does not emit event if missing an arg', async() => {
+      const el = fixtureSync(container());
+      const brStub = {
+        resize: sinon.fake(),
+        currentIndex: sinon.fake(),
+        jumpToIndex: sinon.fake(),
+        options: { enableMultipleBooks: true }
+      };
+      el.bookreader = brStub;
+      await elementUpdated(el);
+
+      let initEventFired = false;
+      el.addEventListener('updateSideMenu', (e) => {
+        initEventFired = true;
+      });
+
+      el.updateSideMenu('', 'open');
+      expect(initEventFired).to.equal(false);
+    });
+  });
 });

--- a/tests/karma/BookNavigator/volumes/volumes-provider.test.js
+++ b/tests/karma/BookNavigator/volumes/volumes-provider.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@open-wc/testing';
+import { expect, fixture } from '@open-wc/testing';
 import sinon from 'sinon';
 import volumesProvider from '../../../../src/BookNavigator/volumes/volumes-provider';
 
@@ -138,4 +138,23 @@ describe('Volumes Provider', () => {
     expect(providerFileTitles).to.eql([...descendingTitles]);
   });
 
+  describe('Sorting icons', () => {
+    it('has 3 icons', async () => {
+      const onSortClick = sinon.fake();
+      const baseHost = "https://archive.org";
+      const provider = new volumesProvider(baseHost, brOptions, onSortClick);
+
+      provider.sortOrderBy = 'orig_sort';
+      const origSortButton = await fixture(provider.sortButton);
+      expect(origSortButton.classList.contains('neutral-icon')).to.be.true;
+
+      provider.sortOrderBy = 'title_asc';
+      const ascButton = await fixture(provider.sortButton);
+      expect(ascButton.classList.contains('asc-icon')).to.be.true;
+
+      provider.sortOrderBy = 'title_desc';
+      const descButton = await fixture(provider.sortButton);
+      expect(descButton.classList.contains('desc-icon')).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
### Remove numbered order & show title only
<img width="317" alt="image" src="https://user-images.githubusercontent.com/7840857/123015055-5fb47700-d37c-11eb-9cc6-71bb144d8618.png">

### Update sort icon buttons
- files sorted by ascending title: AZ w/ UP arrow
- files sorted by descending title: AZ w/ DOWN arrow

![ezgif com-gif-maker (15)](https://user-images.githubusercontent.com/7840857/123015198-adc97a80-d37c-11eb-81a3-12fe5aaea70b.gif)


### Open side panel to multiple volumes on book load but prefer search panel if search was initiated on load

![ezgif com-gif-maker (14)](https://user-images.githubusercontent.com/7840857/123014949-20862600-d37c-11eb-863b-9fa2309c3c7c.gif)
