### PR TITLE
Shared RO late load & Url Plugin double slash fix

### DIFF
--- a/src/BookNavigator/book-navigator.js
+++ b/src/BookNavigator/book-navigator.js
@@ -462,11 +462,16 @@ export class BookNavigator extends LitElement {
       this.brHeight = contentRect.height;
     }
 
+    if (!startBrWidth && this.brWidth) {
+      // loading up, let's update side menus
+      this.initializeBookSubmenus();
+    }
+
     const widthChange = startBrWidth !== this.brWidth;
     const heightChange = startBrHeight !== this.brHeight;
 
     if (!animating && (widthChange || heightChange)) {
-      this.bookreader.resize();
+      this.bookreader?.resize();
     }
   }
 

--- a/src/BookNavigator/book-navigator.js
+++ b/src/BookNavigator/book-navigator.js
@@ -105,6 +105,7 @@ export class BookNavigator extends LitElement {
 
     if (changed.has('sharedObserver') && this.bookreader) {
       this.loadSharedObserver();
+      this.initializeBookSubmenus();
     }
   }
 

--- a/src/plugins/url/UrlPlugin.js
+++ b/src/plugins/url/UrlPlugin.js
@@ -140,7 +140,14 @@ export class UrlPlugin {
     const concatenatedPath = urlStrPath !== '/' ? urlStrPath : '';
     if (this.urlMode == 'history') {
       if (window.history && window.history.replaceState) {
-        const newUrlPath = `${this.urlHistoryBasePath}${concatenatedPath}`;
+        // strip leading slash
+        let newPath = concatenatedPath;
+        // if this.urlHistoryBasePath ends with slash
+        if (this.urlHistoryBasePath.endsWith('/')) {
+          // then strip the leading slash
+          newPath = concatenatedPath.replace(/^\/+/, '');
+        }
+        const newUrlPath = `${this.urlHistoryBasePath}${newPath}`;
         window.history.replaceState({}, null, newUrlPath);
       }
     } else {

--- a/src/plugins/url/UrlPlugin.js
+++ b/src/plugins/url/UrlPlugin.js
@@ -140,14 +140,7 @@ export class UrlPlugin {
     const concatenatedPath = urlStrPath !== '/' ? urlStrPath : '';
     if (this.urlMode == 'history') {
       if (window.history && window.history.replaceState) {
-        // strip leading slash
-        let newPath = concatenatedPath;
-        // if this.urlHistoryBasePath ends with slash
-        if (this.urlHistoryBasePath.endsWith('/')) {
-          // then strip the leading slash
-          newPath = concatenatedPath.replace(/^\/+/, '');
-        }
-        const newUrlPath = `${this.urlHistoryBasePath}${newPath}`;
+        const newUrlPath = `${this.urlHistoryBasePath}${concatenatedPath}`.trim().replace(/(\/+)/g, '/');
         window.history.replaceState({}, null, newUrlPath);
       }
     } else {

--- a/tests/jest/plugins/url/UrlPlugin.test.js
+++ b/tests/jest/plugins/url/UrlPlugin.test.js
@@ -170,6 +170,21 @@ describe('UrlPlugin tests', () => {
       const locationUrl = `${window.location.pathname}${window.location.search}`;
       expect(locationUrl).toEqual('/details/foo/page/12?q=hello&view=theater');
     });
+
+    test('strips leading slash of incoming path name for no double slash', () => {
+      const urlPlugin = new UrlPlugin();
+      urlPlugin.urlMode = 'history';
+
+      urlPlugin.urlHistoryBasePath = '/details/SubBookTest/book1/GPORFP/';
+      urlPlugin.urlState = {
+        "mode": "1up",
+      };
+
+      urlPlugin.setUrlParam('sort', 'title_asc');
+      urlPlugin.setUrlParam('mode', 'thumb');
+
+      expect(window.location.href).toEqual('http://localhost/details/SubBookTest/book1/GPORFP/mode/thumb?sort=title_asc');
+    });
   });
 
 });

--- a/tests/karma/BookNavigator/book-navigator.test.js
+++ b/tests/karma/BookNavigator/book-navigator.test.js
@@ -323,6 +323,10 @@ describe('<book-navigator>', () => {
       const el = fixtureSync(container());
       const brStub = {
         resize: sinon.fake(),
+        options: {},
+        refs: {
+          $brContainer: document.createElement('div')
+        }
       };
       el.bookreader = brStub;
       await elementUpdated(el);
@@ -349,7 +353,12 @@ describe('<book-navigator>', () => {
       const brStub = {
         animating: false,
         resize: sinon.fake(),
+        options: {},
+        refs: {
+          $brContainer: document.createElement('div')
+        }
       };
+
       el.bookreader = brStub;
       await elementUpdated(el);
       expect(el.brWidth).to.equal(0);


### PR DESCRIPTION
Problem: The Shared Resize observer loads after the side menu providers have, thus not conveying proper browser dimensions to those listening for it.

Solution: re-hydrate menus.


Problem: when primary url ends with trailing slash, it appends it, thus adding `//` to url. cannot properly reload page.

Solution: check for `//`