### PR TITLE
Performance improvements to scroll/zooming when text layer is larger

### DIFF
--- a/src/BookReader/Mode1UpLit.js
+++ b/src/BookReader/Mode1UpLit.js
@@ -5,6 +5,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { ModeSmoothZoom } from './ModeSmoothZoom';
 import { arrChanged, calcScreenDPI, genToArray, sum, throttle } from './utils';
 import { HTMLDimensionsCacher } from "./utils/HTMLDimensionsCacher";
+import { ScrollClassAdder } from './utils/ScrollClassAdder';
 /** @typedef {import('./BookModel').BookModel} BookModel */
 /** @typedef {import('./BookModel').PageIndex} PageIndex */
 /** @typedef {import('./BookModel').PageModel} PageModel */
@@ -114,6 +115,8 @@ export class Mode1UpLit extends LitElement {
   htmlDimensionsCacher = new HTMLDimensionsCacher(this);
 
   smoothZoomer = new ModeSmoothZoom(this);
+
+  scrollClassAdder = new ScrollClassAdder(this, 'BRscrolling-active');
 
   /************** CONSTANT PROPERTIES **************/
 
@@ -425,22 +428,13 @@ export class Mode1UpLit extends LitElement {
 
   /************** INPUT HANDLERS **************/
 
-  setScrollingActiveClass = () => {
-    this.$visibleWorld.classList.add('BRscrolling-active');
-    clearTimeout(this.scrollingActiveTimeout);
-    // TODO: Also remove class on mousemove, touch, click, etc.
-    this.scrollingActiveTimeout = setTimeout(() => {
-      this.$visibleWorld.classList.remove('BRscrolling-active');
-    }, 1000);
-  }
-
   attachScrollListeners = () => {
     this.addEventListener("scroll", this.updateVisibleRegion);
-    this.addEventListener("scroll", this.setScrollingActiveClass);
+    this.scrollClassAdder.attach();
   }
 
   detachScrollListeners = () => {
     this.removeEventListener("scroll", this.updateVisibleRegion);
-    this.removeEventListener("scroll", this.setScrollingActiveClass);
+    this.scrollClassAdder.detach();
   }
 }

--- a/src/BookReader/Mode1UpLit.js
+++ b/src/BookReader/Mode1UpLit.js
@@ -305,6 +305,7 @@ export class Mode1UpLit extends LitElement {
       }).$container[0];
 
     pageContainerEl.style.transform = transform;
+    pageContainerEl.classList.toggle('BRpage-visible', this.visiblePages.includes(page));
     return pageContainerEl;
   }
 

--- a/src/BookReader/Mode1UpLit.js
+++ b/src/BookReader/Mode1UpLit.js
@@ -425,11 +425,22 @@ export class Mode1UpLit extends LitElement {
 
   /************** INPUT HANDLERS **************/
 
+  setScrollingActiveClass = () => {
+    this.$visibleWorld.classList.add('BRscrolling-active');
+    clearTimeout(this.scrollingActiveTimeout);
+    // TODO: Also remove class on mousemove, touch, click, etc.
+    this.scrollingActiveTimeout = setTimeout(() => {
+      this.$visibleWorld.classList.remove('BRscrolling-active');
+    }, 1000);
+  }
+
   attachScrollListeners = () => {
-    this.addEventListener("scroll", this.updateVisibleRegion, { passive: true });
+    this.addEventListener("scroll", this.updateVisibleRegion);
+    this.addEventListener("scroll", this.setScrollingActiveClass);
   }
 
   detachScrollListeners = () => {
     this.removeEventListener("scroll", this.updateVisibleRegion);
+    this.removeEventListener("scroll", this.setScrollingActiveClass);
   }
 }

