### PR TITLE
Try splitting node workflow into different jobs

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -41,11 +41,7 @@ jobs:
         node-version: 16.x
     - uses: actions/cache@v2
       with:
-        # Caching node_modules isn't recommended because it can break across
-        # Node versions and won't work with npm ci (See https://github.com/actions/cache/blob/main/examples.md#node---npm )
-        # But we pin the node version, and we don't update it that often anyways. And
-        # we don't use `npm ci` specifically to try to get faster CI flows. So caching
-        # `node_modules` directly.
+        # Use node_modules from previous jobs
         path: 'node_modules'
         key: ${{ runner.os }}-node-16-${{ hashFiles('package*.json') }}
     - uses: actions/cache@v2
@@ -65,11 +61,7 @@ jobs:
         node-version: 16.x
     - uses: actions/cache@v2
       with:
-        # Caching node_modules isn't recommended because it can break across
-        # Node versions and won't work with npm ci (See https://github.com/actions/cache/blob/main/examples.md#node---npm )
-        # But we pin the node version, and we don't update it that often anyways. And
-        # we don't use `npm ci` specifically to try to get faster CI flows. So caching
-        # `node_modules` directly.
+        # Use node_modules from previous jobs
         path: 'node_modules'
         key: ${{ runner.os }}-node-16-${{ hashFiles('package*.json') }}
     - run: npm run lint
@@ -86,11 +78,7 @@ jobs:
         node-version: 16.x
     - uses: actions/cache@v2
       with:
-        # Caching node_modules isn't recommended because it can break across
-        # Node versions and won't work with npm ci (See https://github.com/actions/cache/blob/main/examples.md#node---npm )
-        # But we pin the node version, and we don't update it that often anyways. And
-        # we don't use `npm ci` specifically to try to get faster CI flows. So caching
-        # `node_modules` directly.
+        # Use node_modules from previous jobs
         path: 'node_modules'
         key: ${{ runner.os }}-node-16-${{ hashFiles('package*.json') }}
     - uses: actions/cache@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -45,11 +45,13 @@ jobs:
         path: 'node_modules'
         key: ${{ runner.os }}-node-16-${{ hashFiles('package*.json') }}
     - uses: actions/cache@v2
+      id: build-cache
       with:
         # Cache the build files so we don't have to build twice for e2e tests
         path: 'BookReader'
         key: ${{ runner.os }}-${{ github.sha }}
-    - run: npm run build
+    - if: steps.build-cache.outputs.cache-hit != 'true'
+      run: npm run build
 
   tests:
     needs: install

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -46,6 +46,11 @@ jobs:
         # `node_modules` directly.
         path: 'node_modules'
         key: ${{ runner.os }}-node-16-${{ hashFiles('package*.json') }}
+    - uses: actions/cache@v2
+      with:
+        # Cache the build files so we don't have to build twice for e2e tests
+        path: 'BookReader'
+        key: ${{ runner.os }}-$GITHUB_SHA
     - run: npm run build
 
   tests:
@@ -86,6 +91,11 @@ jobs:
         # `node_modules` directly.
         path: 'node_modules'
         key: ${{ runner.os }}-node-16-${{ hashFiles('package*.json') }}
+    - uses: actions/cache@v2
+      with:
+        # Cache the build files so we don't have to build twice for e2e tests
+        path: 'BookReader'
+        key: ${{ runner.os }}-${{ env.GITHUB_SHA }}
     # Travis machines usually have 2 cores (see https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system )
     # Quarantine mode (sigh) to catch unstable tests (see https://devexpress.github.io/testcafe/documentation/guides/basic-guides/run-tests.html#quarantine-mode )
     - run: npx testcafe --concurrency 2 --quarantine-mode

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         # Cache the build files so we don't have to build twice for e2e tests
         path: 'BookReader'
-        key: ${{ runner.os }}-$GITHUB_SHA
+        key: ${{ runner.os }}-${{ github.sha }}
     - run: npm run build
 
   tests:
@@ -97,7 +97,7 @@ jobs:
       with:
         # Cache the build files so we don't have to build twice for e2e tests
         path: 'BookReader'
