### PR TITLE
search inside request: turn on cache for request (removes random string in url)

### DIFF
--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -213,6 +213,7 @@ BookReader.prototype.search = function(term = '', overrides = {}) {
   return $.ajax({
     url: url,
     dataType: 'jsonp',
+    cache: true,
     beforeSend,
     jsonpCallback: 'BRSearchInProgress'
   }).then(processSearchResults);


### PR DESCRIPTION
Problem: jQuery AJAX JSONP calls are no cache by default.

Even if search endpoint returns cache header, there is a random string in URL that prevents browser to cache request.

Task: set `cache: true` in AJAX config








WEBDEV-4972

