### PR TITLE
Convert search/tts hilites into an SVG layer

### DIFF
--- a/src/BookNavigator/search/search-provider.js
+++ b/src/BookNavigator/search/search-provider.js
@@ -176,6 +176,5 @@ export default class {
   advanceToPage(leaf) {
     const page = this.bookreader.leafNumToIndex(leaf);
     this.bookreader._searchPluginGoToResult(page);
-    this.bookreader.updateSearchHilites();
   }
 }

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -597,11 +597,9 @@ BookReader.prototype.resize = function() {
     if (this.onePage.autofit != 'none') {
       this.resizePageView1up();
       this.centerPageView();
-      if (this.enableSearch) this.updateSearchHilites(); //deletes highlights but does not call remove()
     } else {
       this.centerPageView();
       this.displayedIndices = [];
-      if (this.enableSearch) this.updateSearchHilites(); //deletes highlights but does not call remove()
       this.drawLeafsThrottled();
     }
   } else if (this.constModeThumb == this.mode) {
@@ -1030,7 +1028,6 @@ BookReader.prototype.switchMode = function(
   }
 
   this.trigger(BookReader.eventNames.stop);
-  if (this.enableSearch) this.removeSearchHilites();
 
   this.prevReadMode = this.getPrevReadMode(this.mode);
 

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -267,6 +267,32 @@ BookReader.prototype.setup = function(options) {
   });
 };
 
