### PR TITLE
Use range strategy bump for @internetarchive

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,7 +32,12 @@
     },
     {
       "matchPackagePatterns": ["^@internetarchive/icon-"],
-      "groupName": "@internetarchive icons"
+      "groupName": "@internetarchive icons",
+      "rangeStrategy": "bump"
+    },
+    {
+      "matchPackagePatterns": ["^@internetarchive"],
+      "rangeStrategy": "bump"
     }
   ]
 }


### PR DESCRIPTION
These repos often contain web components which get registered globally, so we would rather have ranges with these than pinned dependencies