### PR TITLE
Pop open side menu

### DIFF
--- a/BookReaderDemo/IADemoBr.js
+++ b/BookReaderDemo/IADemoBr.js
@@ -1,4 +1,5 @@
 /* global BookReader, BookReaderJSIAinit */
+import { extraVolOptions, custvolumesManifest } from './ia-multiple-volumes-manifest.js';
 
 /**
  * This is how Internet Archive loads bookreader
@@ -74,6 +75,18 @@ const initializeBookReader = (brManifest) => {
     br.autoToggle(customAutoflipParams);
   }
 };
+
+window.initializeBookReader = initializeBookReader;
+
+const multiVolume = document.querySelector('#multi-volume');
+multiVolume.addEventListener('click', () => {
+  // remove everything
+  $('#BookReader').empty();
+  delete window.br;
+  // and re-mount with a new book
+  BookReaderJSIAinit(custvolumesManifest, extraVolOptions);
+});
+
 
 const fetchBookManifestAndInitializeBookreader = async (iaMetadata) => {
   document.querySelector('input[name="itemMD"]').checked = true;

--- a/BookReaderDemo/demo-internetarchive.html
+++ b/BookReaderDemo/demo-internetarchive.html
@@ -38,9 +38,6 @@
     <!-- IA scripts -->
     <script src="https://archive.org/bookreader/BookReaderJSIA.js"></script>
 
-    <!-- IA fetch demo -->
-    <script type="module" src="IADemoBr.js"></script>
-
   </head>
 
 <body>
@@ -79,6 +76,9 @@
       <button id="toggle-loggedin">Toggle Logged in view</button>
       <p>Features behind signed in gate: Bookmarks</p>
       <p>Logged In Status: <span id="logged-in-status">Logged Out</span></p>
+    </div>
+    <div class="demo">
+      <button id="multi-volume">Multiple books</button>
     </div>
     <div class="demo">
       <button id="start-fs">Start at Fullscreen</button>
@@ -124,5 +124,8 @@
       placeholder.innerHTML = 'Dependencies are complete, bookreader has loaded';
     });
   </script>
+
+  <!-- IA fetch demo -->
+  <script type="module" src="IADemoBr.js"></script>
 </body>
 </html>

--- a/BookReaderDemo/ia-multiple-volumes-manifest.js
+++ b/BookReaderDemo/ia-multiple-volumes-manifest.js
@@ -1,0 +1,170 @@
+/* eslint-disable no-useless-escape */
+const extraVolOptions = {
+  "isBeta": false,
+  "el": "#BookReader",
+  "enableBookTitleLink": false,
+  "bookUrlText": null,
+  "startFullscreen": false,
+  "initialSearchTerm": null,
+  "onePage": {
+    "autofit": "auto"
+  },
+  "showToolbar": false,
+  "autoResize": false,
+  "enableFSLogoShortcut": true,
+  "enableBookmarks": true,
+  "enableMultipleBooks": true,
+  "purchase_url": "",
+  "multipleBooksList": {
+    "by_subprefix": {
+      "book1/GPORFP": {
+        "url_path": "/details/SubBookTest",
+        "file_subprefix": "book1/GPORFP",
+        "title": "book1/GPORFP.pdf",
+        "file_source": "/book1/GPORFP_jp2.zip",
+        "orig_sort": 0
+      },
+      "subdir/book2/brewster_kahle_internet_archive": {
+        "url_path": "/details/SubBookTest/subdir/book2/brewster_kahle_internet_archive",
+        "file_subprefix": "subdir/book2/brewster_kahle_internet_archive",
+        "title": "subdir/book2/brewster_kahle_internet_archive.pdf",
+        "file_source": "/subdir/book2/brewster_kahle_internet_archive_jp2.zip",
+        "orig_sort": 1
+      },
+      "subdir/subsubdir/book3/Rfp008011ResponseInternetArchive-without-resume": {
+        "url_path": "/details/SubBookTest/subdir/subsubdir/book3/Rfp008011ResponseInternetArchive-without-resume",
+        "file_subprefix": "subdir/subsubdir/book3/Rfp008011ResponseInternetArchive-without-resume",
+        "title": "subdir/subsubdir/book3/Rfp008011ResponseInternetArchive-without-resume.pdf",
+        "file_source": "/subdir/subsubdir/book3/Rfp008011ResponseInternetArchive-without-resume_jp2.zip",
+        "orig_sort": 2
+      }
+    },
+    "main_dir": "/2/items/SubBookTest"
+  }
+};
+const custvolumesManifest = {
+  "data": {
+    "streamOnly": false,
+    "isRestricted": false,
+    "id": "SubBookTest",
+    "subPrefix": "book1/GPORFP",
+    "olHost": "https://openlibrary.org",
+    "bookUrl": "/details/SubBookTest",
+    "downloadUrls": [
+      [
+        "PDF",
+        "//archive.org/download/SubBookTest/book1/GPORFP.pdf"
+      ],
+      [
+        "ePub",
+        "//archive.org/download/SubBookTest/book1/GPORFP.epub"
+      ],
+      [
+        "Plain Text",
+        "//archive.org/download/SubBookTest/book1/GPORFP_djvu.txt"
+      ],
+      [
+        "DAISY",
+        "//archive.org/download/SubBookTest/book1/GPORFP_daisy.zip"
+      ],
+      [
+        "Kindle",
+        "//archive.org/download/SubBookTest/book1/GPORFP.mobi"
+      ]
+    ]
+  },
+  "brOptions": {
+    "bookId": "SubBookTest",
+    "bookPath": "/2/items/SubBookTest/book1/GPORFP",
+    "imageFormat": "jp2",
+    "server": "ia800304.us.archive.org",
+    "subPrefix": "book1/GPORFP",
+    "zip": "/2/items/SubBookTest/book1/GPORFP_jp2.zip",
+    "bookTitle": "Test with sub-dirs",
+    "ppi": "600",
+    "defaultStartLeaf": 0,
+    "pageProgression": "lr",
+    "vars": {
+      "bookId": "SubBookTest",
+      "bookPath": "/2/items/SubBookTest/book1/GPORFP",
+      "server": "ia800304.us.archive.org",
+      "subPrefix": "book1/GPORFP"
+    },
+    "plugins": {
+      "textSelection": {
+        "enabled": true,
+        "singlePageDjvuXmlUrl": "https://{{server}}/BookReader/BookReaderGetTextWrapper.php?path={{bookPath|urlencode}}_djvu.xml&mode=djvu_xml&page={{pageIndex}}"
+      }
+    },
+    "data": [
+      [
+        {
+          "width": 5213,
+          "height": 6566,
+          "uri": "https://ia800304.us.archive.org/BookReader/BookReaderImages.php?zip=/2/items/SubBookTest/book1/GPORFP_jp2.zip&file=GPORFP_jp2/GPORFP_0000.jp2&id=SubBookTest",
+          "leafNum": 0,
+          "uri_2": {
+            "link": "https://archive.org/download/SubBookTest/book1/GPORFP_jp2.zip/GPORFP_jp2%2FGPORFP_0000.jp2",
+            "base_params": "ext=jpg"
+          },
+          "pageType": "Title",
+          "pageSide": "R"
+        }
+      ]
+    ]
+  },
+  "lendingInfo": {
+    "lendingStatus": null,
+    "userid": 0,
+    "isAdmin": false,
+    "isArchiveOrgLending": false,
+    "isOpenLibraryLending": false,
+    "isLendingRequired": false,
+    "isBrowserBorrowable": false,
+    "isPrintDisabledOnly": false,
+    "isAvailable": false,
+    "isAvailableForBrowsing": false,
+    "userHasBorrowed": false,
+    "userHasBrowsed": false,
+    "userOnWaitingList": false,
+    "userHoldIsReady": false,
+    "userIsPrintDisabled": false,
+    "shouldProtectImages": false,
+    "daysLeftOnLoan": 0,
+    "secondsLeftOnLoan": 0,
+    "loansUrl": "",
+    "bookUrl": "",
+    "loanCount": 0,
+    "totalWaitlistCount": 0,
+    "userWaitlistPosition": -1,
+    "maxLoans": 10,
+    "loanRecord": [
+
+    ]
+  },
+  "metadata": {
+    "identifier": "SubBookTest",
+    "title": "Test with sub-dirs",
+    "mediatype": "texts",
+    "collection": [
+      "opensource",
+      "community"
+    ],
+    "publicdate": "2009-07-08 23:10:10",
+    "addeddate": "2009-07-08 23:09:09",
+    "uploader": "mang@archive.org",
+    "updatedate": "2009-07-08 23:10:24",
+    "updater": "mang@archive",
+    "language": "English",
+    "identifier-access": "http://www.archive.org/details/SubBookTest",
+    "identifier-ark": "ark:/13960/t08w3w21h",
+    "ppi": "600",
+    "ocr": "ABBYY FineReader 8.0",
+    "repub_state": "4",
+    "noindex": "true",
+    "curation": "[curator]validator@archive.org[/curator][date]20140402011645[/date][comment]checked for malware[/comment]",
+    "backup_location": "ia903603_14"
+  }
+};
+
+export { custvolumesManifest, extraVolOptions };