-        key: ${{ runner.os }}-${{ env.GITHUB_SHA }}
+        key: ${{ runner.os }}-${{ github.sha }}
     # Travis machines usually have 2 cores (see https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system )
     # Quarantine mode (sigh) to catch unstable tests (see https://devexpress.github.io/testcafe/documentation/guides/basic-guides/run-tests.html#quarantine-mode )
     - run: npx testcafe --concurrency 2 --quarantine-mode

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -33,12 +33,38 @@ jobs:
     needs: install
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 16.x
+    - uses: actions/cache@v2
+      with:
+        # Caching node_modules isn't recommended because it can break across
+        # Node versions and won't work with npm ci (See https://github.com/actions/cache/blob/main/examples.md#node---npm )
+        # But we pin the node version, and we don't update it that often anyways. And
+        # we don't use `npm ci` specifically to try to get faster CI flows. So caching
+        # `node_modules` directly.
+        path: 'node_modules'
+        key: ${{ runner.os }}-node-16-${{ hashFiles('package*.json') }}
     - run: npm run build
 
   tests:
     needs: install
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 16.x
+    - uses: actions/cache@v2
+      with:
+        # Caching node_modules isn't recommended because it can break across
+        # Node versions and won't work with npm ci (See https://github.com/actions/cache/blob/main/examples.md#node---npm )
+        # But we pin the node version, and we don't update it that often anyways. And
+        # we don't use `npm ci` specifically to try to get faster CI flows. So caching
+        # `node_modules` directly.
+        path: 'node_modules'
+        key: ${{ runner.os }}-node-16-${{ hashFiles('package*.json') }}
     - run: npm run lint
     - run: npm run test
     - run: npm run codecov
@@ -47,6 +73,19 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 16.x
+    - uses: actions/cache@v2
+      with:
+        # Caching node_modules isn't recommended because it can break across
+        # Node versions and won't work with npm ci (See https://github.com/actions/cache/blob/main/examples.md#node---npm )
+        # But we pin the node version, and we don't update it that often anyways. And
+        # we don't use `npm ci` specifically to try to get faster CI flows. So caching
+        # `node_modules` directly.
+        path: 'node_modules'
+        key: ${{ runner.os }}-node-16-${{ hashFiles('package*.json') }}
     # Travis machines usually have 2 cores (see https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system )
     # Quarantine mode (sigh) to catch unstable tests (see https://devexpress.github.io/testcafe/documentation/guides/basic-guides/run-tests.html#quarantine-mode )
     - run: npx testcafe --concurrency 2 --quarantine-mode

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,6 +19,7 @@ jobs:
       with:
         node-version: 16.x
     - uses: actions/cache@v2
+      id: cache
       with:
         # Caching node_modules isn't recommended because it can break across
         # Node versions and won't work with npm ci (See https://github.com/actions/cache/blob/main/examples.md#node---npm )
@@ -27,7 +28,8 @@ jobs:
         # `node_modules` directly.
         path: 'node_modules'
         key: ${{ runner.os }}-node-16-${{ hashFiles('package*.json') }}
-    - run: npm install
+    - if: steps.cache.outputs.cache-hit != 'true'
+      run: npm install
 
   build:
     needs: install

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,7 +10,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  install:
     runs-on: ubuntu-latest
 
     steps:
@@ -28,10 +28,25 @@ jobs:
         path: 'node_modules'
         key: ${{ runner.os }}-node-16-${{ hashFiles('package*.json') }}
     - run: npm install
+
+  build:
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
     - run: npm run build
+
+  tests:
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
     - run: npm run lint
     - run: npm run test
     - run: npm run codecov
+    
+  e2e-tests:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
     # Travis machines usually have 2 cores (see https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system )
     # Quarantine mode (sigh) to catch unstable tests (see https://devexpress.github.io/testcafe/documentation/guides/basic-guides/run-tests.html#quarantine-mode )
     - run: npx testcafe --concurrency 2 --quarantine-mode


### PR DESCRIPTION
Saves about ~45s on CI (~5.2min → ~4.5min, sample size ~2). A big chunk is probably from fully skipping `npm install` when we have a `node_modules` cache hit. Then we also parallelize e2e tests with unit test running.

Sample run graph: https://github.com/internetarchive/bookreader/actions/runs/1959466247

![image](https://user-images.githubusercontent.com/6251786/157526064-5efef7cb-3c00-45e5-8180-ca22627e06d5.png)


Before:

![image](https://user-images.githubusercontent.com/6251786/157526333-7597ebd7-6cdd-47c1-8d3e-71f0f226bdb2.png)

After:

![image](https://user-images.githubusercontent.com/6251786/157526422-9c48b855-6786-4244-b0fd-98f31a4321e4.png)
