### PR TITLE
keep  url param dynamic with patron's search request

### DIFF
--- a/src/BookNavigator/search/search-provider.js
+++ b/src/BookNavigator/search/search-provider.js
@@ -75,6 +75,10 @@ export default class SearchProvider {
       searchCanceled: true
     };
     this.updateMenu(updateMenuFor);
+
+    if (this.bookreader.urlPlugin) {
+      this.updateSearchInUrl();
+    }
   }
 
   onSearchStarted(e) {
@@ -146,7 +150,20 @@ export default class SearchProvider {
     };
     this.updateMenu({ openMenu: false });
     this.bookreader?.searchView?.clearSearchFieldAndResults(false);
+    this.bookreader?.urlPlugin?.pullFromAddressBar();
     this.bookreader?.urlPlugin?.removeUrlParam('q');
+  }
+
+  /** update URL `q=<term>` query param in URL */
+  updateSearchInUrl() {
+    if (this.bookreader.urlPlugin) {
+      this.bookreader.urlPlugin.pullFromAddressBar();
+      if (searchState.query) {
+        this.bookreader.urlPlugin.setUrlParam('q', searchState.query);
+      } else {
+        this.bookreader.urlPlugin.removeUrlParam('q');
+      }
+    }
   }
 
   /**

--- a/src/BookNavigator/search/search-provider.js
+++ b/src/BookNavigator/search/search-provider.js
@@ -150,8 +150,9 @@ export default class SearchProvider {
     };
     this.updateMenu({ openMenu: false });
     this.bookreader?.searchView?.clearSearchFieldAndResults(false);
-    this.bookreader?.urlPlugin?.pullFromAddressBar();
-    this.bookreader?.urlPlugin?.removeUrlParam('q');
+    if (this.bookreader.urlPlugin) {
+      this.updateSearchInUrl();
+    }
   }
 
   /** update URL `q=<term>` query param in URL */

--- a/src/BookNavigator/search/search-provider.js
+++ b/src/BookNavigator/search/search-provider.js
@@ -146,6 +146,7 @@ export default class SearchProvider {
     };
     this.updateMenu({ openMenu: false });
     this.bookreader?.searchView?.clearSearchFieldAndResults(false);