--- a/src/BookReader/Mode2Up.js
+++ b/src/BookReader/Mode2Up.js
@@ -6,6 +6,7 @@ import { EVENTS } from './events.js';
 import { ModeSmoothZoom } from "./ModeSmoothZoom.js";
 import { HTMLDimensionsCacher } from './utils/HTMLDimensionsCacher.js';
 import { DragScrollable } from './DragScrollable.js';
+import { ScrollClassAdder } from './utils/ScrollClassAdder.js';
 
 /** @typedef {import('../BookReader.js').default} BookReader */
 /** @typedef {import('./BookModel.js').BookModel} BookModel */
@@ -36,6 +37,9 @@ export class Mode2Up {
     this.smoothZoomer = null;
     this._scale = 1;
     this.scaleCenter = { x: 0.5, y: 0.5 };
+
+    /** @type {ScrollClassAdder} */
+    this.scrollClassAdder = null;
   }
 
   get $container() {
@@ -242,6 +246,12 @@ export class Mode2Up {
 
     this.smoothZoomer = this.smoothZoomer || new ModeSmoothZoom(this);
     this.smoothZoomer.attach();
+    if (!this.scrollClassAdder) {
+      this.scrollClassAdder = new ScrollClassAdder(this.$container, 'BRscrolling-active');
+    }
+    this.scrollClassAdder.detach();
+    this.scrollClassAdder.element = this.$container;
+    this.scrollClassAdder.attach();
 
     this.htmlDimensionsCacher = this.htmlDimensionsCacher || new HTMLDimensionsCacher(this.$container);
   }
@@ -250,6 +260,7 @@ export class Mode2Up {
     // Mode2Up attaches these listeners to the main BR container, so we need to
     // detach these or it will cause issues for the other modes.
     this.smoothZoomer.detach();
+    this.scrollClassAdder.detach();
   }
 
   /**

--- a/src/BookReader/ModeSmoothZoom.js
+++ b/src/BookReader/ModeSmoothZoom.js
@@ -89,6 +89,7 @@ export class ModeSmoothZoom {
   _pinchStart = () => {
     // Do this in case the pinchend hasn't fired yet.
     this.oldScale = 1;
+    this.mode.$visibleWorld.classList.add("BRsmooth-zooming");
     this.mode.$visibleWorld.style.willChange = "transform";
     this.detachCtrlZoom();
     this.mode.detachScrollListeners?.();
@@ -124,6 +125,7 @@ export class ModeSmoothZoom {
     await this.pinchMoveFramePromise;
     this.mode.scaleCenter = { x: 0.5, y: 0.5 };
     this.oldScale = 1;
+    this.mode.$visibleWorld.classList.remove("BRsmooth-zooming");
     this.mode.$visibleWorld.style.willChange = "auto";
     this.attachCtrlZoom();
     this.mode.attachScrollListeners?.();

--- a/src/BookReader/PageContainer.js
+++ b/src/BookReader/PageContainer.js
@@ -46,11 +46,17 @@ export class PageContainer {
     const alreadyLoaded = this.imageCache.imageLoaded(this.page.index, reduce);
     const nextBestLoadedReduce = !alreadyLoaded && this.imageCache.getBestLoadedReduce(this.page.index, reduce);
 
-    // Add the actual, highres image
+    // Create high res image
+    const $newImg = this.imageCache.image(this.page.index, reduce);
+
+    // Avoid removing/re-adding the image if it's already there
+    // This can be called quite a bit, so we need to be fast
+    if (this.$img?.[0].src == $newImg[0].src) {
+      return this;
+    }
+
     this.$img?.remove();
-    this.$img = this.imageCache
-      .image(this.page.index, reduce)
-      .prependTo(this.$container);
+    this.$img = $newImg.prependTo(this.$container);
 
     const backgroundLayers = [];
     if (!alreadyLoaded) {

--- a/src/BookReader/utils/ScrollClassAdder.js
+++ b/src/BookReader/utils/ScrollClassAdder.js
@@ -1,0 +1,31 @@
+/** Adds a class while the given element is experiencing scrolling */
+export class ScrollClassAdder {
+  /**
+   * @param {HTMLElement} element
+   * @param {string} className
+   */
+  constructor(element, className) {
+    /** @type {HTMLElement} */
+    this.element = element;
+    /** @type {string} */
+    this.className = className;
+    this.timeout = null;
+  }
+
+  attach() {
+    this.element.addEventListener('scroll', this.onScroll);
+  }
+
+  detach() {
+    this.element.removeEventListener('scroll', this.onScroll);
+  }
+
+  onScroll = () => {
+    this.element.classList.add(this.className);
+    clearTimeout(this.timeout);
+    // TODO: Also remove class on mousemove, touch, click, etc.
+    this.timeout = setTimeout(() => {
+      this.element.classList.remove(this.className);
+    }, 1000);
+  }
+}

--- a/src/BookReader/utils/ScrollClassAdder.js
+++ b/src/BookReader/utils/ScrollClassAdder.js
@@ -26,6 +26,6 @@ export class ScrollClassAdder {
     // TODO: Also remove class on mousemove, touch, click, etc.
     this.timeout = setTimeout(() => {
       this.element.classList.remove(this.className);
-    }, 1000);
+    }, 600);
   }
 }

