### PR TITLE
Make jest tests support root-level importing

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,10 +2,15 @@
   "compilerOptions": {
     "target": "es6",
     "moduleResolution": "node",
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": [
-    "src/**/*.js"
+    "src/**/*.js",
+    "tests/**/*.js",
   ],
   "exclude": [
     "node_modules",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
     "transformIgnorePatterns": [
       "node_modules/(?!(lit-html|lit-element|lit)/)"
     ],
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/$1"
+    },
     "setupFiles": [
       "./src/jquery-wrapper.js"
     ],

--- a/tests/BookReader.options.test.js
+++ b/tests/BookReader.options.test.js
@@ -1,5 +1,5 @@
 
-import BookReader from '../src/BookReader.js';
+import BookReader from '@/src/BookReader.js';
 
 beforeAll(() => {
   document.body.innerHTML = '<div id="BookReader">';

--- a/tests/BookReader.test.js
+++ b/tests/BookReader.test.js
@@ -1,7 +1,7 @@
 
-import BookReader from '../src/BookReader.js';
-import '../src/plugins/plugin.resume.js';
-import '../src/plugins/plugin.url.js';
+import BookReader from '@/src/BookReader.js';
+import '@/src/plugins/plugin.resume.js';
+import '@/src/plugins/plugin.url.js';
 
 let br;
 beforeAll(() => {

--- a/tests/BookReader/BookModel.test.js
+++ b/tests/BookReader/BookModel.test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import { deepCopy } from '../utils.js';
-import { BookModel } from '../../src/BookReader/BookModel.js';
-/** @typedef {import('../../src/BookReader/options.js').BookReaderOptions} BookReaderOptions */
+import { BookModel } from '@/src/BookReader/BookModel.js';
+/** @typedef {import('@/src/BookReader/options.js').BookReaderOptions} BookReaderOptions */
 
 afterEach(() => {
   sinon.restore();

--- a/tests/BookReader/BookReaderPublicFunctions.test.js
+++ b/tests/BookReader/BookReaderPublicFunctions.test.js
@@ -1,4 +1,4 @@
-import BookReader from '../../src/BookReader';
+import BookReader from '@/src/BookReader';
 
 beforeAll(() => {
   global.alert = jest.fn();

--- a/tests/BookReader/DebugConsole.test.js
+++ b/tests/BookReader/DebugConsole.test.js
@@ -1,5 +1,5 @@
 import sinon from 'sinon';
-import { DebugConsole } from '../../src/BookReader/DebugConsole.js';
+import { DebugConsole } from '@/src/BookReader/DebugConsole.js';
 
 beforeEach(() => {
   sinon.stub(console, 'log');

--- a/tests/BookReader/ImageCache.test.js
+++ b/tests/BookReader/ImageCache.test.js
@@ -1,8 +1,8 @@
 import sinon from 'sinon';
-import { BookModel } from '../../src/BookReader/BookModel.js';
-import { ImageCache } from '../../src/BookReader/ImageCache.js';
-import { Pow2ReduceSet } from '../../src/BookReader/ReduceSet.js';
-/** @typedef {import('../../src/BookReader/options.js').BookReaderOptions} BookReaderOptions */
+import { BookModel } from '@/src/BookReader/BookModel.js';
+import { ImageCache } from '@/src/BookReader/ImageCache.js';
+import { Pow2ReduceSet } from '@/src/BookReader/ReduceSet.js';
+/** @typedef {import('@/src/BookReader/options.js').BookReaderOptions} BookReaderOptions */
 
 afterEach(() => {
   jest.restoreAllMocks();

--- a/tests/BookReader/Mode1UpLit.test.js
+++ b/tests/BookReader/Mode1UpLit.test.js
@@ -1,7 +1,7 @@
-import { BookModel } from '../../src/BookReader/BookModel.js';
-import { Mode1UpLit } from '../../src/BookReader/Mode1UpLit.js';
+import { BookModel } from '@/src/BookReader/BookModel.js';
+import { Mode1UpLit } from '@/src/BookReader/Mode1UpLit.js';
 
-/** @type {import('../../src/BookReader/options.js').BookReaderOptions['data']} */
+/** @type {import('@/src/BookReader/options.js').BookReaderOptions['data']} */
 const SAMPLE_DATA = [
   [
     { width: 123, height: 123, uri: 'https://archive.org/image0.jpg', pageNum: '1' },

--- a/tests/BookReader/Mode2Up.test.js
+++ b/tests/BookReader/Mode2Up.test.js
@@ -1,8 +1,8 @@
 
 import sinon from 'sinon';
 import { deepCopy } from '../utils.js';
-import BookReader from '../../src/BookReader.js';
-/** @typedef {import('../../src/BookReader/options.js').BookReaderOptions} BookReaderOptions */
+import BookReader from '@/src/BookReader.js';
+/** @typedef {import('@/src/BookReader/options.js').BookReaderOptions} BookReaderOptions */
 
 beforeAll(() => {
   global.alert = jest.fn();

--- a/tests/BookReader/ModeSmoothZoom.test.js
+++ b/tests/BookReader/ModeSmoothZoom.test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import { EventTargetSpy } from '../utils.js';
-import { ModeSmoothZoom } from '../../src/BookReader/ModeSmoothZoom.js';
-/** @typedef {import('../../src/BookReader/ModeSmoothZoom.js').SmoothZoomable} SmoothZoomable */
+import { ModeSmoothZoom } from '@/src/BookReader/ModeSmoothZoom.js';
+/** @typedef {import('@/src/BookReader/ModeSmoothZoom.js').SmoothZoomable} SmoothZoomable */
 
 /**
  * @param {Partial<SmoothZoomable>} overrides

--- a/tests/BookReader/Navbar/Navbar.test.js
+++ b/tests/BookReader/Navbar/Navbar.test.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
-import { getNavPageNumHtml } from '../../../src/BookReader/Navbar/Navbar.js';
-import BookReader from '../../../src/BookReader.js';
+import { getNavPageNumHtml } from '@/src/BookReader/Navbar/Navbar.js';
+import BookReader from '@/src/BookReader.js';
 
 describe('getNavPageNumHtml', () => {
   const f = getNavPageNumHtml;

--- a/tests/BookReader/PageContainer.test.js
+++ b/tests/BookReader/PageContainer.test.js
@@ -1,4 +1,4 @@
-import {PageContainer, boxToSVGRect, createSVGPageLayer, renderBoxesInPageContainerLayer} from '../../src/BookReader/PageContainer.js';
+import {PageContainer, boxToSVGRect, createSVGPageLayer, renderBoxesInPageContainerLayer} from '@/src/BookReader/PageContainer.js';
 
 describe('constructor', () => {
   test('protected books', () => {

--- a/tests/BookReader/ReduceSet.test.js
+++ b/tests/BookReader/ReduceSet.test.js
@@ -1,4 +1,4 @@
-import {IntegerReduceSet, Pow2ReduceSet} from '../../src/BookReader/ReduceSet.js';
+import {IntegerReduceSet, Pow2ReduceSet} from '@/src/BookReader/ReduceSet.js';
 
 describe('IntegerReduceSet', () => {
   test('floor', () => {

--- a/tests/BookReader/Toolbar/Toolbar.test.js
+++ b/tests/BookReader/Toolbar/Toolbar.test.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 
-import { createPopup } from '../../../src/BookReader/Toolbar/Toolbar.js';
+import { createPopup } from '@/src/BookReader/Toolbar/Toolbar.js';
 
 afterEach(() => {
   sinon.restore();

--- a/tests/BookReader/utils.test.js
+++ b/tests/BookReader/utils.test.js
@@ -10,7 +10,7 @@ import {
   isInputActive,
   polyfillCustomEvent,
   PolyfilledCustomEvent,
-} from '../../src/BookReader/utils.js';
+} from '@/src/BookReader/utils.js';
 
 test('clamp function returns Math.min(Math.max(value, min), max)', () => {
   expect(clamp(2,1,3)).toEqual(2);

--- a/tests/BookReader/utils/HTMLDimensionsCacher.test.js
+++ b/tests/BookReader/utils/HTMLDimensionsCacher.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import  sinon from 'sinon';
-import { HTMLDimensionsCacher } from '../../../src/BookReader/utils/HTMLDimensionsCacher';
+import { HTMLDimensionsCacher } from '@/src/BookReader/utils/HTMLDimensionsCacher';
 
 describe('HTMLDimensionsCacher', () => {
   test('Does not read from element directly', () => {

--- a/tests/BookReader/utils/classes.test.js
+++ b/tests/BookReader/utils/classes.test.js
@@ -1,4 +1,4 @@
-import { exposeOverrideable } from '../../../src/BookReader/utils/classes.js';
+import { exposeOverrideable } from '@/src/BookReader/utils/classes.js';
 
 describe('exposeOverrideable', () => {
   test('adds method to To class', () => {

--- a/tests/plugins/plugin.archive_analytics.test.js
+++ b/tests/plugins/plugin.archive_analytics.test.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
-import BookReader from '../../src/BookReader.js';
-import '../../src/plugins/plugin.archive_analytics.js';
+import BookReader from '@/src/BookReader.js';
+import '@/src/plugins/plugin.archive_analytics.js';
 
 describe('archiveAnalyticsSendEvent', () => {
   const sendEvent = BookReader.prototype.archiveAnalyticsSendEvent;

--- a/tests/plugins/plugin.autoplay.test.js
+++ b/tests/plugins/plugin.autoplay.test.js
@@ -1,6 +1,6 @@
 
-import BookReader from '../../src/BookReader.js';
-import '../../src/plugins/plugin.autoplay.js';
+import BookReader from '@/src/BookReader.js';
+import '@/src/plugins/plugin.autoplay.js';
 
 
 let br;

--- a/tests/plugins/plugin.chapters.test.js
+++ b/tests/plugins/plugin.chapters.test.js
@@ -1,8 +1,8 @@
 import sinon from 'sinon';
 
-import BookReader from '../../src/BookReader.js';
-import '../../src/plugins/plugin.mobile_nav.js';
-import '../../src/plugins/plugin.chapters.js';
+import BookReader from '@/src/BookReader.js';
+import '@/src/plugins/plugin.mobile_nav.js';
+import '@/src/plugins/plugin.chapters.js';
 
 const SAMPLE_TOC = [{
   "pagenum": "3",

--- a/tests/plugins/plugin.iframe.test.js
+++ b/tests/plugins/plugin.iframe.test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 
-import BookReader from '../../src/BookReader.js';
-import { _attachEventListeners } from '../../src/plugins/plugin.iframe.js';
+import BookReader from '@/src/BookReader.js';
+import { _attachEventListeners } from '@/src/plugins/plugin.iframe.js';
 
 afterEach(() => {
   sinon.restore();

--- a/tests/plugins/plugin.mobile_nav.test.js
+++ b/tests/plugins/plugin.mobile_nav.test.js
@@ -1,6 +1,6 @@
 
-import BookReader from '../../src/BookReader.js';
-import '../../src/plugins/plugin.mobile_nav.js';
+import BookReader from '@/src/BookReader.js';
+import '@/src/plugins/plugin.mobile_nav.js';
 
 /** @type {BookReader} */
 let br;

--- a/tests/plugins/plugin.resume.test.js
+++ b/tests/plugins/plugin.resume.test.js
@@ -1,8 +1,8 @@
-import BookReader from '../../src/BookReader.js';
-import '../../src/plugins/plugin.resume.js';
+import BookReader from '@/src/BookReader.js';
+import '@/src/plugins/plugin.resume.js';
 
 import sinon from 'sinon';
-import * as docCookies from '../../src/util/docCookies.js';
+import * as docCookies from '@/src/util/docCookies.js';
 
 let br;
 beforeAll(() => {

--- a/tests/plugins/plugin.text_selection.test.js
+++ b/tests/plugins/plugin.text_selection.test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 
-import '../../src/BookReader.js';
-import { BookreaderWithTextSelection, TextSelectionPlugin, Cache } from '../../src/plugins/plugin.text_selection.js';
+import '@/src/BookReader.js';
+import { BookreaderWithTextSelection, TextSelectionPlugin, Cache } from '@/src/plugins/plugin.text_selection.js';
 
 
 /** @type {BookReader} */

--- a/tests/plugins/plugin.url.test.js
+++ b/tests/plugins/plugin.url.test.js
@@ -1,6 +1,6 @@
 
-import BookReader from '../../src/BookReader.js';
-import '../../src/plugins/plugin.url.js';
+import BookReader from '@/src/BookReader.js';
+import '@/src/plugins/plugin.url.js';
 
 let br;
 beforeAll(() => {

--- a/tests/plugins/plugin.vendor-fullscreen.test.js
+++ b/tests/plugins/plugin.vendor-fullscreen.test.js
@@ -1,6 +1,6 @@
 
-import BookReader from '../../src/BookReader.js';
-import * as util from '../../src/plugins/plugin.vendor-fullscreen.js';
+import BookReader from '@/src/BookReader.js';
+import * as util from '@/src/plugins/plugin.vendor-fullscreen.js';
 
 let br;
 beforeEach(() => {

--- a/tests/plugins/search/plugin.search.test.js
+++ b/tests/plugins/search/plugin.search.test.js
@@ -1,9 +1,9 @@
 
-import BookReader from '../../../src/BookReader.js';
-import '../../../src/plugins/plugin.mobile_nav.js';
-import '../../../src/plugins/search/plugin.search.js';
+import BookReader from '@/src/BookReader.js';
+import '@/src/plugins/plugin.mobile_nav.js';
+import '@/src/plugins/search/plugin.search.js';
 
-jest.mock('../../../src/plugins/search/view.js');
+jest.mock('@/src/plugins/search/view.js');
 
 let br;
 const namespace = 'BookReader:';

--- a/tests/plugins/search/plugin.search.view.test.js
+++ b/tests/plugins/search/plugin.search.view.test.js
@@ -1,8 +1,8 @@
 
-import BookReader from '../../../src/BookReader.js';
-import '../../../src/plugins/plugin.mobile_nav.js';
-import '../../../src/plugins/search/plugin.search.js';
-import '../../../src/plugins/search/view.js';
+import BookReader from '@/src/BookReader.js';
+import '@/src/plugins/plugin.mobile_nav.js';
+import '@/src/plugins/search/plugin.search.js';
+import '@/src/plugins/search/view.js';
 
 let br;
 const namespace = 'BookReader:';

--- a/tests/plugins/tts/AbstractTTSEngine.test.js
+++ b/tests/plugins/tts/AbstractTTSEngine.test.js
@@ -1,8 +1,8 @@
 import sinon from 'sinon';
 import { afterEventLoop } from '../../utils.js';
-import AbstractTTSEngine from '../../../src/plugins/tts/AbstractTTSEngine.js';
-import PageChunkIterator from '../../../src/plugins/tts/PageChunkIterator.js';
-/** @typedef {import('../../../src/plugins/tts/AbstractTTSEngine.js').TTSEngineOptions} TTSEngineOptions */
+import AbstractTTSEngine from '@/src/plugins/tts/AbstractTTSEngine.js';
+import PageChunkIterator from '@/src/plugins/tts/PageChunkIterator.js';
+/** @typedef {import('@/src/plugins/tts/AbstractTTSEngine.js').TTSEngineOptions} TTSEngineOptions */
 
 // Skipping because it's flaky. Fix in #672
 describe.skip('AbstractTTSEngine', () => {

--- a/tests/plugins/tts/FestivalTTSEngine.test.js
+++ b/tests/plugins/tts/FestivalTTSEngine.test.js
@@ -1,10 +1,10 @@
-import FestivalTTSEngine from '../../../src/plugins/tts/FestivalTTSEngine.js';
+import FestivalTTSEngine from '@/src/plugins/tts/FestivalTTSEngine.js';
 import sinon from 'sinon';
 import { afterEventLoop } from '../../utils.js';
 import { DUMMY_TTS_ENGINE_OPTS } from './AbstractTTSEngine.test.js';
-import PageChunk from '../../../src/plugins/tts/PageChunk.js';
-import PageChunkIterator from '../../../src/plugins/tts/PageChunkIterator.js';
-/** @typedef {import('../../../src/plugins/tts/AbstractTTSEngine.js').TTSEngineOptions} TTSEngineOptions */
+import PageChunk from '@/src/plugins/tts/PageChunk.js';
+import PageChunkIterator from '@/src/plugins/tts/PageChunkIterator.js';
+/** @typedef {import('@/src/plugins/tts/AbstractTTSEngine.js').TTSEngineOptions} TTSEngineOptions */
 
 describe('iOSCaptureUserIntentHack', () => {
   test('synchronously calls createSound/play to capture user intent', () => {

--- a/tests/plugins/tts/PageChunk.test.js
+++ b/tests/plugins/tts/PageChunk.test.js
@@ -1,4 +1,4 @@
-import PageChunk from '../../../src/plugins/tts/PageChunk.js';
+import PageChunk from '@/src/plugins/tts/PageChunk.js';
 
 describe('_fixChunkRects', () => {
   const { _fixChunkRects } = PageChunk;

--- a/tests/plugins/tts/PageChunkIterator.test.js
+++ b/tests/plugins/tts/PageChunkIterator.test.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
-import PageChunkIterator from "../../../src/plugins/tts/PageChunkIterator";
-import PageChunk from '../../../src/plugins/tts/PageChunk';
+import PageChunkIterator from "@/src/plugins/tts/PageChunkIterator";
+import PageChunk from '@/src/plugins/tts/PageChunk';
 
 describe('Buffers pages', () => {
   test('Does not error if no room for reverse buffer', async () => {

--- a/tests/plugins/tts/WebTTSEngine.test.js
+++ b/tests/plugins/tts/WebTTSEngine.test.js
@@ -1,5 +1,5 @@
 import sinon from 'sinon';
-import { WebTTSSound } from '../../../src/plugins/tts/WebTTSEngine.js';
+import { WebTTSSound } from '@/src/plugins/tts/WebTTSEngine.js';
 import { afterEventLoop, eventTargetMixin } from '../../utils.js';
 
 beforeEach(() => {

--- a/tests/plugins/tts/utils.test.js
+++ b/tests/plugins/tts/utils.test.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import { afterEventLoop, eventTargetMixin } from '../../utils.js';
-import * as utils from '../../../src/plugins/tts/utils.js';
+import * as utils from '@/src/plugins/tts/utils.js';
 
 describe('promisifyEvent', () => {
   const { promisifyEvent } = utils;

--- a/tests/util/browserSniffing.test.js
+++ b/tests/util/browserSniffing.test.js
@@ -1,6 +1,6 @@
 import {
   isChrome, isFirefox, isSafari,
-} from '../../src/util/browserSniffing.js';
+} from '@/src/util/browserSniffing.js';
 
 const TESTS = [
   {

--- a/tests/util/docCookies.test.js
+++ b/tests/util/docCookies.test.js
@@ -1,4 +1,4 @@
-import * as docCookies from '../../src/util/docCookies.js';
+import * as docCookies from '@/src/util/docCookies.js';
 
 afterEach(() => {
   jest.clearAllMocks();

--- a/tests/util/strings.test.js
+++ b/tests/util/strings.test.js
@@ -1,4 +1,4 @@
-import { APPLY_FILTERS, applyVariables } from '../../src/util/strings.js';
+import { APPLY_FILTERS, applyVariables } from '@/src/util/strings.js';
 
 describe('applyVariables', () => {
   test('null cases', () => {


### PR DESCRIPTION
This avoids the headache of nested ../../../src, and we still get auto-complete in vs code!

CC @dualcnhq 