### PR TITLE
Resolved eslint on $.browser

### DIFF
--- a/src/plugins/tts/FestivalTTSEngine.js
+++ b/src/plugins/tts/FestivalTTSEngine.js
@@ -23,7 +23,7 @@ export default class FestivalTTSEngine extends AbstractTTSEngine {
     // $.browsers is sometimes undefined on some Android browsers :/
     // Likely related to when $.browser was moved to npm
     /** @type {'mp3' | 'ogg'} format of audio to get */
-    this.audioFormat = $.browser?.mozilla ? 'ogg' : 'mp3';
+    this.audioFormat = $.browser?.mozilla ? 'ogg' : 'mp3'; //eslint-disable-line
   }
 
   /** @override */

--- a/src/plugins/tts/FestivalTTSEngine.js
+++ b/src/plugins/tts/FestivalTTSEngine.js
@@ -23,7 +23,7 @@ export default class FestivalTTSEngine extends AbstractTTSEngine {
     // $.browsers is sometimes undefined on some Android browsers :/
     // Likely related to when $.browser was moved to npm
     /** @type {'mp3' | 'ogg'} format of audio to get */
-    this.audioFormat = $.browser?.mozilla ? 'ogg' : 'mp3'; //eslint-disable-line
+    this.audioFormat = $.browser?.mozilla ? 'ogg' : 'mp3'; //eslint-disable-line no-jquery/no-browser
   }
 
   /** @override */


### PR DESCRIPTION
Resolves Issue #899 
Added the `//eslint-disable-line` comment to line 26 so that it disables all warnings for that particular line only.
Kindly review @cdrini 
