### PR TITLE
Bundle/auto-merge GitHub actions updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,6 +38,11 @@
     {
       "matchPackagePatterns": ["*"],
       "rangeStrategy": "bump"
+    },
+    {
+      "matchDatasources": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
Any errors will very likely be caught by CI, so automerge! This will update things like: https://github.com/internetarchive/bookreader/blob/3111b955903a1e2bff5a1f3a8112f76b96348a2f/.github/workflows/npm-publish.yml#L14

- `matchDataSources` will match all the github action deps not using any pattern; just get all of 'em!
- `groupName` causes the updates to only create one PR and get updated together
- `automerge` ... auto merges!