### PR TITLE
Group @internetarchive icon updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,10 @@
       ],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
+    },
+    {
+      "matchPackagePatterns": ["^@internetarchive/icon-"],
+      "groupName": "@internetarchive icons"
     }
   ]
 }


### PR DESCRIPTION
This will place all icon updates in one PR, but not auto-merge. Since there are no tests that really cover whether the icons are working correctly, I think it might be best to have these require manual verification/merge.