### PR TITLE
Add volumes sorting order state preservation logic

### DIFF
--- a/src/BookNavigator/volumes/volumes-provider.js
+++ b/src/BookNavigator/volumes/volumes-provider.js
@@ -29,8 +29,8 @@ export default class VolumesProvider {
 
     // get sort state from query param
     // always fallback to `orig_sort` if sortOrderBy value is invalid
-    const urlParams = new URLSearchParams(window.location.href);
-    if (urlParams.get("sort")) {
+    const urlParams = new URLSearchParams(bookreader.readQueryString());
+    if (urlParams.get("sort") != null || urlParams.get("sort") != "") {
       const urlSortValue = urlParams.get("sort");
       this.sortOrderBy = sortArr.includes(urlSortValue) ? urlSortValue : "orig_sort";
     } else {

--- a/src/BookNavigator/volumes/volumes-provider.js
+++ b/src/BookNavigator/volumes/volumes-provider.js
@@ -44,14 +44,14 @@ export default class VolumesProvider {
 
   get sortButton() {
     const sortIcons = {
-      orig_sort: html`
+      '': html`
         <button class="sort-by neutral-icon" aria-label="Sort volumes in initial order" @click=${() => this.sortVolumes("title_asc")}>${sortNeutralIcon}</button>
       `,
       title_asc: html`
         <button class="sort-by asc-icon" aria-label="Sort volumes in ascending order" @click=${() => this.sortVolumes("title_desc")}>${sortAscIcon}</button>
       `,
       title_desc: html`
-        <button class="sort-by desc-icon" aria-label="Sort volumes in descending order" @click=${() => this.sortVolumes("orig_sort")}>${sortDescIcon}</button>
+        <button class="sort-by desc-icon" aria-label="Sort volumes in descending order" @click=${() => this.sortVolumes("")}>${sortDescIcon}</button>
       `,
     };
 
@@ -59,7 +59,7 @@ export default class VolumesProvider {
   }
 
   /**
-   * @param {'orig_sort' | 'title_asc' | 'title_desc'} sortByType
+   * @param {'title_asc' | 'title_desc'} sortByType
    */
   sortVolumes(sortByType) {
     let sortedFiles = [];
@@ -81,7 +81,7 @@ export default class VolumesProvider {
   }
 
   /**
-   * @param {'orig_sort' | 'title_asc' | 'title_desc'} orderBy
+   * @param {'title_asc' | 'title_desc'} orderBy
    */
   multipleFilesClicked(orderBy) {
     if (!window.archive_analytics) {

--- a/src/BookNavigator/volumes/volumes-provider.js
+++ b/src/BookNavigator/volumes/volumes-provider.js
@@ -7,7 +7,11 @@ import volumesIcon from '../assets/icon_volumes.js';
 
 import './volumes.js';
 
-const sortArr = ["orig_sort", "title_asc", "title_desc"];
+const availableSorts = {
+  asc: 'sort_asc',
+  desc: 'sort_desc',
+  orig: ''
+};
 
 export default class VolumesProvider {
 
@@ -27,14 +31,12 @@ export default class VolumesProvider {
     this.label = `Viewable files (${this.volumeCount})`;
     this.icon = html`${volumesIcon}`;
 
+    this.sortOrderBy = availableSorts.orig;
     // get sort state from query param
-    // always fallback to `orig_sort` if sortOrderBy or urlParam `sort` value is invalid or empty
     const urlParams = new URLSearchParams(bookreader.readQueryString());
-    if (urlParams.get("sort") !== null || urlParams.get("sort") !== "") {
-      const urlSortValue = urlParams.get("sort");
-      this.sortOrderBy = sortArr.includes(urlSortValue) ? urlSortValue : "orig_sort";
-    } else {
-      this.sortOrderBy = "orig_sort";
+    const urlSortValue = urlParams.get("sort");
+    if (urlSortValue === availableSorts.asc || urlSortValue === availableSorts.desc) {
+      this.sortOrderBy = urlSortValue;
     }
 
     this.sortVolumes(this.sortOrderBy);

--- a/src/BookNavigator/volumes/volumes-provider.js
+++ b/src/BookNavigator/volumes/volumes-provider.js
@@ -7,6 +7,8 @@ import volumesIcon from '../assets/icon_volumes.js';
 
 import './volumes.js';
 
+const sortArr = ["orig_sort", "title_asc", "title_desc"];
+
 export default class VolumesProvider {
 
   constructor(baseHost, bookreader, optionChange) {
@@ -25,8 +27,17 @@ export default class VolumesProvider {
     this.label = `Viewable files (${this.volumeCount})`;
     this.icon = html`${volumesIcon}`;
 
-    this.sortOrderBy = "orig_sort";
-    this.sortVolumes("orig_sort");
+    // get sort state from query param
+    // always fallback to `orig_sort` if sortOrderBy value is invalid
+    const urlParams = new URLSearchParams(window.location.href);
+    if (urlParams.get("sort")) {
+      const urlSortValue = urlParams.get("sort");
+      this.sortOrderBy = sortArr.includes(urlSortValue) ? urlSortValue : "orig_sort";
+    } else {
+      this.sortOrderBy = "orig_sort";
+    }
+
+    this.sortVolumes(this.sortOrderBy);
   }
 
   get sortButton() {
@@ -53,13 +64,14 @@ export default class VolumesProvider {
 
     const files = this.viewableFiles;
     sortedFiles = files.sort((a, b) => {
-      if (sortByType === 'orig_sort') return a.orig_sort - b.orig_sort;
-      else if (sortByType === 'title_asc') return a.title.localeCompare(b.title);
-      else return b.title.localeCompare(a.title);
+      if (sortByType === 'title_asc') return a.title.localeCompare(b.title);
+      else if (sortByType === 'title_desc') return b.title.localeCompare(a.title);
+      else return a.orig_sort - b.orig_sort;
     });
 
     this.sortOrderBy = sortByType;
     this.component.viewableFiles  = [...sortedFiles];
+    this.component.sortBy = sortByType;
     this.actionButton = this.sortButton;
     this.optionChange(this.bookreader);
 

--- a/src/BookNavigator/volumes/volumes-provider.js
+++ b/src/BookNavigator/volumes/volumes-provider.js
@@ -28,9 +28,9 @@ export default class VolumesProvider {
     this.icon = html`${volumesIcon}`;
 
     // get sort state from query param
-    // always fallback to `orig_sort` if sortOrderBy value is invalid
+    // always fallback to `orig_sort` if sortOrderBy or urlParam `sort` value is invalid or empty
     const urlParams = new URLSearchParams(bookreader.readQueryString());
-    if (urlParams.get("sort") != null || urlParams.get("sort") != "") {
+    if (urlParams.get("sort") !== null || urlParams.get("sort") !== "") {
       const urlSortValue = urlParams.get("sort");
       this.sortOrderBy = sortArr.includes(urlSortValue) ? urlSortValue : "orig_sort";
     } else {

--- a/src/BookNavigator/volumes/volumes-provider.js
+++ b/src/BookNavigator/volumes/volumes-provider.js
@@ -8,8 +8,8 @@ import volumesIcon from '../assets/icon_volumes.js';
 import './volumes.js';
 
 const availableSorts = {
-  asc: 'sort_asc',
-  desc: 'sort_desc',
+  asc: 'title_asc',
+  desc: 'title_desc',
   orig: ''
 };
 

--- a/src/BookNavigator/volumes/volumes.js
+++ b/src/BookNavigator/volumes/volumes.js
@@ -56,11 +56,13 @@ export class Volumes extends LitElement {
 
   volumeItem(item) {
     const activeClass = this.subPrefix === item.file_subprefix ? ' active' : '';
+    const baseUrl = `https://${this.hostUrl}${item.url_path}`;
+    const hrefUrl = this.sortBy === 'orig_sort' ? baseUrl : `${baseUrl}?sort=${this.sortBy}`;
     return html`
       <li>
         <div class="separator"></div>
         <div class="content${activeClass}">
-          <a href="https://${this.hostUrl}${item.url_path}?sort=${this.sortBy}">
+          <a href="${hrefUrl}">
             <p class="item-title">${item.title}</p>
           </a>
         </div>

--- a/src/BookNavigator/volumes/volumes.js
+++ b/src/BookNavigator/volumes/volumes.js
@@ -57,7 +57,7 @@ export class Volumes extends LitElement {
   volumeItem(item) {
     const activeClass = this.subPrefix === item.file_subprefix ? ' active' : '';
     const baseUrl = `https://${this.hostUrl}${item.url_path}`;
-    const hrefUrl = this.sortBy === 'orig_sort' ? baseUrl : `${baseUrl}?sort=${this.sortBy}`;
+    const hrefUrl = this.sortBy === '' ? baseUrl : `${baseUrl}?sort=${this.sortBy}`;
     return html`
       <li>
         <div class="separator"></div>

--- a/src/BookNavigator/volumes/volumes.js
+++ b/src/BookNavigator/volumes/volumes.js
@@ -8,6 +8,7 @@ export class Volumes extends LitElement {
       subPrefix: { type: String },
       hostUrl: { type: String },
       viewableFiles: { type: Array },
+      sortBy: { type: String },
     };
   }
 
@@ -15,6 +16,7 @@ export class Volumes extends LitElement {
     super();
     this.subPrefix = '';
     this.hostUrl = '';
+    this.sortBy = '';
     this.viewableFiles = [];
   }
 
@@ -58,7 +60,7 @@ export class Volumes extends LitElement {
       <li>
         <div class="separator"></div>
         <div class="content${activeClass}">
-          <a href="https://${this.hostUrl}${item.url_path}">
+          <a href="https://${this.hostUrl}${item.url_path}?sort=${this.sortBy}">
             <p class="item-title">${item.title}</p>
           </a>
         </div>

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -2393,7 +2393,6 @@ BookReader.prototype.paramsFromCurrent = function() {
   if (this.enableSearch) {
     params.search = this.searchTerm;
   }
-
   return params;
 };
 
@@ -2522,11 +2521,7 @@ BookReader.prototype.fragmentFromParams = function(params, urlMode = 'hash') {
  * @param {string} [urlMode]
  * @return {string}
  */
-BookReader.prototype.queryStringFromParams = function(
-  params,
-  currQueryString,
-  urlMode = 'hash'
-) {
+BookReader.prototype.queryStringFromParams = function(params, currQueryString, urlMode = 'hash') {
   const newParams = new URLSearchParams(currQueryString);
   if (params.search && urlMode === 'history') {
     newParams.set('q', params.search);

--- a/tests/karma/BookNavigator/volumes/volumes-provider.test.js
+++ b/tests/karma/BookNavigator/volumes/volumes-provider.test.js
@@ -49,7 +49,7 @@ describe('Volumes Provider', () => {
     const volumeCount = Object.keys(files).length;
 
     expect(brOptions.readQueryString).callCount(1);
-    expect(provider.sortOrderBy).to.equal("orig_sort"); // default value
+    expect(provider.sortOrderBy).to.equal(""); // default value
 
     expect(provider.optionChange).to.equal(onSortClick);
     expect(provider.id).to.equal('volumes');
@@ -69,7 +69,7 @@ describe('Volumes Provider', () => {
     const baseHost = "https://archive.org";
     const provider = new volumesProvider(baseHost, brOptions, onSortClick);
 
-    expect(provider.sortOrderBy).to.equal("orig_sort");
+    expect(provider.sortOrderBy).to.equal("");
 
     provider.sortVolumes("title_asc");
     expect(provider.sortOrderBy).to.equal("title_asc");
@@ -79,8 +79,8 @@ describe('Volumes Provider', () => {
     expect(provider.sortOrderBy).to.equal("title_desc");
     expect(provider.sortButton.getHTML()).includes("sort-by desc-icon");
 
-    provider.sortVolumes("orig_sort");
-    expect(provider.sortOrderBy).to.equal("orig_sort");
+    provider.sortVolumes("");
+    expect(provider.sortOrderBy).to.equal("");
     expect(provider.sortButton.getHTML()).includes("sort-by neutral-icon");
   });
 
@@ -93,9 +93,9 @@ describe('Volumes Provider', () => {
     const files = Object.keys(parsedFiles).map(item => parsedFiles[item]).sort((a, b) => a.orig_sort - b.orig_sort);
     const origSortTitles = files.map(item => item.title);
 
-    provider.sortVolumes("orig_sort");
+    provider.sortVolumes("");
 
-    expect(provider.sortOrderBy).to.equal("orig_sort");
+    expect(provider.sortOrderBy).to.equal("");
     expect(provider.actionButton).to.exist;
 
     const providerFileTitles = provider.viewableFiles.map(item => item.title);
@@ -149,7 +149,7 @@ describe('Volumes Provider', () => {
       const baseHost = "https://archive.org";
       const provider = new volumesProvider(baseHost, brOptions, onSortClick);
 
-      provider.sortOrderBy = 'orig_sort';
+      provider.sortOrderBy = '';
       const origSortButton = await fixture(provider.sortButton);
       expect(origSortButton.classList.contains('neutral-icon')).to.be.true;
 

--- a/tests/karma/BookNavigator/volumes/volumes-provider.test.js
+++ b/tests/karma/BookNavigator/volumes/volumes-provider.test.js
@@ -41,10 +41,15 @@ describe('Volumes Provider', () => {
   it('constructor', () => {
     const onSortClick = sinon.fake();
     const baseHost = "https://archive.org";
+
+    brOptions["readQueryString"] = sinon.fake();
     const provider = new volumesProvider(baseHost, brOptions, onSortClick);
 
     const files = brOptions.options.multipleBooksList.by_subprefix;
     const volumeCount = Object.keys(files).length;
+
+    expect(brOptions.readQueryString).callCount(1);
+    expect(provider.sortOrderBy).to.equal("orig_sort"); // default value
 
     expect(provider.optionChange).to.equal(onSortClick);
     expect(provider.id).to.equal('volumes');


### PR DESCRIPTION
## Changes:

- getting queryString value: `?sort=` for setting the default or specific volumes sorting order for sorting order state preservation when page is reloaded
- set the default sort order to `default`

![br-sorting-flow-state](https://user-images.githubusercontent.com/1281581/123478820-961b1c00-d632-11eb-956c-232d3307b786.gif)
