### PR TITLE
Limit non-ia dep updates to monthly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "schedule:monthly"
   ],
   "packageRules": [
     {
@@ -42,6 +43,10 @@
       "matchPackagePatterns": ["^actions/"],
       "groupName": "GitHub Actions",
       "automerge": true
+    },
+    {
+      "matchPackagePatterns": ["^@internetarchive"],
+      "schedule": ["at any time"]
     }
   ]
 }


### PR DESCRIPTION
This is getting a little noisy, and causing netlify to struggle with all the PRs. Limit to monthly for non-IA package updates.