### PR TITLE
Allow small drops in codecov coverage (< 0.5%)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,7 @@ codecov:
     project:
       default:
         # Allow small drops in coverage
-        threshold: 0.01  # 1 %
+        threshold: 0.005  # .5 %
         if_not_found: failure
 
 coverage:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,12 @@
 codecov:
   notify:
     require_ci_to_pass: yes
+  status:
+    project:
+      default:
+        # Allow small drops in coverage
+        threshold: 0.01  # 1 %
+        if_not_found: failure
 
 coverage:
   precision: 2


### PR DESCRIPTION
Codecov is constantly failing for small changes -- oftentimes incorrectly. Let's add some leniency here ; if your change is very tiny, it's ok if it causes a coverage decrease.