--- a/src/BookNavigator/book-navigator.js
+++ b/src/BookNavigator/book-navigator.js
@@ -147,6 +147,9 @@ export class BookNavigator extends LitElement {
     };
   }
 
+  get isWideEnoughToOpenMenu() {
+    return this.brWidth >= 640;
+  }
   /**
    * Instantiates books submenus & their update callbacks
    *
@@ -181,8 +184,7 @@ export class BookNavigator extends LitElement {
             /* refresh br instance reference */
             this.bookreader = brInstance;
           }
-          const wideEnoughToOpenMenu = this.brWidth >= 640;
-          if (wideEnoughToOpenMenu && !searchUpdates?.searchCanceled) {
+          if (this.isWideEnoughToOpenMenu && !searchUpdates?.searchCanceled) {
             /* open side search menu */
             setTimeout(() => {
               this.updateSideMenu('search', 'open');
@@ -214,7 +216,12 @@ export class BookNavigator extends LitElement {
             this.bookreader = brInstance;
           }
           this.updateMenuContents();
-          this.updateSideMenu('volumes', 'open');
+          if (this.isWideEnoughToOpenMenu) {
+            /* open side search menu */
+            setTimeout(() => {
+              this.updateSideMenu('volumes', 'open');
+            });
+          }
         }
       });
     }