+    this.bookreader?.urlPlugin?.removeUrlParam('q');
   }
 
   /**

--- a/src/BookNavigator/search/search-results.js
+++ b/src/BookNavigator/search/search-results.js
@@ -60,6 +60,9 @@ export class IABookSearchResults extends LitElement {
 
   setQuery(e) {
     this.query = e.currentTarget.value;
+    if (!this.query) {
+      this.cancelSearch();
+    }
   }
 
   performSearch(e) {
@@ -148,6 +151,7 @@ export class IABookSearchResults extends LitElement {
             name="query"
             alt="Search inside this book."
             @keyup=${this.setQuery}
+            @search=${this.setQuery}
             .value=${this.query}
           />
         </fieldset>

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -250,7 +250,7 @@ BookReader.prototype.cancelSearchRequest = function () {
     this.searchView.toggleSearchPending();
     this.trigger('SearchCanceled', { term: this.searchTerm, instance: this });
   }
-  this.bookreader?.urlPlugin?.removeUrlParam('q');
+  this?.urlPlugin?.removeUrlParam('q');
 };
 
 /**

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -217,12 +217,6 @@ BookReader.prototype.search = async function(term = '', overrides = {}) {
     cache: true,
     beforeSend: xhr => { this.searchXHR = xhr; },
   }));
-
-  if (!this.searchTerm) {
-    this.bookreader?.urlPlugin?.removeUrlParam('q');
-  } else {
-    this.bookreader?.urlPlugin?.setUrlParam('q', this.searchTerm);
-  }
 };
 
 /**
@@ -236,7 +230,6 @@ BookReader.prototype._cancelSearch = function () {
   this.searchXHR = null;
   this.searchCancelled = true;
   this.searchResults = [];
-  this.bookreader?.urlPlugin?.removeUrlParam('q');
 };
 
 /**
@@ -250,7 +243,6 @@ BookReader.prototype.cancelSearchRequest = function () {
     this.searchView.toggleSearchPending();
     this.trigger('SearchCanceled', { term: this.searchTerm, instance: this });
   }
-  this?.urlPlugin?.removeUrlParam('q');
 };
 
 /**

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -217,6 +217,12 @@ BookReader.prototype.search = async function(term = '', overrides = {}) {
     cache: true,
     beforeSend: xhr => { this.searchXHR = xhr; },
   }));
+
+  if (!this.searchTerm) {
+    this.bookreader?.urlPlugin?.removeUrlParam('q');
+  } else {
+    this.bookreader?.urlPlugin?.setUrlParam('q', this.searchTerm);
+  }
 };
 
 /**
@@ -230,6 +236,7 @@ BookReader.prototype._cancelSearch = function () {
   this.searchXHR = null;
   this.searchCancelled = true;
   this.searchResults = [];
+  this.bookreader?.urlPlugin?.removeUrlParam('q');
 };
 
 /**
@@ -243,6 +250,7 @@ BookReader.prototype.cancelSearchRequest = function () {
     this.searchView.toggleSearchPending();
     this.trigger('SearchCanceled', { term: this.searchTerm, instance: this });
   }
+  this.bookreader?.urlPlugin?.removeUrlParam('q');
 };
 
 /**

--- a/tests/jest/BookNavigator/search/search-provider.test.js
+++ b/tests/jest/BookNavigator/search/search-provider.test.js
@@ -102,7 +102,7 @@ describe('Search Provider', () => {
 
       expect(provider.bookreader._searchPluginGoToResult.callCount).toEqual(1);
     });
-    test('update url when search is cancelled', async() => {
+    test('update url when search is cancelled or input cleared', async() => {
       const urlPluginMock = {
         pullFromAddressBar: sinon.fake(),
         removeUrlParam: sinon.fake()
@@ -121,6 +121,12 @@ describe('Search Provider', () => {
 
       expect(urlPluginMock.pullFromAddressBar.callCount).toEqual(1);
       expect(urlPluginMock.removeUrlParam.callCount).toEqual(1);
+
+      provider.onSearchCanceled();
+      await provider.updateComplete;
+
+      expect(urlPluginMock.pullFromAddressBar.callCount).toEqual(2);
+      expect(urlPluginMock.removeUrlParam.callCount).toEqual(2);
     });
   });
 });

--- a/tests/jest/BookNavigator/search/search-provider.test.js
+++ b/tests/jest/BookNavigator/search/search-provider.test.js
@@ -102,5 +102,25 @@ describe('Search Provider', () => {
 
       expect(provider.bookreader._searchPluginGoToResult.callCount).toEqual(1);
     });
+    test('update url when search is cancelled', async() => {
+      const urlPluginMock = {
+        pullFromAddressBar: sinon.fake(),
+        removeUrlParam: sinon.fake()
+      };
+      const provider = new searchProvider({
+        onProviderChange: sinon.fake(),
+        bookreader: {
+          leafNumToIndex: sinon.fake(),
+          _searchPluginGoToResult: sinon.fake(),
+          urlPlugin: urlPluginMock
+        }
+      });
+
+      provider.onSearchCanceled();
+      await provider.updateComplete;
+
+      expect(urlPluginMock.pullFromAddressBar.callCount).toEqual(1);
+      expect(urlPluginMock.removeUrlParam.callCount).toEqual(1);
+    });
   });
 });

--- a/tests/jest/BookNavigator/search/search-provider.test.js
+++ b/tests/jest/BookNavigator/search/search-provider.test.js
@@ -128,5 +128,40 @@ describe('Search Provider', () => {
       expect(urlPluginMock.pullFromAddressBar.callCount).toEqual(2);
       expect(urlPluginMock.removeUrlParam.callCount).toEqual(2);
     });
+    it('updateSearchInUrl', async () => {
+      let fieldToSet;
+      let valueOfFieldToSet;
+      let setUrlParamCalled = false;
+      const urlPluginMock = {
+        pullFromAddressBar: sinon.fake(),
+        removeUrlParam: sinon.fake(),
+        setUrlParam: (field, val) => {
+          fieldToSet = field;
+          valueOfFieldToSet = val;
+          setUrlParamCalled = true;
+        }
+      };
+      const provider = new searchProvider({
+        onProviderChange: sinon.fake(),
+        bookreader: {
+          leafNumToIndex: sinon.fake(),
+          _searchPluginGoToResult: sinon.fake(),
+          urlPlugin: urlPluginMock,
+          search: sinon.fake()
+        }
+      });
+
+      const searchInitiatedEvent = new CustomEvent('bookSearchInitiated', { detail: { query: 'foobar' } });
+      // set initial seachState with a query
+      provider.onBookSearchInitiated(searchInitiatedEvent);
+      await provider.updateComplete;
+      // checking this fn:
+      provider.updateSearchInUrl();
+      await provider.updateComplete;
+
+      expect(fieldToSet).toEqual('q');
+      expect(valueOfFieldToSet).toEqual('foobar');
+      expect(setUrlParamCalled).toBe(true);
+    });
   });
 });

--- a/tests/jest/BookNavigator/search/search-results.test.js
+++ b/tests/jest/BookNavigator/search/search-results.test.js
@@ -245,7 +245,7 @@ describe('<ia-book-search-results>', () => {
     const searchInput = el.shadowRoot.querySelector('[name="query"]');
 
     searchInput.value = '';
-    searchInput.dispatchEvent(new Event('keyup'));
+    searchInput.dispatchEvent(new Event('search'));
 
     expect(el.cancelSearch.callCount).toEqual(1);
   });

--- a/tests/jest/BookNavigator/search/search-results.test.js
+++ b/tests/jest/BookNavigator/search/search-results.test.js
@@ -236,4 +236,17 @@ describe('<ia-book-search-results>', () => {
 
     expect(response).toBeDefined();
   });
+  it('cancels search when input is cleared', async () => {
+    const el = await fixture(container(results));
+
+    el.cancelSearch = sinon.fake();
+    await el.updateComplete;
+
+    const searchInput = el.shadowRoot.querySelector('[name="query"]');
+
+    searchInput.value = '';
+    searchInput.dispatchEvent(new Event('keyup'));
+
+    expect(el.cancelSearch.callCount).toEqual(1);
+  });
 });


### PR DESCRIPTION
This PR removes `q=<term>` query param when search is cancelled or when search menu input is cleared