+/**
+ * Get all the HTML Elements that are being/can be rendered.
+ * Includes cached elements which might be rendered again.
+ */
+BookReader.prototype.getActivePageContainerElements = function() {
+  let containerEls = Object.values(this._modes.mode2Up.pageContainers).map(pc => pc.$container[0]);
+  if (this.mode != this.constMode2up) {
+    containerEls = containerEls.concat(this.$('.BRpagecontainer').toArray());
+  }
+  return containerEls;
+};
+
+/**
+ * Get the HTML Elements for the rendered page. Note there can be more than one, since
+ * (at least as of writing) different modes can maintain different caches.
+ * @param {PageIndex} pageIndex
+ */
+BookReader.prototype.getActivePageContainerElementsForIndex = function(pageIndex) {
+  const mode2UpContainer = this._modes.mode2Up.pageContainers[pageIndex]?.$container?.[0];
+  let containerEls = mode2UpContainer ? [mode2UpContainer] : [];
+  if (this.mode != this.constMode2up) {
+    containerEls = containerEls.concat(this.$(`.pagediv${pageIndex}`).toArray());
+  }
+  return containerEls;
+};
+
 /** @deprecated unused outside Mode2Up */
 Object.defineProperty(BookReader.prototype, 'leafEdgeL', {
   get() { return this._modes.mode2Up.leafEdgeL; },

--- a/src/BookReader/Mode1Up.js
+++ b/src/BookReader/Mode1Up.js
@@ -173,10 +173,7 @@ export class Mode1Up {
         this.br.$(`.pagediv${index}`).remove();
       }
     }
-
     this.br.displayedIndices = displayedIndices;
-    if (this.br.enableSearch) this.br.updateSearchHilites();
-
     this.br.updateToolbarZoom(this.realWorldReduce);
 
     // Update the slider
@@ -244,12 +241,6 @@ export class Mode1Up {
 
     this.resizePageView();
     this.br.updateToolbarZoom(this.realWorldReduce);
-
-    // Recalculate search hilites
-    if (this.br.enableSearch) {
-      this.br.removeSearchHilites();
-      this.br.updateSearchHilites();
-    }
   }
 
   /**
@@ -366,11 +357,6 @@ export class Mode1Up {
 
     // Draw all visible pages
     this.drawLeafs();
-
-    if (this.br.enableSearch) {
-      this.br.removeSearchHilites();
-      this.br.updateSearchHilites();
-    }
   }
 
   /**

--- a/src/BookReader/Mode2Up.js
+++ b/src/BookReader/Mode2Up.js
@@ -219,12 +219,6 @@ export class Mode2Up {
 
     this.drawLeafs();
     this.br.updateToolbarZoom(this.br.reduce);
-
-    if (this.br.enableSearch) {
-      this.br.removeSearchHilites();
-      this.br.updateSearchHilites();
-    }
-
     this.br.updateBrClasses();
   }
 
@@ -616,8 +610,6 @@ export class Mode2Up {
 
     $(this.br.leafEdgeTmp).animate({left: gutter}, this.br.flipSpeed, 'easeInSine');
 
-    if (this.br.enableSearch) this.br.removeSearchHilites();
-
     this.pageContainers[leftLeaf].$container.animate({width: '0px'}, this.br.flipSpeed, 'easeInSine', () => {
 
       $(this.br.leafEdgeTmp).animate({left: `${gutter + newWidthR}px`}, this.br.flipSpeed, 'easeOutSine');
@@ -662,8 +654,6 @@ export class Mode2Up {
         this.br.animating = false;
 
         this.resizeSpread();
-
-        if (this.br.enableSearch) this.br.updateSearchHilites();
 
         this.setMouseHandlers();
 
@@ -778,8 +768,6 @@ export class Mode2Up {
     $(this.leafEdgeR).css({width: `${newLeafEdgeWidthR}px`, left: `${gutter + newWidthR}px` });
     const speed = this.br.flipSpeed;
 
-    if (this.br.enableSearch) this.br.removeSearchHilites();
-
     $(this.br.leafEdgeTmp).animate({left: gutter}, speed, 'easeInSine');
     this.pageContainers[this.br.twoPage.currentIndexR].$container.animate({width: '0px'}, speed, 'easeInSine', () => {
       this.br.$('BRgutter').css({left: `${gutter - this.br.twoPage.bookSpineDivWidth * 0.5}px`});
@@ -813,8 +801,6 @@ export class Mode2Up {
         this.br.animating = false;
 
         this.resizeSpread();
-
-        if (this.br.enableSearch) this.br.updateSearchHilites();
 
         this.setMouseHandlers();
 

--- a/src/BookReader/PageContainer.js
+++ b/src/BookReader/PageContainer.js
@@ -89,11 +89,7 @@ export function createSVGPageLayer(page, className) {
 }
 
 /**
- * @param {object} box
- * @param {number} box.l
- * @param {number} box.r
- * @param {number} box.b
- * @param {number} box.t
+ * @param {{ l: number, r: number, b: number, t: number }} box
  */
 export function boxToSVGRect({ l: left, r: right, b: bottom, t: top }) {
   const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
@@ -102,4 +98,23 @@ export function boxToSVGRect({ l: left, r: right, b: bottom, t: top }) {
   rect.setAttribute("width", (right - left).toString());
   rect.setAttribute("height", (bottom - top).toString());
   return rect;
+}
+
+/**
+ * @param {string} layerClass
+ * @param {Array<{ l: number, r: number, b: number, t: number }>} boxes
+ * @param {PageModel} page
+ * @param {HTMLElement} containerEl
+ */
+export function renderBoxesInPageContainerElement(layerClass, boxes, page, containerEl) {
+  const mountedSvg = containerEl.querySelector(`.${layerClass}`);
+  // Create the layer if it's not there
+  const svg = mountedSvg || createSVGPageLayer(page, layerClass);
+  if (!mountedSvg) {
+    // Insert after the image if the image is already loaded.
+    const imgEl = containerEl.querySelector('.BRpageimage');
+    if (imgEl) $(svg).insertAfter(imgEl);
+    else $(svg).prependTo(containerEl);
+  }
+  boxes.forEach(box => svg.appendChild(boxToSVGRect(box)));
 }

--- a/src/BookReader/PageContainer.js
+++ b/src/BookReader/PageContainer.js
@@ -73,3 +73,17 @@ export class PageContainer {
     return this;
   }
 }
+
+
+/**
+ * @param {PageModel} page
+ * @param {string} className
+ */
+export function createSVGPageLayer(page, className) {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+  svg.setAttribute("viewBox", `0 0 ${page.width} ${page.height}`);
+  svg.setAttribute('class', `BRPageLayer ${className}`);
+  svg.setAttribute('preserveAspectRatio', 'none');
+  return svg;
+}

--- a/src/BookReader/PageContainer.js
+++ b/src/BookReader/PageContainer.js
@@ -106,7 +106,7 @@ export function boxToSVGRect({ l: left, r: right, b: bottom, t: top }) {
  * @param {PageModel} page
  * @param {HTMLElement} containerEl
  */
-export function renderBoxesInPageContainerElement(layerClass, boxes, page, containerEl) {
+export function renderBoxesInPageContainerLayer(layerClass, boxes, page, containerEl) {
   const mountedSvg = containerEl.querySelector(`.${layerClass}`);
   // Create the layer if it's not there
   const svg = mountedSvg || createSVGPageLayer(page, layerClass);

--- a/src/BookReader/PageContainer.js
+++ b/src/BookReader/PageContainer.js
@@ -87,3 +87,19 @@ export function createSVGPageLayer(page, className) {
   svg.setAttribute('preserveAspectRatio', 'none');
   return svg;
 }
+
+/**
+ * @param {object} box
+ * @param {number} box.l
+ * @param {number} box.r
+ * @param {number} box.b
+ * @param {number} box.t
+ */
+export function boxToSVGRect({ l: left, r: right, b: bottom, t: top }) {
+  const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+  rect.setAttribute("x", left.toString());
+  rect.setAttribute("y", top.toString());
+  rect.setAttribute("width", (right - left).toString());
+  rect.setAttribute("height", (bottom - top).toString());
+  return rect;
+}

--- a/src/css/_BRpages.scss
+++ b/src/css/_BRpages.scss
@@ -48,6 +48,19 @@
   }
 }
 
+svg.BRPageLayer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+// Hides page layers during page flip animation
+.BRpageFlipping .BRPageLayer {
+  display: none;
+}
+
 .BRbookcover {
   position: absolute;
   background-image: none;

--- a/src/css/_BRsearch.scss
+++ b/src/css/_BRsearch.scss
@@ -25,7 +25,9 @@
 }
 
 #{$brScope} {
-  .searchHiliteLayer {
+  // FIXME: .ttsHiliteLayer should probably not be in this file,
+  // but they appear the same in the UI.
+  .searchHiliteLayer, .ttsHiliteLayer {
     pointer-events: none;
 
     rect {

--- a/src/css/_BRsearch.scss
+++ b/src/css/_BRsearch.scss
@@ -25,16 +25,17 @@
 }
 
 #{$brScope} {
-  .BookReaderSearchHilite {
-    opacity: 0.20;
-    filter: alpha(opacity = 20);
-    background-color: #0000ff;
+  .searchHiliteLayer {
     position: absolute;
-    /* z-index is important */
-    z-index: $brZindexBase + 3;
+    pointer-events: none;
 
-    animation: hiliteFadeIn .2s;
+    rect {
+      fill: #0000ff;
+      fill-opacity: 0.2;
+      animation: hiliteFadeIn .2s;
+    }
   }
+
   .BRchapter, .BRsearch {
     position: absolute;
     bottom: 0;  /* Relative to nav line */
@@ -206,8 +207,7 @@
 }
 
 @keyframes hiliteFadeIn {
-  from { opacity: 0; }
-  to { opacity: 0.2; }
+  from { fill-opacity: 0; }
 }
 
 /* Mid size breakpoint */

--- a/src/css/_BRsearch.scss
+++ b/src/css/_BRsearch.scss
@@ -26,7 +26,6 @@
 
 #{$brScope} {
   .searchHiliteLayer {
-    position: absolute;
     pointer-events: none;
 
     rect {

--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -17,10 +17,9 @@
     }
 
     .BRparagElement {
-        fill: red;
+        fill: transparent;
         cursor: text;
         white-space: pre;
-        fill-opacity: 0;
         font-family: Georgia, serif;
     }
 }

--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -1,9 +1,4 @@
 .textSelectionSVG {
-    width: 100%;
-    position: absolute;
-    height: 100%;
-    top: 0;
-    left: 0;
     // Make it so right-clicking on "blank" part of svg sends events to the image (for saving)
     pointer-events: none;
     .BRwordElement { pointer-events: all; }
@@ -35,14 +30,4 @@
     -webkit-user-select: none;
     -moz-user-select: none;
     user-select: none;
-}
-
-// Hides svg text layer when page animation is running
-.BRpageFlipping .textSelectionSVG {
-    display: none;
-}
-
-// Hide phantom page when last page is selected
-.BRpagecontainer.BRemptypage .textSelectionSVG{
-    display: none;
 }

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -23,7 +23,7 @@
  * @event BookReader:SearchCanceled - When no results found. Receives
  *   `instance`
  */
-import { createSVGPageLayer } from '../../BookReader/PageContainer.js';
+import { boxToSVGRect, createSVGPageLayer } from '../../BookReader/PageContainer.js';
 import SearchView from './view.js';
 /** @typedef {import('../../BookReader/PageContainer').PageContainer} PageContainer */
 /** @typedef {import('../../BookReader/BookModel').PageIndex} PageIndex */
@@ -124,7 +124,7 @@ BookReader.prototype._createPageContainer = (function (super_) {
       if (pageIndex in this._searchBoxesByIndex) {
         this._searchHiliteLayers[pageIndex].forEach(svg => svg.innerHTML = '');
         for (const box of this._searchBoxesByIndex[pageIndex]) {
-          this._searchHiliteLayers[pageIndex].forEach(svg => svg.appendChild(renderBoxInSVGLayer(box)));
+          this._searchHiliteLayers[pageIndex].forEach(svg => svg.appendChild(boxToSVGRect(box)));
         }
       }
     }
@@ -334,22 +334,6 @@ BookReader.prototype._BRSearchCallbackError = function(results) {
 };
 
 /**
- * @param {object} box
- * @param {number} box.l
- * @param {number} box.r
- * @param {number} box.b
- * @param {number} box.t
- */
-function renderBoxInSVGLayer({ l: left, r: right, b: bottom, t: top }) {
-  const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
-  rect.setAttribute("x", left.toString());
-  rect.setAttribute("y", top.toString());
-  rect.setAttribute("width", (right - left).toString());
-  rect.setAttribute("height", (bottom - top).toString());
-  return rect;
-}
-
-/**
  * updates search on-page highlights controller
  */
 BookReader.prototype.updateSearchHilites = function() {
@@ -370,7 +354,7 @@ BookReader.prototype.updateSearchHilites = function() {
 
       // update any already created pages
       if (pageIndex in this._searchHiliteLayers) {
-        this._searchHiliteLayers[pageIndex].forEach(svg => svg.appendChild(renderBoxInSVGLayer(box)));
+        this._searchHiliteLayers[pageIndex].forEach(svg => svg.appendChild(boxToSVGRect(box)));
       }
     }
   }
@@ -382,7 +366,7 @@ BookReader.prototype.updateSearchHilites = function() {
  * remove search highlights
  */
 BookReader.prototype.removeSearchHilites = function() {
-  Object.values(this._searchHiliteLayers).flatMap(svg => svg.innerHTML = '');
+  Object.values(this._searchHiliteLayers).flat().forEach(svg => svg.innerHTML = '');
 };
 
 /**

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -122,7 +122,7 @@ BookReader.prototype._createPageContainer = (function (super_) {
       }
 
       if (pageIndex in this._searchBoxesByIndex) {
-        this._searchHiliteLayers[pageIndex].forEach(svg => svg.innerHTML = '');
+        $(this._searchHiliteLayers[pageIndex]).empty();
         for (const box of this._searchBoxesByIndex[pageIndex]) {
           this._searchHiliteLayers[pageIndex].forEach(svg => svg.appendChild(boxToSVGRect(box)));
         }
@@ -366,7 +366,7 @@ BookReader.prototype.updateSearchHilites = function() {
  * remove search highlights
  */
 BookReader.prototype.removeSearchHilites = function() {
-  Object.values(this._searchHiliteLayers).flat().forEach(svg => svg.innerHTML = '');
+  $(Object.values(this._searchHiliteLayers).flat()).empty();
 };
 
 /**

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -23,7 +23,7 @@
  * @event BookReader:SearchCanceled - When no results found. Receives
  *   `instance`
  */
-import { renderBoxesInPageContainerElement } from '../../BookReader/PageContainer.js';
+import { renderBoxesInPageContainerLayer } from '../../BookReader/PageContainer.js';
 import SearchView from './view.js';
 /** @typedef {import('../../BookReader/PageContainer').PageContainer} PageContainer */
 /** @typedef {import('../../BookReader/BookModel').PageIndex} PageIndex */
@@ -112,7 +112,7 @@ BookReader.prototype._createPageContainer = (function (super_) {
     const pageContainer = super_.call(this, index);
     if (this.enableSearch && pageContainer.page && index in this._searchBoxesByIndex) {
       const pageIndex = pageContainer.page.index;
-      renderBoxesInPageContainerElement('searchHiliteLayer', this._searchBoxesByIndex[pageIndex], pageContainer.page, pageContainer.$container[0]);
+      renderBoxesInPageContainerLayer('searchHiliteLayer', this._searchBoxesByIndex[pageIndex], pageContainer.page, pageContainer.$container[0]);
     }
     return pageContainer;
   };
@@ -345,7 +345,7 @@ BookReader.prototype.updateSearchHilites = function() {
     const pageIndex = parseFloat(pageIndexString);
     const page = this._models.book.getPage(pageIndex);
     const pageContainers = this.getActivePageContainerElementsForIndex(pageIndex);
-    pageContainers.forEach(container => renderBoxesInPageContainerElement('searchHiliteLayer', boxes, page, container));
+    pageContainers.forEach(container => renderBoxesInPageContainerLayer('searchHiliteLayer', boxes, page, container));
   }
 
   this._searchBoxesByIndex = boxesByIndex;

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -24,6 +24,8 @@
  *   `instance`
  */
 import SearchView from './view.js';
+/** @typedef {import('../../BookReader/PageContainer').PageContainer} PageContainer */
+/** @typedef {import('../../BookReader/BookModel').PageIndex} PageIndex */
 
 jQuery.extend(BookReader.defaultOptions, {
   server: 'ia600609.us.archive.org',
@@ -54,6 +56,11 @@ BookReader.prototype.setup = (function (super_) {
     this.searchXHR = null;
     this._cancelSearch.bind(this);
     this.cancelSearchRequest.bind(this);
+
+    /** @type { {[pageIndex: number]: SVGSVGElement[]} } */
+    this._searchHiliteLayers = {};
+    /** @type { {[pageIndex: number]: SearchInsideMatchBox[]} } */
+    this._searchBoxesByIndex = {};
 
     if (this.searchView) { return; }
     this.searchView = new SearchView({
@@ -99,6 +106,42 @@ BookReader.prototype.buildToolbarElement = (function (super_) {
     return $el;
   };
 })(BookReader.prototype.buildToolbarElement);
+
+/**
+ * @param {PageContainer} pageContainer
+ */
+function createSearchHiliteLayer(pageContainer) {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+  svg.setAttribute("viewBox", `0 0 ${pageContainer.page.width} ${pageContainer.page.height}`);
+  svg.setAttribute('class', 'searchHiliteLayer');
+  svg.setAttribute('preserveAspectRatio', 'none');
+  return svg;
+}
+
+/** @override */
+BookReader.prototype._createPageContainer = (function (super_) {
+  return function (index) {
+    const pageContainer = super_.call(this, index);
+    if (this.enableSearch && pageContainer.page) {
+      const pageIndex = pageContainer.page.index;
+      if (!pageContainer.$container.find('.searchHiliteLayer').length) {
+        const layer = createSearchHiliteLayer(pageContainer);
+        this._searchHiliteLayers[pageIndex] = this._searchHiliteLayers[pageIndex] || [];
+        this._searchHiliteLayers[pageIndex].push(layer);
+        pageContainer.$container.append(layer);
+      }
+
+      if (pageIndex in this._searchBoxesByIndex) {
+        this._searchHiliteLayers[pageIndex].forEach(svg => svg.innerHTML = '');
+        for (const box of this._searchBoxesByIndex[pageIndex]) {
+          this._searchHiliteLayers[pageIndex].forEach(svg => svg.appendChild(renderBoxInSVGLayer(box)));
+        }
+      }
+    }
+    return pageContainer;
+  };
+})(BookReader.prototype._createPageContainer);
 
 /**
  * @typedef {object} SearchOptions
@@ -302,98 +345,55 @@ BookReader.prototype._BRSearchCallbackError = function(results) {
 };
 
 /**
+ * @param {object} box
+ * @param {number} box.l
+ * @param {number} box.r
+ * @param {number} box.b
+ * @param {number} box.t
+ */
+function renderBoxInSVGLayer({ l: left, r: right, b: bottom, t: top }) {
+  const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+  rect.setAttribute("x", left.toString());
+  rect.setAttribute("y", top.toString());
+  rect.setAttribute("width", (right - left).toString());
+  rect.setAttribute("height", (bottom - top).toString());
+  return rect;
+}
+
+/**
  * updates search on-page highlights controller
  */
 BookReader.prototype.updateSearchHilites = function() {
-  if (this.constMode2up == this.mode) {
-    this.updateSearchHilites2UP();
-    return;
-  }
-  this.updateSearchHilites1UP();
-};
+  /** @type {SearchInsideMatch[]} */
+  const matches = this.searchResults?.matches || [];
+  /** @type { {[pageIndex: number]: SearchInsideMatch[]} } */
+  const boxesByIndex = {};
 
-/**
- * update search on-page highlights in 1up mode
- */
-BookReader.prototype.updateSearchHilites1UP = function() {
-  const results = this.searchResults;
-  if (null == results) return;
-  results.matches?.forEach(match => {
-    match.par[0].boxes.forEach(box => {
+  // Clear any existing svg layers
+  this.removeSearchHilites();
+
+  // Group by pageIndex
+  for (const match of matches) {
+    for (const box of match.par[0].boxes) {
       const pageIndex = this.leafNumToIndex(box.page);
-      const pageIsInView = jQuery.inArray(pageIndex, this.displayedIndices) >= 0;
-      if (pageIsInView) {
-        if (!box.div) {
-          //create a div for the search highlight, and stash it in the box object
-          box.div = document.createElement('div');
-          $(box.div).prop('className', 'BookReaderSearchHilite').appendTo(this.$(`.pagediv${pageIndex}`));
-        }
-        const page = this._models.book.getPage(pageIndex);
-        const highlight = {
-          width: this._modes.mode1Up.physicalInchesToDisplayPixels((box.r - box.l) / page.ppi),
-          height: this._modes.mode1Up.physicalInchesToDisplayPixels((box.b - box.t) / page.ppi),
-          left: this._modes.mode1Up.physicalInchesToDisplayPixels(box.l / page.ppi),
-          top: this._modes.mode1Up.physicalInchesToDisplayPixels(box.t / page.ppi),
-        };
-        $(box.div).css(highlight);
-      } else {
-        if (box.div) {
-          $(box.div).remove();
-          box.div = null;
-        }
+      const pageMatches = boxesByIndex[pageIndex] || (boxesByIndex[pageIndex] = []);
+      pageMatches.push(box);
+
+      // update any already created pages
+      if (pageIndex in this._searchHiliteLayers) {
+        this._searchHiliteLayers[pageIndex].forEach(svg => svg.appendChild(renderBoxInSVGLayer(box)));
       }
-    });
-  });
-};
+    }
+  }
 
-/**
- * update search on-page highlights in 2up mode
- */
-BookReader.prototype.updateSearchHilites2UP = function() {
-  const results = this.searchResults;
-
-  if (results === null) return;
-
-  const { matches = [] } = results;
-  matches.forEach((match) => {
-    match.par[0].boxes.forEach(box => {
-      const pageIndex = this.leafNumToIndex(match.par[0].page);
-      const pageIsInView = jQuery.inArray(pageIndex, this.displayedIndices) >= 0;
-      const { isViewable } = this._models.book.getPage(pageIndex);
-
-      if (pageIsInView && isViewable) {
-        if (!box.div) {
-          //create a div for the search highlight, and stash it in the box object
-          box.div = document.createElement('div');
-          $(box.div).addClass('BookReaderSearchHilite')
-            .appendTo(this.refs.$brTwoPageView);
-        }
-        this.setHilightCss2UP(box.div, pageIndex, box.l, box.r, box.t, box.b);
-      } else {
-        // clear stale reference
-        if (box.div) {
-          $(box.div).remove();
-          box.div = null;
-        }
-      }
-    });
-  });
+  this._searchBoxesByIndex = boxesByIndex;
 };
 
 /**
  * remove search highlights
  */
 BookReader.prototype.removeSearchHilites = function() {
-  const results = this.searchResults;
-  if (null == results || !results.matches) { return; }
-  results.matches.forEach(match => {
-    match.par[0].boxes.forEach(box => {
-      if (null != box.div) {
-        $(box.div).remove();
-        box.div = null;
-      }
-    });
-  });
+  Object.values(this._searchHiliteLayers).flatMap(svg => svg.innerHTML = '');
 };
 
 /**

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -23,6 +23,7 @@
  * @event BookReader:SearchCanceled - When no results found. Receives
  *   `instance`
  */
+import { createSVGPageLayer } from '../../BookReader/PageContainer.js';
 import SearchView from './view.js';
 /** @typedef {import('../../BookReader/PageContainer').PageContainer} PageContainer */
 /** @typedef {import('../../BookReader/BookModel').PageIndex} PageIndex */
@@ -107,18 +108,6 @@ BookReader.prototype.buildToolbarElement = (function (super_) {
   };
 })(BookReader.prototype.buildToolbarElement);
 
-/**
- * @param {PageContainer} pageContainer
- */
-function createSearchHiliteLayer(pageContainer) {
-  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
-  svg.setAttribute("viewBox", `0 0 ${pageContainer.page.width} ${pageContainer.page.height}`);
-  svg.setAttribute('class', 'searchHiliteLayer');
-  svg.setAttribute('preserveAspectRatio', 'none');
-  return svg;
-}
-
 /** @override */
 BookReader.prototype._createPageContainer = (function (super_) {
   return function (index) {
@@ -126,7 +115,7 @@ BookReader.prototype._createPageContainer = (function (super_) {
     if (this.enableSearch && pageContainer.page) {
       const pageIndex = pageContainer.page.index;
       if (!pageContainer.$container.find('.searchHiliteLayer').length) {
-        const layer = createSearchHiliteLayer(pageContainer);
+        const layer = createSVGPageLayer(pageContainer.page, 'searchHiliteLayer');
         this._searchHiliteLayers[pageIndex] = this._searchHiliteLayers[pageIndex] || [];
         this._searchHiliteLayers[pageIndex].push(layer);
         pageContainer.$container.append(layer);

--- a/src/plugins/search/view.js
+++ b/src/plugins/search/view.js
@@ -281,7 +281,6 @@ class SearchView {
           // Todo: update to arrow function & clean up closures
           // to remove `bind` dependency
           this.br._searchPluginGoToResult(+$(event.target).data('pageIndex'));
-          this.br.updateSearchHilites();
         }.bind(this));
     });
   }

--- a/src/plugins/tts/plugin.tts.js
+++ b/src/plugins/tts/plugin.tts.js
@@ -6,8 +6,9 @@ import FestivalTTSEngine from './FestivalTTSEngine.js';
 import WebTTSEngine from './WebTTSEngine.js';
 import { toISO6391, approximateWordCount } from './utils.js';
 import { en as tooltips } from './tooltip_dict.js';
-/** @typedef {import('./PageChunk.js')} PageChunk */
-/** @typedef {import("./AbstractTTSEngine.js")} AbstractTTSEngine */
+import { boxToSVGRect, createSVGPageLayer } from '../../BookReader/PageContainer.js';
+/** @typedef {import('./PageChunk.js').default} PageChunk */
+/** @typedef {import("./AbstractTTSEngine.js").default} AbstractTTSEngine */
 
 // Default options for TTS
 jQuery.extend(BookReader.defaultOptions, {
@@ -22,7 +23,11 @@ BookReader.prototype.setup = (function (super_) {
     super_.call(this, options);
 
     if (this.options.enableTtsPlugin) {
-      this.ttsHilites = [];
+      /** @type { {[pageIndex: number]: SVGSVGElement[]} } */
+      this._ttsHiliteLayers = {};
+      /** @type { {[pageIndex: number]: Array<{ l: number, r: number, t: number, b: number }>} } */
+      this._ttsBoxesByIndex = {};
+
       let TTSEngine = WebTTSEngine.isSupported() ? WebTTSEngine :
         FestivalTTSEngine.isSupported() ? FestivalTTSEngine :
           null;
@@ -54,17 +59,6 @@ BookReader.prototype.init = (function(super_) {
     if (this.options.enableTtsPlugin) {
       // Bind to events
 
-      // TODO move this to BookReader.js or something
-      this.bind(BookReader.eventNames.fragmentChange, () => {
-        if (this.mode == this.constMode2up) {
-          // clear highlights if they're no longer valid for this page
-          const visibleIndices = [this.twoPage.currentIndexL, this.twoPage.currentIndexR];
-          const visibleSelector = visibleIndices.map(i => `.BRReadAloudHilite.Leaf-${i}`).join(', ');
-          $(this.ttsHilites).filter(visibleSelector).show();
-          $(this.ttsHilites).not(visibleSelector).hide();
-        }
-      });
-
       this.bind(BookReader.eventNames.PostInit, () => {
         this.$('.BRicon.read').click(() => {
           this.ttsToggle();
@@ -88,6 +82,29 @@ BookReader.prototype.init = (function(super_) {
   };
 })(BookReader.prototype.init);
 
+/** @override */
+BookReader.prototype._createPageContainer = (function (super_) {
+  return function (index) {
+    const pageContainer = super_.call(this, index);
+    if (this.options.enableTtsPlugin && pageContainer.page) {
+      const pageIndex = pageContainer.page.index;
+      if (!pageContainer.$container.find('.ttsHiliteLayer').length) {
+        const layer = createSVGPageLayer(pageContainer.page, 'ttsHiliteLayer');
+        this._ttsHiliteLayers[pageIndex] = this._ttsHiliteLayers[pageIndex] || [];
+        this._ttsHiliteLayers[pageIndex].push(layer);
+        pageContainer.$container.append(layer);
+      }
+
+      if (pageIndex in this._ttsBoxesByIndex) {
+        this._ttsHiliteLayers[pageIndex].forEach(svg => svg.innerHTML = '');
+        for (const box of this._ttsBoxesByIndex[pageIndex]) {
+          this._ttsHiliteLayers[pageIndex].forEach(svg => svg.appendChild(boxToSVGRect(box)));
+        }
+      }
+    }
+    return pageContainer;
+  };
+})(BookReader.prototype._createPageContainer);
 
 // Extend buildMobileDrawerElement
 BookReader.prototype.buildMobileDrawerElement = (function (super_) {
@@ -233,12 +250,12 @@ BookReader.prototype.ttsStop = function () {
  * @param {PageChunk} chunk
  * @return {PromiseLike<void>} returns once the flip is done
  */
-BookReader.prototype.ttsBeforeChunkPlay = function(chunk) {
-  return this.ttsMaybeFlipToIndex(chunk.leafIndex)
-    .then(() => {
-      this.ttsHighlightChunk(chunk);
-      this.ttsScrollToChunk(chunk);
-    });
+BookReader.prototype.ttsBeforeChunkPlay = async function(chunk) {
+  await this.ttsMaybeFlipToIndex(chunk.leafIndex);
+  this.ttsHighlightChunk(chunk);
+  // This appears not to work; ttsMaybeFlipToIndex causes a scroll to the top of
+  // the active page :/ Disabling cause the extra scroll just adds an odd jitter.
+  // this.ttsScrollToChunk(chunk);
 };
 
 /**
@@ -281,12 +298,21 @@ BookReader.prototype.ttsMaybeFlipToIndex = function (leafIndex) {
  * @param {PageChunk} chunk
  */
 BookReader.prototype.ttsHighlightChunk = function(chunk) {
+  // The poorly-named variable leafIndex
+  const pageIndex = chunk.leafIndex;
+
   this.ttsRemoveHilites();
 
-  if (this.constMode2up == this.mode) {
-    this.ttsHilite2UP(chunk);
-  } else {
-    this.ttsHilite1UP(chunk);
+  // group by index; currently only possible to have chunks on one page :/
+  this._ttsBoxesByIndex = {
+    [pageIndex]: chunk.lineRects.map(([l, b, r, t]) => ({l, r, b, t}))
+  };
+
+  // update any already created pages
+  if (pageIndex in this._ttsHiliteLayers) {
+    for (const box of this._ttsBoxesByIndex[pageIndex]) {
+      this._ttsHiliteLayers[pageIndex].forEach(svg => svg.appendChild(boxToSVGRect(box)));
+    }
   }
 };
 
@@ -296,84 +322,14 @@ BookReader.prototype.ttsHighlightChunk = function(chunk) {
 BookReader.prototype.ttsScrollToChunk = function(chunk) {
   if (this.constMode1up != this.mode) return;
 
-  let leafTop = 0;
-  let h;
-  let i;
-  for (i = 0; i < chunk.leafIndex; i++) {
-    h = parseInt(this._getPageHeight(i) / this.reduce);
-    leafTop += h + this.padding;
-  }
-
-  const chunkTop = chunk.lineRects[0][3]; //coords are in l,b,r,t order
-  const chunkBot = chunk.lineRects[chunk.lineRects.length - 1][1];
-
-  const topOfFirstChunk = leafTop + chunkTop / this.reduce;
-  const botOfLastChunk  = leafTop + chunkBot / this.reduce;
-
-  if (window?.soundManager?.debugMode) console.log('leafTop = ' + leafTop + ' topOfFirstChunk = ' + topOfFirstChunk + ' botOfLastChunk = ' + botOfLastChunk);
-
-  const containerTop = this.refs.$brContainer.prop('scrollTop');
-  const containerBot = containerTop + this.refs.$brContainer.height();
-  if (window?.soundManager?.debugMode) console.log('containerTop = ' + containerTop + ' containerBot = ' + containerBot);
-
-  if ((topOfFirstChunk < containerTop) || (botOfLastChunk > containerBot)) {
-    this.refs.$brContainer.stop(true).animate({scrollTop: topOfFirstChunk},'fast');
-  }
-};
-
-/**
- * @param {PageChunk} chunk
- */
-BookReader.prototype.ttsHilite1UP = function(chunk) {
-  for (let i = 0; i < chunk.lineRects.length; i++) {
-    //each rect is an array of l,b,r,t coords (djvu.xml ordering...)
-    const l = chunk.lineRects[i][0];
-    const b = chunk.lineRects[i][1];
-    const r = chunk.lineRects[i][2];
-    const t = chunk.lineRects[i][3];
-
-    const div = document.createElement('div');
-    this.ttsHilites.push(div);
-    $(div).prop('className', 'BookReaderSearchHilite').appendTo(
-      this.$('.pagediv' + chunk.leafIndex)
-    );
-
-    $(div).css({
-      width:  (r - l) / this.reduce + 'px',
-      height: (b - t) / this.reduce + 'px',
-      left:   l / this.reduce + 'px',
-      top:    t / this.reduce + 'px'
-    });
-  }
-
-};
-
-/**
- * @param {PageChunk} chunk
- */
-BookReader.prototype.ttsHilite2UP = function (chunk) {
-  for (let i = 0; i < chunk.lineRects.length; i++) {
-    //each rect is an array of l,b,r,t coords (djvu.xml ordering...)
-    const l = chunk.lineRects[i][0];
-    const b = chunk.lineRects[i][1];
-    const r = chunk.lineRects[i][2];
-    const t = chunk.lineRects[i][3];
-
-    const div = document.createElement('div');
-    this.ttsHilites.push(div);
-    $(div)
-      .prop('className', 'BookReaderSearchHilite BRReadAloudHilite Leaf-' + chunk.leafIndex)
-      .css('zIndex', 3)
-      .appendTo(this.refs.$brTwoPageView);
-    this.setHilightCss2UP(div, chunk.leafIndex, l, r, t, b);
-  }
+  $(`.pagediv${chunk.leafIndex} .ttsHiliteLayer rect`)[0]?.scrollIntoView();
 };
 
 // ttsRemoveHilites()
 //______________________________________________________________________________
 BookReader.prototype.ttsRemoveHilites = function () {
-  $(this.ttsHilites).remove();
-  this.ttsHilites = [];
+  Object.values(this._ttsHiliteLayers).flat().forEach(svg => svg.innerHTML = '');
+  this._ttsBoxesByIndex = {};
 };
 
 /**

--- a/src/plugins/tts/plugin.tts.js
+++ b/src/plugins/tts/plugin.tts.js
@@ -96,7 +96,7 @@ BookReader.prototype._createPageContainer = (function (super_) {
       }
 
       if (pageIndex in this._ttsBoxesByIndex) {
-        this._ttsHiliteLayers[pageIndex].forEach(svg => svg.innerHTML = '');
+        $(this._ttsHiliteLayers[pageIndex]).empty();
         for (const box of this._ttsBoxesByIndex[pageIndex]) {
           this._ttsHiliteLayers[pageIndex].forEach(svg => svg.appendChild(boxToSVGRect(box)));
         }
@@ -328,7 +328,7 @@ BookReader.prototype.ttsScrollToChunk = function(chunk) {
 // ttsRemoveHilites()
 //______________________________________________________________________________
 BookReader.prototype.ttsRemoveHilites = function () {
-  Object.values(this._ttsHiliteLayers).flat().forEach(svg => svg.innerHTML = '');
+  $(Object.values(this._ttsHiliteLayers).flat()).empty();
   this._ttsBoxesByIndex = {};
 };
 

--- a/src/plugins/tts/plugin.tts.js
+++ b/src/plugins/tts/plugin.tts.js
@@ -6,7 +6,7 @@ import FestivalTTSEngine from './FestivalTTSEngine.js';
 import WebTTSEngine from './WebTTSEngine.js';
 import { toISO6391, approximateWordCount } from './utils.js';
 import { en as tooltips } from './tooltip_dict.js';
-import { renderBoxesInPageContainerElement } from '../../BookReader/PageContainer.js';
+import { renderBoxesInPageContainerLayer } from '../../BookReader/PageContainer.js';
 /** @typedef {import('./PageChunk.js').default} PageChunk */
 /** @typedef {import("./AbstractTTSEngine.js").default} AbstractTTSEngine */
 
@@ -86,7 +86,7 @@ BookReader.prototype._createPageContainer = (function (super_) {
     const pageContainer = super_.call(this, index);
     if (this.options.enableTtsPlugin && pageContainer.page && index in this._ttsBoxesByIndex) {
       const pageIndex = pageContainer.page.index;
-      renderBoxesInPageContainerElement('ttsHiliteLayer', this._ttsBoxesByIndex[pageIndex], pageContainer.page, pageContainer.$container[0]);
+      renderBoxesInPageContainerLayer('ttsHiliteLayer', this._ttsBoxesByIndex[pageIndex], pageContainer.page, pageContainer.$container[0]);
     }
     return pageContainer;
   };
@@ -299,7 +299,7 @@ BookReader.prototype.ttsHighlightChunk = function(chunk) {
     const pageIndex = parseFloat(pageIndexString);
     const page = this._models.book.getPage(pageIndex);
     const pageContainers = this.getActivePageContainerElementsForIndex(pageIndex);
-    pageContainers.forEach(container => renderBoxesInPageContainerElement('ttsHiliteLayer', boxes, page, container));
+    pageContainers.forEach(container => renderBoxesInPageContainerLayer('ttsHiliteLayer', boxes, page, container));
   }
 };
 

--- a/tests/BookReader/PageContainer.test.js
+++ b/tests/BookReader/PageContainer.test.js
@@ -1,4 +1,4 @@
-import {PageContainer} from '../../src/BookReader/PageContainer.js';
+import {PageContainer, boxToSVGRect, createSVGPageLayer} from '../../src/BookReader/PageContainer.js';
 
 describe('constructor', () => {
   test('protected books', () => {
@@ -111,5 +111,23 @@ describe('update', () => {
     // expect(pc.$img.css('background').includes('page12.jpg')).toBe(true);
     pc.$img.trigger('loadend');
     expect(pc.$img.css('background')).toBeFalsy();
+  });
+});
+
+describe('createSVGPageLayer', () => {
+  test('Does what it says', () => {
+    const svg = createSVGPageLayer({ width: 100, height: 200}, 'myClass');
+    expect(svg.getAttribute('viewBox')).toBe('0 0 100 200');
+    expect(svg.getAttribute('class')).toContain('myClass');
+  });
+});
+
+describe('boxToSVGRect', () => {
+  test('Does what it says', () => {
+    const rect = boxToSVGRect({ l: 100, r: 200, t: 300, b: 500 });
+    expect(rect.getAttribute('x')).toBe('100');
+    expect(rect.getAttribute('y')).toBe('300');
+    expect(rect.getAttribute('width')).toBe('100');
+    expect(rect.getAttribute('height')).toBe('200');
   });
 });

--- a/tests/BookReader/PageContainer.test.js
+++ b/tests/BookReader/PageContainer.test.js
@@ -1,4 +1,4 @@
-import {PageContainer, boxToSVGRect, createSVGPageLayer} from '../../src/BookReader/PageContainer.js';
+import {PageContainer, boxToSVGRect, createSVGPageLayer, renderBoxesInPageContainerLayer} from '../../src/BookReader/PageContainer.js';
 
 describe('constructor', () => {
   test('protected books', () => {
@@ -129,5 +129,59 @@ describe('boxToSVGRect', () => {
     expect(rect.getAttribute('y')).toBe('300');
     expect(rect.getAttribute('width')).toBe('100');
     expect(rect.getAttribute('height')).toBe('200');
+  });
+});
+
+describe('renderBoxesInPageContainerLayer', () => {
+  test('Handles missing layer', () => {
+    const container = document.createElement('div');
+    const page = { width: 100, height: 200 };
+    const boxes = [{l: 1, r: 2, t: 3, b: 4}];
+    renderBoxesInPageContainerLayer('foo', boxes, page, container);
+    expect(container.querySelector('.foo')).toBeTruthy();
+    expect(container.querySelectorAll('.foo rect').length).toBe(1);
+  });
+
+  test('Handles existing layer', () => {
+    const container = document.createElement('div');
+    const layer = document.createElement('svg');
+    layer.classList.add('foo');
+    container.append(layer);
+
+    const page = { width: 100, height: 200 };
+    const boxes = [{l: 1, r: 2, t: 3, b: 4}];
+    renderBoxesInPageContainerLayer('foo', boxes, page, container);
+    expect(container.querySelector('.foo')).toBe(layer);
+    expect(container.querySelectorAll('.foo rect').length).toBe(1);
+  });
+
+  test('Adds layer after image if it exists', () => {
+    const container = document.createElement('div');
+    const img = document.createElement('img');
+    img.classList.add('BRpageimage');
+    container.append(img);
+
+    const page = { width: 100, height: 200 };
+    const boxes = [{l: 1, r: 2, t: 3, b: 4}];
+    renderBoxesInPageContainerLayer('foo', boxes, page, container);
+    expect(container.querySelector('.foo')).toBeTruthy();
+    expect(container.children[0].getAttribute('class')).toBe('BRpageimage');
+    expect(container.children[1].getAttribute('class')).toBe('BRPageLayer foo');
+  });
+
+  test('Renders all boxes', () => {
+    const container = document.createElement('div');
+    const page = { width: 100, height: 200 };
+    const boxes = [{l: 1, r: 2, t: 3, b: 4}, {l: 1, r: 2, t: 3, b: 4}, {l: 1, r: 2, t: 3, b: 4}];
+    renderBoxesInPageContainerLayer('foo', boxes, page, container);
+    expect(container.querySelectorAll('.foo rect').length).toBe(3);
+  });
+
+  test('Handles no boxes', () => {
+    const container = document.createElement('div');
+    const page = { width: 100, height: 200 };
+    const boxes = [];
+    renderBoxesInPageContainerLayer('foo', boxes, page, container);
+    expect(container.querySelectorAll('.foo rect').length).toBe(0);
   });
 });

--- a/tests/e2e/helpers/desktopSearch.js
+++ b/tests/e2e/helpers/desktopSearch.js
@@ -43,7 +43,7 @@ export function runDesktopSearchTests(br) {
       await t.expect(getPageUrl()).contains(PAGE_FIRST_RESULT);
 
       //checks highlight on result page is visible
-      const highlight = br.shell.find(".BookReaderSearchHilite");
+      const highlight = br.shell.find(".searchHiliteLayer rect");
       await t.expect(highlight.visible).ok();
 
     });

--- a/tests/e2e/helpers/mobileSearch.js
+++ b/tests/e2e/helpers/mobileSearch.js
@@ -47,7 +47,7 @@ export function runMobileSearchTests(br) {
       await t.expect(getPageUrl()).contains(PAGE_FIRST_RESULT);
 
       //checks highlight on result page is visible
-      const highlight = br.shell.find(".BookReaderSearchHilite");
+      const highlight = br.shell.find(".searchHiliteLayer rect");
       await t.expect(highlight.visible).ok();
 
       await t.maximizeWindow();

--- a/tests/plugins/plugin.text_selection.test.js
+++ b/tests/plugins/plugin.text_selection.test.js
@@ -73,7 +73,7 @@ describe("Generic tests", () => {
     sinon.stub(br.textSelectionPlugin, "getPageText")
       .returns($(new DOMParser().parseFromString(FAKE_XML_1WORD, "text/xml")));
     const pageIndex = br.data.length - 1;
-    await br.textSelectionPlugin.createTextLayer(pageIndex, $container);
+    await br.textSelectionPlugin.createTextLayer({ $container, page: { index: pageIndex, width: 100, height: 100 }});
     expect($container.find(".textSelectionSVG").length).toBe(1);
     expect($container.find(".BRparagElement").length).toBe(1);
   });
@@ -83,17 +83,7 @@ describe("Generic tests", () => {
     const xml = FAKE_XML_1WORD.replace(/<WORD.*<\/WORD>/, FAKE_XML_1WORD.match(/<WORD.*<\/WORD>/)[0].repeat(3000));
     sinon.stub(br.textSelectionPlugin, "getPageText")
       .returns($(new DOMParser().parseFromString(xml, "text/xml")));
-    await br.textSelectionPlugin.createTextLayer(0, $container);
-    expect($container.find(".textSelectionSVG").length).toBe(0);
-    expect($container.find(".BRparagElement").length).toBe(0);
-    expect($container.find(".BRwordElement").length).toBe(0);
-  });
-
-  // GRRRR!!! This is a useful test :( But can't get it working for some reason,
-  // and the error output is super cryptic.
-  test.skip("createTextLayer will not create text layer if index is more than total number of book pages", async () => {
-    const $container = br.refs.$brContainer;
-    await br.textSelectionPlugin.createTextLayer(150, $container);
+    await br.textSelectionPlugin.createTextLayer({ $container, page: { index: 0, width: 100, height: 100 }});
     expect($container.find(".textSelectionSVG").length).toBe(0);
     expect($container.find(".BRparagElement").length).toBe(0);
     expect($container.find(".BRwordElement").length).toBe(0);
@@ -103,7 +93,7 @@ describe("Generic tests", () => {
     const $container = br.refs.$brContainer;
     sinon.stub(br.textSelectionPlugin, "getPageText")
       .returns($(new DOMParser().parseFromString(FAKE_XML_1WORD, "text/xml")));
-    await br.textSelectionPlugin.createTextLayer(1, $container);
+    await br.textSelectionPlugin.createTextLayer({ $container, page: { index: 1, width: 100, height: 100 }});
     expect($container.find(".textSelectionSVG").length).toBe(1);
     expect($container.find(".BRparagElement").length).toBe(1);
     expect($container.find(".BRwordElement").length).toBe(1);
@@ -114,7 +104,7 @@ describe("Generic tests", () => {
     const $container = br.refs.$brContainer;
     sinon.stub(br.textSelectionPlugin, "getPageText")
       .returns($(new DOMParser().parseFromString(FAKE_XML_MULT_WORDS, "text/xml")));
-    await br.textSelectionPlugin.createTextLayer(2, $container);
+    await br.textSelectionPlugin.createTextLayer({ $container, page: { index: 2, width: 100, height: 100 }});
     expect($container.find(".textSelectionSVG").length).toBe(1);
     expect($container.find(".BRparagElement").length).toBe(1);
     expect($container.find(".BRwordElement").length).toBe(5);
@@ -125,7 +115,7 @@ describe("Generic tests", () => {
     const $container = br.refs.$brContainer;
     sinon.stub(br.textSelectionPlugin, "getPageText")
       .returns($(new DOMParser().parseFromString(FAKE_XML_5COORDS, "text/xml")));
-    await br.textSelectionPlugin.createTextLayer(3, $container);
+    await br.textSelectionPlugin.createTextLayer({ $container, page: { index: 3, width: 100, height: 100 }});
     expect($container.find(".textSelectionSVG").length).toBe(1);
     expect($container.find(".BRparagElement").length).toBe(1);
     expect($container.find(".BRwordElement").length).toBe(1);
@@ -135,7 +125,7 @@ describe("Generic tests", () => {
     const $container = br.refs.$brContainer;
     sinon.stub(br.textSelectionPlugin, "getPageText")
       .returns($(new DOMParser().parseFromString(FAKE_XML_EMPTY, "text/xml")));
-    await br.textSelectionPlugin.createTextLayer(4, $container);
+    await br.textSelectionPlugin.createTextLayer({ $container, page: { index: 4, width: 100, height: 100 }});
     expect($container.find(".textSelectionSVG").length).toBe(1);
     expect($container.find(".BRparagElement").length).toBe(0);
     expect($container.find(".BRwordElement").length).toBe(0);


### PR DESCRIPTION
Now we don't have to manually update their positions, since they just scale like images! Pre-requisite refactor for Pinch zoom.

Notes:
- ~This does increase the memory footprint a bit :/ Since page containers could be kept around for a potentially long time, and precached/cached, I needed a way to make sure all layers were up-to-date.~
- ~Actually, it introduces a memory leak :/~
    - Both fixed!