--- a/src/ia-bookreader/ia-bookreader.js
+++ b/src/ia-bookreader/ia-bookreader.js
@@ -52,6 +52,10 @@ export class IaBookReader extends LitElement {
     }
   }
 
+  get itemNav() {
+    return this.shadowRoot.querySelector('ia-item-navigator');
+  }
+
   /** Creates modal DOM & attaches to `<body>` */
   setModalManager() {
     let modalManager = document.querySelector('modal-manager');
@@ -95,11 +99,10 @@ export class IaBookReader extends LitElement {
     }
 
     if (action === 'open') {
-      this.itemNav.openShortcut(menuId);
-      this.openShortcut(menuId);
+      this.itemNav?.openShortcut(menuId);
     } else if (action === 'toggle') {
-      this.itemNav.openMenu(menuId);
-      this.itemNav.toggleMenu();
+      this.itemNav?.openMenu(menuId);
+      this.itemNav?.toggleMenu();
     }
   }
 

--- a/tests/karma/BookNavigator/book-navigator.test.js
+++ b/tests/karma/BookNavigator/book-navigator.test.js
@@ -220,6 +220,18 @@ describe('<book-navigator>', () => {
 
     describe('Controlling Menu Side Panel & Shortcuts', () => {
       describe('Side Menu Panels', () => {
+        it('`isWideEnoughToOpenMenu` checks if menu should be open', async () => {
+          const el = fixtureSync(container());
+          el.brWidth = 300;
+          await el.elementUpdated;
+
+          expect(el.isWideEnoughToOpenMenu).to.equal(false);
+
+          el.brWidth = 641;
+          await el.elementUpdated;
+
+          expect(el.isWideEnoughToOpenMenu).to.equal(true);
+        });
         describe('Control which side menu to toggle open by using: `this.updateSideMenu`', () => {
           it('Emits `@updateSideMenu` to signal which menu gets the update', async () => {
             const el = fixtureSync(container());


### PR DESCRIPTION
Fixes dom check to toggle side menu

+ new demo button -> draw a multiple files book dynamically to show side menu (does not fully work as it is not tied to the XHR manifest call, but a quick click to see side menu)

to test demo, go to: https://deploy-preview-931--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=theworksofplato01platiala# 
- > scroll down & click on "Multiple Books" -> bookreader dynamically loads `SubBookTest` with mulitiple files pane open

![ezgif com-gif-maker](https://user-images.githubusercontent.com/7840857/152577954-7a5588e5-599a-4794-84d0-bcb0b28c638e.gif)

