### PR TITLE
Fix keyboard shortcuts interferring with input fields [BC]

### DIFF
--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -659,7 +659,7 @@ BookReader.prototype.setupKeyListeners = function() {
   $(document).keydown(function(e) {
 
     // Keyboard navigation
-    if (!self.keyboardNavigationIsDisabled(e)) {
+    if (!utils.isInputActive()) {
       switch (e.keyCode) {
       case KEY_PGUP:
       case KEY_UP:
@@ -1527,15 +1527,6 @@ BookReader.prototype.stopFlipAnimations = function() {
   jQuery.each(this._modes.mode2Up.pageContainers, function() {
     $(this.$container).stop(false, true);
   });
-};
-
-/**
- * Returns true if keyboard navigation should be disabled for the event
- * @param {Event}
- * @return {boolean}
- */
-BookReader.prototype.keyboardNavigationIsDisabled = function(event) {
-  return event.target.tagName == "INPUT";
 };
 
 /**

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -659,56 +659,62 @@ BookReader.prototype.setupKeyListeners = function() {
   $(document).keydown(function(e) {
 
     // Keyboard navigation
-    if (!utils.isInputActive()) {
-      switch (e.keyCode) {
-      case KEY_PGUP:
-      case KEY_UP:
-        // In 1up mode page scrolling is handled by browser
-        if (self.constMode2up == self.mode) {
-          e.preventDefault();
-          self.prev();
-        }
-        break;
-      case KEY_DOWN:
-      case KEY_PGDOWN:
-        if (self.constMode2up == self.mode) {
-          e.preventDefault();
-          self.next();
-        }
-        break;
-      case KEY_END:
+    switch (e.keyCode) {
+    case KEY_PGUP:
+    case KEY_UP:
+      // In 1up mode page scrolling is handled by browser
+      if (!utils.isInputActive() && self.constMode2up == self.mode) {
+        e.preventDefault();
+        self.prev();
+      }
+      break;
+    case KEY_DOWN:
+    case KEY_PGDOWN:
+      if (!utils.isInputActive() && self.constMode2up == self.mode) {
+        e.preventDefault();
+        self.next();
+      }
+      break;
+    case KEY_END:
+      if (!utils.isInputActive()) {
         e.preventDefault();
         self.last();
-        break;
-      case KEY_HOME:
+      }
+      break;
+    case KEY_HOME:
+      if (!utils.isInputActive()) {
         e.preventDefault();
         self.first();
-        break;
-      case KEY_LEFT:
-        if (self.constModeThumb != self.mode) {
-          e.preventDefault();
-          self.left();
-        }
-        break;
-      case KEY_RIGHT:
-        if (self.constModeThumb != self.mode) {
-          e.preventDefault();
-          self.right();
-        }
-        break;
-      case KEY_MINUS:
-      case KEY_MINUS_F:
-      case KEY_NUMPAD_SUBTRACT:
+      }
+      break;
+    case KEY_LEFT:
+      if (!utils.isInputActive() && self.constModeThumb != self.mode) {
+        e.preventDefault();
+        self.left();
+      }
+      break;
+    case KEY_RIGHT:
+      if (!utils.isInputActive() && self.constModeThumb != self.mode) {
+        e.preventDefault();
+        self.right();
+      }
+      break;
+    case KEY_MINUS:
+    case KEY_MINUS_F:
+    case KEY_NUMPAD_SUBTRACT:
+      if (!utils.isInputActive()) {
         e.preventDefault();
         self.zoom(-1);
-        break;
-      case KEY_EQUAL:
-      case KEY_EQUAL_F:
-      case KEY_NUMPAD_ADD:
+      }
+      break;
+    case KEY_EQUAL:
+    case KEY_EQUAL_F:
+    case KEY_NUMPAD_ADD:
+      if (!utils.isInputActive()) {
         e.preventDefault();
         self.zoom(+1);
-        break;
       }
+      break;
     }
   });
 };

--- a/src/BookReader/utils.js
+++ b/src/BookReader/utils.js
@@ -41,6 +41,23 @@ export function notInArray(value, array) {
 }
 
 /**
+ * Determines the active element, going into shadow doms.
+ * @return {Element}
+ */
+export function getActiveElement(doc = document, recurseShadowDom = true) {
+  const activeElement = doc.activeElement;
+  if (recurseShadowDom && activeElement?.shadowRoot) {
+    return getActiveElement(activeElement.shadowRoot, true);
+  }
+  return activeElement;
+}
+
+/** Check if an input field is active. Also checks shadow DOMs. */
+export function isInputActive(doc = document) {
+  return getActiveElement(doc)?.tagName == "INPUT";
+}
+
+/**
  * @param {HTMLIFrameElement} iframe
  * @return {Document}
  */

--- a/tests/BookReader/utils.test.js
+++ b/tests/BookReader/utils.test.js
@@ -6,6 +6,8 @@ import {
   decodeURIComponentPlus,
   encodeURIComponentPlus,
   escapeHTML,
+  getActiveElement,
+  isInputActive,
   polyfillCustomEvent,
   PolyfilledCustomEvent,
   sleep,
@@ -34,6 +36,44 @@ test('Decodes a URI component and converts + to emptyStr', () => {
 test('Encodes a URI component and converts emptyStr to +', () => {
   expect(encodeURIComponentPlus("?x=test ")).toEqual("%3Fx%3Dtest+");
   expect(encodeURIComponentPlus("ABC abc 123")).toEqual("ABC+abc+123");
+});
+
+describe('getActiveElement', () => {
+  test('Can ignore shadow DOM', () => {
+    const doc = {activeElement: { shadowRoot: {activeElement: {}}}};
+    expect(getActiveElement(doc, false)).toBe(doc.activeElement);
+  });
+
+  test('Can traverse shadow DOM', () => {
+    const doc = {activeElement: { shadowRoot: {activeElement: {}}}};
+    expect(getActiveElement(doc, true)).toBe(doc.activeElement.shadowRoot.activeElement);
+  });
+
+  test('Handles non-shadow elements', () => {
+    const doc = {activeElement: {}};
+    expect(getActiveElement(doc, true)).toBe(doc.activeElement);
+  });
+
+  test('Handles no active element', () => {
+    const doc = {activeElement: null};
+    expect(getActiveElement(doc, true)).toBe(null);
+  });
+});
+
+describe('isInputActive', () => {
+  test('Handles no activeElement', () => {
+    expect(isInputActive({activeElement: null})).toBe(false);
+  });
+
+  test('Handles deep input activeElement', () => {
+    const doc = {activeElement: { shadowRoot: {activeElement: { tagName: 'INPUT' }}}};
+    expect(isInputActive(doc)).toBe(true);
+  });
+
+  test('Handles deep non-input activeElement', () => {
+    const doc = {activeElement: { shadowRoot: {activeElement: { tagName: 'A' }}}};
+    expect(isInputActive(doc)).toBe(false);
+  });
 });
 
 let clock;


### PR DESCRIPTION
Closes #371 ; Closes #673 ; Closes WEBDEV-4107

Breaking change: Remove public method `BookReader.prototype.keyboardNavigationIsDisabled`

To test:

Go to one of the demos.

Run this JS:

```js
customElements.define('test-element', class extends HTMLElement {
  constructor() {
    super();
    this.attachShadow({mode: 'open'});
    this.shadowRoot.append(document.createElement('input'));
  }
});
$(document.body).prepend($(`<test-element/>`));
```

Type in the added input.

- [x] Confirm keyboard shortcuts work when the input does not have focus
- [x] Confirm keyboard shortcuts do not work when the input does have focus
- [x] Confirm keyboard shortcuts do not work when typing in searchbox in side panel
- [x] Confirm keyboard shortcuts do not work when typing in searchbox in header