### PR TITLE
Feature: Some visual bounce to make search highlight more noticeable on click

### DIFF
--- a/src/BookNavigator/search/search-provider.js
+++ b/src/BookNavigator/search/search-provider.js
@@ -1,6 +1,7 @@
 import { html, nothing } from 'lit';
 import '@internetarchive/icon-search/icon-search';
 import './search-results';
+/** @typedef {import('@/src/plugins/search/plugin.search.js').SearchInsideMatch} SearchInsideMatch */
 
 let searchState = {
   query: '',
@@ -28,10 +29,10 @@ export default class SearchProvider {
     this.bindEventListeners = this.bindEventListeners.bind(this);
     this.getMenuDetails = this.getMenuDetails.bind(this);
     this.getComponent = this.getComponent.bind(this);
-    this.advanceToPage = this.advanceToPage.bind(this);
     this.updateMenu = this.updateMenu.bind(this);
 
     this.onProviderChange = onProviderChange;
+    /** @type {import('@/src/BookReader.js').default} */
     this.bookreader = bookreader;
     this.icon = html`<ia-icon-search style="width: var(--iconWidth); height: var(--iconHeight);"></ia-icon-search>`;
     this.label = 'Search inside';
@@ -174,13 +175,10 @@ export default class SearchProvider {
   `;
   }
 
+  /**
+   * @param {{ detail: {match: SearchInsideMatch} }} param0
+   */
   onSearchResultsClicked({ detail }) {
-    const page = detail.match.par[0].page;
-    this.advanceToPage(page);
-  }
-
-  advanceToPage(leaf) {
-    const page = this.bookreader.leafNumToIndex(leaf);
-    this.bookreader._searchPluginGoToResult(page);
+    this.bookreader._searchPluginGoToResult(detail.match);
   }
 }

--- a/src/BookNavigator/search/search-provider.js
+++ b/src/BookNavigator/search/search-provider.js
@@ -179,6 +179,6 @@ export default class SearchProvider {
    * @param {{ detail: {match: SearchInsideMatch} }} param0
    */
   onSearchResultsClicked({ detail }) {
-    this.bookreader._searchPluginGoToResult(detail.match);
+    this.bookreader._searchPluginGoToResult(detail.match.matchIndex);
   }
 }

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -1006,10 +1006,8 @@ BookReader.prototype.jumpToPage = function(pageNum) {
  * @param {PageIndex} index
  */
 BookReader.prototype._isIndexDisplayed = function(index) {
-  // One up "caches" pages +- current, so exclude those in the test.
-  return this.constMode1up == this.mode ? this.displayedIndices.slice(1, -1).includes(index) :
-    this.displayedIndices ? this.displayedIndices.includes(index) :
-      this.currentIndex() == index;
+  return this.displayedIndices ? this.displayedIndices.includes(index) :
+    this.currentIndex() == index;
 };
 
 /**

--- a/src/BookReader/PageContainer.js
+++ b/src/BookReader/PageContainer.js
@@ -101,6 +101,8 @@ export function boxToSVGRect({ l: left, r: right, b: bottom, t: top }) {
   const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
   rect.setAttribute("x", left.toString());
   rect.setAttribute("y", top.toString());
+  rect.setAttribute("rx", "4");
+  rect.setAttribute("ry", "4");
   rect.setAttribute("width", (right - left).toString());
   rect.setAttribute("height", (bottom - top).toString());
   return rect;

--- a/src/BookReader/PageContainer.js
+++ b/src/BookReader/PageContainer.js
@@ -111,8 +111,9 @@ export function boxToSVGRect({ l: left, r: right, b: bottom, t: top }) {
  * @param {Array<{ l: number, r: number, b: number, t: number }>} boxes
  * @param {PageModel} page
  * @param {HTMLElement} containerEl
+ * @param {string[]} [rectClasses] CSS classes to add to the rects
  */
-export function renderBoxesInPageContainerLayer(layerClass, boxes, page, containerEl) {
+export function renderBoxesInPageContainerLayer(layerClass, boxes, page, containerEl, rectClasses = null) {
   const mountedSvg = containerEl.querySelector(`.${layerClass}`);
   // Create the layer if it's not there
   const svg = mountedSvg || createSVGPageLayer(page, layerClass);
@@ -122,5 +123,12 @@ export function renderBoxesInPageContainerLayer(layerClass, boxes, page, contain
     if (imgEl) $(svg).insertAfter(imgEl);
     else $(svg).prependTo(containerEl);
   }
-  boxes.forEach(box => svg.appendChild(boxToSVGRect(box)));
+
+  for (const [i, box] of boxes.entries()) {
+    const rect = boxToSVGRect(box);
+    if (rectClasses) {
+      rect.setAttribute('class', rectClasses[i]);
+    }
+    svg.appendChild(rect);
+  }
 }

--- a/src/BookReader/PageContainer.js
+++ b/src/BookReader/PageContainer.js
@@ -101,10 +101,12 @@ export function boxToSVGRect({ l: left, r: right, b: bottom, t: top }) {
   const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
   rect.setAttribute("x", left.toString());
   rect.setAttribute("y", top.toString());
-  rect.setAttribute("rx", "4");
-  rect.setAttribute("ry", "4");
   rect.setAttribute("width", (right - left).toString());
   rect.setAttribute("height", (bottom - top).toString());
+
+  // Some style; corner radius 4px. Can't set this in CSS yet
+  rect.setAttribute("rx", "4");
+  rect.setAttribute("ry", "4");
   return rect;
 }
 

--- a/src/BookReader/utils.js
+++ b/src/BookReader/utils.js
@@ -238,3 +238,27 @@ export function arrEquals(arr1, arr2) {
 export function arrChanged(arr1, arr2) {
   return arr1 && arr2 && !arrEquals(arr1, arr2);
 }
+
+/**
+ * Waits the provided number of ms and then resolves with a promise
+ * @param {number} ms
+ **/
+export async function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * @template T
+ * @param {function(): T} fn
+ * @param {Object} options
+ * @param {function(T): boolean} [options.until]
+ * @return {T | undefined}
+ */
+export async function poll(fn, { step = 50, timeout = 500, until = val => Boolean(val), _sleep = sleep } = {}) {
+  const startTime = Date.now();
+  while (Date.now() - startTime < timeout) {
+    const result = fn();
+    if (until(result)) return result;
+    await _sleep(step);
+  }
+}

--- a/src/css/_BRsearch.scss
+++ b/src/css/_BRsearch.scss
@@ -39,7 +39,7 @@
 
   .searchHiliteLayer rect {
     animation: highlightFocus 600ms 1 reverse;
-    outline: 0px solid blue;
+    outline: 4px solid blue;
     outline-offset: 4px;
     border-radius: 4px;
 

--- a/src/css/_BRsearch.scss
+++ b/src/css/_BRsearch.scss
@@ -39,9 +39,8 @@
 
   .searchHiliteLayer rect {
     animation: highlightFocus 600ms 1 reverse;
-    outline: 4px solid blue;
-    outline-offset: 4px;
-    border-radius: 4px;
+    stroke: blue;
+    stroke-width: 4px;
 
     // Sass for loop for nth-child animation delay
     @for $i from 1 through 10 {
@@ -222,7 +221,7 @@
 }
 
 @keyframes highlightFocus {
-  to { outline-width: 20px; }
+  to { stroke-width: 20px; }
 }
 
 /* Mid size breakpoint */

--- a/src/css/_BRsearch.scss
+++ b/src/css/_BRsearch.scss
@@ -31,9 +31,23 @@
     pointer-events: none;
 
     rect {
-      fill: #0000ff;
-      fill-opacity: 0.2;
-      animation: hiliteFadeIn .2s;
+      // Note: Can't use fill-opacity ; safari inexplicably applies that to
+      // the outline as well
+      fill: rgba(0, 0, 255, 0.2);
+    }
+  }
+
+  .searchHiliteLayer rect {
+    animation: highlightFocus 600ms 1 reverse;
+    outline: 0px solid blue;
+    outline-offset: 4px;
+    border-radius: 4px;
+
+    // Sass for loop for nth-child animation delay
+    @for $i from 1 through 10 {
+      &:nth-child(#{$i}) {
+        animation-delay: #{($i - 1) * 50}ms;
+      }
     }
   }
 
@@ -207,8 +221,8 @@
   }
 }
 
-@keyframes hiliteFadeIn {
-  from { fill-opacity: 0; }
+@keyframes highlightFocus {
+  to { outline-width: 20px; }
 }
 
 /* Mid size breakpoint */

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -289,7 +289,7 @@ BookReader.prototype.BRSearchCallback = function(results, options) {
   this.updateSearchHilites();
   this.removeProgressPopup();
   if (options.goToFirstResult) {
-    this._searchPluginGoToResult(results.matches[0]);
+    this._searchPluginGoToResult(0);
   }
   this.trigger('SearchCallback', { results, options, instance: this });
 };
@@ -374,9 +374,10 @@ BookReader.prototype.removeSearchHilites = function() {
  * Goes to the page specified. If the page is not viewable, tries to load the page
  * FIXME Most of this logic is IA specific, and should be less integrated into here
  * or at least more configurable.
- * @param {SearchInsideMatch} match
+ * @param {number} matchIndex
  */
-BookReader.prototype._searchPluginGoToResult = async function (match) {
+BookReader.prototype._searchPluginGoToResult = async function (matchIndex) {
+  const match = this.searchResults?.matches[matchIndex];
   const pageIndex = this.leafNumToIndex(match.par[0].page);
   const { book } = this._models;
   const page = book.getPage(pageIndex);

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -380,6 +380,7 @@ BookReader.prototype._searchPluginGoToResult = async function (match) {
   const pageIndex = this.leafNumToIndex(match.par[0].page);
   const { book } = this._models;
   const page = book.getPage(pageIndex);
+  const onNearbyPage = Math.abs(this.currentIndex() - pageIndex) < 3;
   let makeUnviewableAtEnd = false;
   if (!page.isViewable) {
     const resp = await fetch('/services/bookreader/request_page?' + new URLSearchParams({
@@ -425,7 +426,7 @@ BookReader.prototype._searchPluginGoToResult = async function (match) {
       // full-width, and covers up the last line of the highlight.
       block: this.constMode1up == this.mode || this.isFullscreenActive ? 'center' : 'nearest',
       inline: 'center',
-      behavior: 'smooth',
+      behavior: onNearbyPage ? 'smooth' : 'auto',
     });
     // wait for animation to start
     await new Promise(resolve => setTimeout(resolve, 100));

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -24,6 +24,7 @@
  * @event BookReader:SearchCanceled - When no results found. Receives
  *   `instance`
  */
+import { poll } from '../../BookReader/utils.js';
 import { renderBoxesInPageContainerLayer } from '../../BookReader/PageContainer.js';
 import SearchView from './view.js';
 /** @typedef {import('../../BookReader/PageContainer').PageContainer} PageContainer */
@@ -405,8 +406,6 @@ BookReader.prototype._searchPluginGoToResult = async function (matchIndex) {
   if (!this._isIndexDisplayed(pageIndex)) {
     this.suppressFragmentChange = false;
     this.jumpToIndex(pageIndex);
-    // Wait 100ms for flipping or anything; bit of a hack
-    await new Promise(resolve => setTimeout(resolve, 100));
   }
 
   // Reset it to unviewable if it wasn't resolved
@@ -415,7 +414,7 @@ BookReader.prototype._searchPluginGoToResult = async function (matchIndex) {
   }
 
   // Scroll/flash in the ui
-  const $boxes = $(`rect.match-index-${match.matchIndex}`);
+  const $boxes = await poll(() => $(`rect.match-index-${match.matchIndex}`), { until: result => result.length > 0 });
   if ($boxes.length) {
     $boxes.css('animation', 'none');
     $boxes[0].scrollIntoView({

--- a/src/plugins/search/view.js
+++ b/src/plugins/search/view.js
@@ -260,7 +260,6 @@ class SearchView {
             <div>${uiStringPage} ${pageNumber}</div>
           </div>
         `)
-        .data({ pageIndex })
         .appendTo(this.br.$('.BRnavline'))
         .on("mouseenter", (event) => {
           // remove from other markers then turn on just for this
@@ -277,12 +276,7 @@ class SearchView {
           $(event.target).addClass('front');
         })
         .on("mouseleave", (event) => $(event.target).removeClass('front'))
-        .on("click", function (event) {
-          // closures are nested and deep, using an arrow function breaks references.
-          // Todo: update to arrow function & clean up closures
-          // to remove `bind` dependency
-          this.br._searchPluginGoToResult(+$(event.target).data('pageIndex'));
-        }.bind(this));
+        .on("click", () => { this.br._searchPluginGoToResult(match); });
     });
   }
 