--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -24,6 +24,13 @@
     }
 }
 
+// Hide text layer for performance during zooming & scrolling
+.BRsmooth-zooming, .BRscrolling-active {
+    .textSelectionSVG {
+        display: none;
+    }
+}
+
 // Makes page image unselectable
 .BRpagecontainer img {
     -webkit-user-select: none;

--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -31,6 +31,12 @@
     }
 }
 
+// Hide text selection layers of off-screen pages, and only display
+// 2 text layers regardless of zoom level
+.BRmode1up .BRpagecontainer:not(.BRpage-visible) .textSelectionSVG {
+    display: none;
+}
+
 // Makes page image unselectable
 .BRpagecontainer img {
     -webkit-user-select: none;

--- a/tests/jest/BookReader/PageContainer.test.js
+++ b/tests/jest/BookReader/PageContainer.test.js
@@ -62,17 +62,18 @@ describe('update', () => {
     expect(pc.$img[0].style.background).toBe('');
   });
 
-  test('removes image between updates', () => {
+  test('removes image between updates only if changed', () => {
     const fakeImageCache = {
       imageLoaded: () => true,
-      image: () => $('<img/>'),
+      image: (index, reduce) => $(`<img src="page${index}-${reduce}.jpg" />`),
     };
     const pc = new PageContainer({index: 12}, {imageCache: fakeImageCache});
     pc.update({ reduce: 7 });
     const $im1 = pc.$img;
     pc.update({ reduce: 7 });
-    const $im2 = pc.$img;
-    expect($im1).not.toBe($im2);
+    expect(pc.$img).toBe($im1);
+    pc.update({ reduce: 16 });
+    expect(pc.$img).not.toBe($im1);
     expect($im1.parent().length).toBe(0);
   });
 

--- a/tests/jest/BookReader/utils/ScrollClassAdder.test.js
+++ b/tests/jest/BookReader/utils/ScrollClassAdder.test.js
@@ -1,0 +1,49 @@
+// @ts-check
+import  sinon from 'sinon';
+import { ScrollClassAdder } from '@/src/BookReader/utils/ScrollClassAdder';
+
+describe('ScrollClassAdder', () => {
+  test('Does not attach during construction', () => {
+    const element = document.createElement('div');
+    const attachSpy = sinon.spy(ScrollClassAdder.prototype, 'attach');
+    new ScrollClassAdder(element, 'foo');
+    expect(attachSpy.callCount).toBe(0);
+  });
+
+  test('Attach/detach call correct methods', () => {
+    const el = document.createElement('div');
+    const addEventListenerSpy = sinon.spy(el, 'addEventListener');
+    const removeEventListenerSpy = sinon.spy(el, 'removeEventListener');
+    const sca = new ScrollClassAdder(el, 'foo');
+    expect(addEventListenerSpy.callCount).toBe(0);
+    sca.attach();
+    expect(addEventListenerSpy.callCount).toBe(1);
+    sca.detach();
+    expect(removeEventListenerSpy.callCount).toBe(1);
+  });
+
+  test('onScroll adds class at right time', () => {
+    const clock = sinon.useFakeTimers();
+    const el = document.createElement('div');
+    const sca = new ScrollClassAdder(el, 'foo');
+    expect(el.getAttribute('class')).toBeFalsy();
+    sca.onScroll();
+    expect(el.getAttribute('class')).toBe('foo');
+    clock.tick(1000);
+    expect(el.getAttribute('class')).toBeFalsy();
+
+    sca.onScroll();
+    expect(el.getAttribute('class')).toBe('foo');
+    clock.tick(900);
+    expect(el.getAttribute('class')).toBe('foo');
+    sca.onScroll();
+    expect(el.getAttribute('class')).toBe('foo');
+    clock.tick(100);
+    expect(el.getAttribute('class')).toBe('foo');
+    clock.tick(899);
+    expect(el.getAttribute('class')).toBe('foo');
+    clock.tick(1);
+    expect(el.getAttribute('class')).toBeFalsy();
+    clock.restore();
+  });
+});

--- a/tests/jest/BookReader/utils/ScrollClassAdder.test.js
+++ b/tests/jest/BookReader/utils/ScrollClassAdder.test.js
@@ -29,18 +29,18 @@ describe('ScrollClassAdder', () => {
     expect(el.getAttribute('class')).toBeFalsy();
     sca.onScroll();
     expect(el.getAttribute('class')).toBe('foo');
-    clock.tick(1000);
+    clock.tick(600);
     expect(el.getAttribute('class')).toBeFalsy();
 
     sca.onScroll();
     expect(el.getAttribute('class')).toBe('foo');
-    clock.tick(900);
+    clock.tick(500);
     expect(el.getAttribute('class')).toBe('foo');
     sca.onScroll();
     expect(el.getAttribute('class')).toBe('foo');
     clock.tick(100);
     expect(el.getAttribute('class')).toBe('foo');
-    clock.tick(899);
+    clock.tick(499);
     expect(el.getAttribute('class')).toBe('foo');
     clock.tick(1);
     expect(el.getAttribute('class')).toBeFalsy();


### PR DESCRIPTION
### Perf Improvment 1: Don't re-mount image during scroll/zoom

This didn't have a big impact on experience anecdotally, but I imagine it's probably good. Note the elements are no longer flashing in the devtools.

| Before | After |
| -- | -- |
| <video src="https://user-images.githubusercontent.com/6251786/158461482-e53e70ce-a325-4271-9266-cf1841f0956f.mp4"> | <video src="https://user-images.githubusercontent.com/6251786/158461668-1f7a0fce-4c99-494d-aab4-68c1a47c1e08.mp4"> |

### Perf Improvement 2: Hide text layer during scroll/zoom

This had a big impact on books with large text layers!


https://user-images.githubusercontent.com/6251786/158468209-a580f8d0-c379-4387-a7d8-5c23da8079b9.mp4

### Perf Improvement 3: hide off-screen text layers

Reduces "sticky" feeling when starting scroll/zoom. Note before/after here is relative to Perf improvement 2.

https://user-images.githubusercontent.com/6251786/158490805-cefd5993-1b52-41e5-bec1-078fcb694de5.mp4




- Before: https://lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=sim_weekly-recorder-a-news-paper_1819-12-09_6_17#mode/1up
- After: https://deploy-preview-1006--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=sim_weekly-recorder-a-news-paper_1819-12-09_6_17#mode/1up

Tested on Chrome/FF98 on Windows

Test:

- pinching/zooming, scrolling on mode 1up and 2up
- Selecting text
