### PR TITLE
Bump @internetarchive/ia-icons from 1.2.2 to 1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4029,9 +4029,9 @@
       }
     },
     "@internetarchive/ia-icons": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@internetarchive/ia-icons/-/ia-icons-1.2.2.tgz",
-      "integrity": "sha512-JvKFbQa4IcpPIZwIT4uW7LvEzVsP+WsXLAhzGgABbRErk3cmor971R1gd2JgKT/N2xc8yIs5NxeHk70S+nh49Q==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@internetarchive/ia-icons/-/ia-icons-1.2.3.tgz",
+      "integrity": "sha512-dhRvTqCd39UtWfTlz8NjnaWI11fYv5Hsn8S1YZu88+LP6cR/y/q0XDIhOZhfGVZ68gf/fuEUIA+4f1W/PP5ifA==",
       "requires": {
         "@internetarchive/icon-advance": "^1.1.3",
         "@internetarchive/icon-applepay": "^1.1.3",
@@ -4039,6 +4039,7 @@
         "@internetarchive/icon-calendar": "^1.1.3",
         "@internetarchive/icon-calendar-blank": "^1.1.3",
         "@internetarchive/icon-close": "^1.1.3",
+        "@internetarchive/icon-close-circle": "^1.0.1",
         "@internetarchive/icon-collapse-sidebar": "^1.1.3",
         "@internetarchive/icon-credit-card": "^1.1.3",
         "@internetarchive/icon-dl": "^1.1.3",
@@ -4060,6 +4061,8 @@
         "@internetarchive/icon-search": "^1.2.3",
         "@internetarchive/icon-share": "^1.1.3",
         "@internetarchive/icon-software": "^1.1.3",
+        "@internetarchive/icon-sort-ascending": "^1.0.5",
+        "@internetarchive/icon-sort-descending": "^1.0.5",
         "@internetarchive/icon-texts": "^1.1.3",
         "@internetarchive/icon-toc": "^1.1.3",
         "@internetarchive/icon-tumblr": "^1.1.3",
@@ -4154,6 +4157,25 @@
       "integrity": "sha512-Fa39kI7CXq+ZbtNUwWa86/qkb5b1YJb2lD6bD3bVaaYL3/MWVBZ3eU/6GNhOkw/PoUpqwjdAYt1veOP+HHKePg==",
       "requires": {
         "lit-html": "^1.2.1"
+      }
+    },
+    "@internetarchive/icon-close-circle": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-close-circle/-/icon-close-circle-1.0.1.tgz",
+      "integrity": "sha512-qYSm9DUegdhjH8AZti9Q3aoGEJlI8h3Bcz8KLOAVnhVUyAMZ8sstkEJPswCDysiS8Aq6Dl9CV8IWoNnyAPs1XA==",
+      "requires": {
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.2.1"
+      },
+      "dependencies": {
+        "lit-element": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.5.1.tgz",
+          "integrity": "sha512-ogu7PiJTA33bEK0xGu1dmaX5vhcRjBXCFexPja0e7P7jqLhTpNKYRPmE+GmiCaRVAbiQKGkUgkh/i6+bh++dPQ==",
+          "requires": {
+            "lit-html": "^1.1.1"
+          }
+        }
       }
     },
     "@internetarchive/icon-collapse-sidebar": {
@@ -4320,6 +4342,22 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@internetarchive/icon-software/-/icon-software-1.1.3.tgz",
       "integrity": "sha512-tHpajklRFlzUoCrT8y844L5i2KXPRGx0QqJkyuBBN3zopMcG2LxVaOmV7G1ukQ7WDtDhv+1XKQB1KExoHusbXg==",
+      "requires": {
+        "lit-html": "^1.2.1"
+      }
+    },
+    "@internetarchive/icon-sort-ascending": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-sort-ascending/-/icon-sort-ascending-1.0.5.tgz",
+      "integrity": "sha512-KCuKE15Yi0Qejfb2x8XdUvZH41ih9BRhq940wOCfg7AND4k+REAXkHMx9ta2nWKHmZARCYXFllahQsQ6WQAgww==",
+      "requires": {
+        "lit-html": "^1.2.1"
+      }
+    },
+    "@internetarchive/icon-sort-descending": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-sort-descending/-/icon-sort-descending-1.0.5.tgz",
+      "integrity": "sha512-HEvtnMSrmvutNKePX4qt3vNPg9tN0aHGDIVJPI+LwjVALkyWzvBxDcbTjHxp8+PgovFGRR3lWDxmpiL5V66zdg==",
       "requires": {
         "lit-html": "^1.2.1"
       }


### PR DESCRIPTION
Bumps @internetarchive/ia-icons from 1.2.2 to 1.2.3.

---
updated-dependencies:
- dependency-name: "@internetarchive/ia-icons"
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>