--- a/src/plugins/search/view.js
+++ b/src/plugins/search/view.js
@@ -276,7 +276,7 @@ class SearchView {
           $(event.target).addClass('front');
         })
         .on("mouseleave", (event) => $(event.target).removeClass('front'))
-        .on("click", () => { this.br._searchPluginGoToResult(match); });
+        .on("click", () => { this.br._searchPluginGoToResult(match.matchIndex); });
     });
   }
 

--- a/src/plugins/tts/FestivalTTSEngine.js
+++ b/src/plugins/tts/FestivalTTSEngine.js
@@ -1,5 +1,5 @@
 import AbstractTTSEngine from './AbstractTTSEngine.js';
-import { sleep } from './utils.js';
+import { sleep } from '../../BookReader/utils.js';
 /* global soundManager */
 import 'soundmanager2';
 import 'jquery.browser';

--- a/src/plugins/tts/WebTTSEngine.js
+++ b/src/plugins/tts/WebTTSEngine.js
@@ -1,6 +1,7 @@
 /* global br */
 import { isChrome, isFirefox } from '../../util/browserSniffing.js';
-import { sleep, promisifyEvent, isAndroid } from './utils.js';
+import { promisifyEvent, isAndroid } from './utils.js';
+import { sleep } from '../../BookReader/utils.js';
 import AbstractTTSEngine from './AbstractTTSEngine.js';
 /** @typedef {import("./AbstractTTSEngine.js").PageChunk} PageChunk */
 /** @typedef {import("./AbstractTTSEngine.js").AbstractTTSSound} AbstractTTSSound */

