### PR TITLE
Textareas should also be keyboard shortcut deadzones

### DIFF
--- a/src/BookReader/utils.js
+++ b/src/BookReader/utils.js
@@ -52,9 +52,10 @@ export function getActiveElement(doc = document, recurseShadowDom = true) {
   return activeElement;
 }
 
-/** Check if an input field is active. Also checks shadow DOMs. */
+/** Check if an input field/textarea is active. Also checks shadow DOMs. */
 export function isInputActive(doc = document) {
-  return getActiveElement(doc)?.tagName == "INPUT";
+  const activeEl = getActiveElement(doc);
+  return activeEl?.tagName == "INPUT" || activeEl?.tagName == "TEXTAREA";
 }
 
 /**

--- a/tests/BookReader/utils.test.js
+++ b/tests/BookReader/utils.test.js
@@ -73,6 +73,11 @@ describe('isInputActive', () => {
     const doc = {activeElement: { shadowRoot: {activeElement: { tagName: 'A' }}}};
     expect(isInputActive(doc)).toBe(false);
   });
+  
+  test('Handles textarea activeElement', () => {
+    const doc = {activeElement: { tagName: 'TEXTAREA' }};
+    expect(isInputActive(doc)).toBe(true);
+  });
 });
 
 describe('debounce', () => {

--- a/tests/BookReader/utils.test.js
+++ b/tests/BookReader/utils.test.js
@@ -73,7 +73,7 @@ describe('isInputActive', () => {
     const doc = {activeElement: { shadowRoot: {activeElement: { tagName: 'A' }}}};
     expect(isInputActive(doc)).toBe(false);
   });
-  
+
   test('Handles textarea activeElement', () => {
     const doc = {activeElement: { tagName: 'TEXTAREA' }};
     expect(isInputActive(doc)).toBe(true);


### PR DESCRIPTION
To test:

Go to one of the demos.

Run this JS:

```js
customElements.define('test-element', class extends HTMLElement {
  constructor() {
    super();
    this.attachShadow({mode: 'open'});
    this.shadowRoot.append(document.createElement('textarea'));
  }
});
$(document.body).prepend($(`<test-element/>`));
```

Type in the added input.

- [x] Confirm keyboard shortcuts work when the input does not have focus
- [x] Confirm keyboard shortcuts do not work when the input does have focus
- [x] Confirm keyboard shortcuts do not work when typing in searchbox in side panel
- [x] Confirm keyboard shortcuts do not work when typing in searchbox in header