### PR TITLE
Update hyphen stitching regex to include dangling "¬" (not signs)

### DIFF
--- a/src/plugins/tts/PageChunk.js
+++ b/src/plugins/tts/PageChunk.js
@@ -97,7 +97,10 @@ export default class PageChunk {
    * @return {string}
    */
   static _removeDanglingHyphens(text) {
-    return text.replace(/-\s+/g, '');
+    // Some books mis-OCR a dangling hyphen as a ¬ (mathematical not sign) . Since in math
+    // the not sign should not appear followed by a space, we think we can safely assume
+    // this should be replaced.
+    return text.replace(/[-¬]\s+/g, '');
   }
 }
 


### PR DESCRIPTION
Some books mis-OCR a dangling hyphen as a ¬ (mathematical not sign) . Since in math the not sign should not appear followed by a space, we think we can safely assume this should be replaced.

Reported on twitter: https://twitter.com/neurdy/status/1484567701666156546

Tested with the word "Between" on the right page here, in Chrome: https://archive.org/details/contestedknowled0000seid_x2i5/page/230/mode/2up