--- a/src/plugins/tts/utils.js
+++ b/src/plugins/tts/utils.js
@@ -27,15 +27,6 @@ export function approximateWordCount(text) {
 }
 
 /**
- * Waits the provided number of ms and then resolves with a promise
- * @param {number} ms
- * @return {Promise}
- */
-export function sleep(ms) {
-  return new Promise(res => setTimeout(res, ms));
-}
-
-/**
  * Checks whether the current browser is on android
  * @param {string} [userAgent]
  * @return {boolean}

--- a/tests/jest/BookReader/BookReaderPublicFunctions.test.js
+++ b/tests/jest/BookReader/BookReaderPublicFunctions.test.js
@@ -1,5 +1,5 @@
 import BookReader from '@/src/BookReader';
-import { sleep } from '@/src/plugins/tts/utils';
+import { sleep } from '@/src/BookReader/utils.js';
 import sinon from 'sinon';
 
 beforeAll(() => {

--- a/tests/jest/BookReader/PageContainer.test.js
+++ b/tests/jest/BookReader/PageContainer.test.js
@@ -178,6 +178,15 @@ describe('renderBoxesInPageContainerLayer', () => {
     expect(container.querySelectorAll('.foo rect').length).toBe(3);
   });
 
+  test('Adds optional classes', () => {
+    const container = document.createElement('div');
+    const page = { width: 100, height: 200 };
+    const boxes = [{l: 1, r: 2, t: 3, b: 4}, {l: 1, r: 2, t: 3, b: 4}, {l: 1, r: 2, t: 3, b: 4}];
+    renderBoxesInPageContainerLayer('foo', boxes, page, container, ['match-1', 'match-2', 'match-3']);
+    const rects = Array.from(container.querySelectorAll('.foo rect'));
+    expect(rects.map(r => r.getAttribute('class'))).toEqual(['match-1', 'match-2', 'match-3']);
+  });
+
   test('Handles no boxes', () => {
     const container = document.createElement('div');
     const page = { width: 100, height: 200 };

--- a/tests/jest/BookReader/utils.test.js
+++ b/tests/jest/BookReader/utils.test.js
@@ -8,6 +8,7 @@ import {
   escapeHTML,
   getActiveElement,
   isInputActive,
+  poll,
   polyfillCustomEvent,
   PolyfilledCustomEvent,
 } from '@/src/BookReader/utils.js';
@@ -132,5 +133,29 @@ describe('PolyfilledCustomEvent', () => {
     new PolyfilledCustomEvent('foo');
     expect(createEventSpy.callCount).toBe(1);
     expect(initCustomEventSpy.callCount).toBe(1);
+  });
+});
+
+describe('poll', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+  test('polls until condition is true', async () => {
+    const fakeSleep = sinon.spy((ms) => jest.advanceTimersByTime(ms));
+
+    const returns = [null, null, 'foo'];
+    const check = sinon.spy(() => returns.shift());
+    const result = await poll(check, {_sleep: fakeSleep});
+    expect(fakeSleep.callCount).toBe(2);
+    expect(result).toBe('foo');
+    expect(check.callCount).toBe(3);
+  });
+
+  test('times out eventually', async () => {
+    const fakeSleep = sinon.spy((ms) => jest.advanceTimersByTime(ms));
+
+    const check = sinon.stub().returns(null);
+    const result = await poll(check, {_sleep: fakeSleep});
+    expect(result).toBeUndefined();
+    expect(check.callCount).toBe(10);
   });
 });

--- a/tests/jest/plugins/tts/utils.test.js
+++ b/tests/jest/plugins/tts/utils.test.js
@@ -66,31 +66,6 @@ describe('approximateWordCount', () => {
   });
 });
 
-describe('sleep', () => {
-  const { sleep } = utils;
-
-  test('Sleep 0 doest not called immediately', async () => {
-    const spy = sinon.spy();
-    sleep(0).then(spy);
-    expect(spy.callCount).toBe(0);
-    await afterEventLoop();
-    expect(spy.callCount).toBe(1);
-  });
-
-  test('Waits the appropriate ms', async () => {
-    const clock = sinon.useFakeTimers();
-    const spy = sinon.spy();
-    sleep(10).then(spy);
-    expect(spy.callCount).toBe(0);
-    clock.tick(10);
-    expect(spy.callCount).toBe(0);
-    clock.restore();
-
-    await afterEventLoop();
-    expect(spy.callCount).toBe(1);
-  });
-});
-
 describe('toISO6391', () => {
   const { toISO6391 } = utils;
 

--- a/tests/karma/BookNavigator/search/search-provider.test.js
+++ b/tests/karma/BookNavigator/search/search-provider.test.js
@@ -23,21 +23,6 @@ describe('Search Provider', () => {
     expect(provider.menuDetails).to.exist;
     expect(provider.component).to.exist;
   });
-  describe('BR calls', () => {
-    it('`advanceToPage', () => {
-      const provider = new searchProvider({
-        onProviderChange: sinon.fake(),
-        bookreader: {
-          leafNumToIndex: sinon.fake(),
-          _searchPluginGoToResult: sinon.fake()
-        }
-      });
-
-      provider.advanceToPage(1);
-      expect(provider?.bookreader.leafNumToIndex.callCount).to.equal(1);
-      expect(provider?.bookreader._searchPluginGoToResult.callCount).to.equal(1);
-    });
-  });
   describe('Search request life cycles', () => {
     it('Event: catches `BookReader:SearchStarted`', async() => {
       const provider = new searchProvider({
@@ -106,7 +91,6 @@ describe('Search Provider', () => {
           _searchPluginGoToResult: sinon.fake()
         }
       });
-      sinon.spy(provider, 'advanceToPage');
 
       const searchResultStub = {
         match: { par: [{ text: 'foo', page: 3 }] },
@@ -116,7 +100,6 @@ describe('Search Provider', () => {
           { detail: searchResultStub })
       );
 
-      expect(provider.advanceToPage.callCount).to.equal(1);
       expect(provider.bookreader._searchPluginGoToResult.callCount).to.equal(1);
     });
   });


### PR DESCRIPTION
Examples:
- https://deploy-preview-998--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=goody#page/8/mode/1up/search/margery
- https://deploy-preview-998--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=sim_weekly-recorder-a-news-paper_1819-12-09_6_17#mode/1up/search/god

Outstanding:
- PUNT: On mobile search panel no longer closing for some reason after clicking
    - Apparently pre-existing issue; not related to changes here
- PUNT: Not scrolling into view on initial search
    - It usually is? Some books seem to have `options.goToFirst` set to false :/ (like https://archive.org/details/sim_los-angeles-times_1989-04-30_parsed/sim_los-angeles-times_1989-04-30_2/page/n88/mode/1up?q=ibm )

Future fixes:
- #1011 
- Zoom in to ensure selected result readable
- Fix some wonkiness in the search results toolbar