### PR TITLE
Fix leaf positioning during rtl flip anim

### DIFF
--- a/src/BookReader/Mode2Up.js
+++ b/src/BookReader/Mode2Up.js
@@ -843,6 +843,13 @@ export class Mode2Up {
     this.pageContainers[this.br.twoPage.currentIndexR].$container.animate({width: '0px'}, speed, 'easeInSine', () => {
       this.br.$('BRgutter').css({left: `${gutter - this.br.twoPage.bookSpineDivWidth * 0.5}px`});
       $(this.br.leafEdgeTmp).animate({left: `${gutter - newWidthL - leafEdgeTmpW}px`}, speed, 'easeOutSine');
+
+      // Ensure the new left leaf is right-positioned before animating its width.
+      // Otherwise, it animates in the wrong direction.
+      this.pageContainers[newIndexL].$container.css({
+        right: `${newWidthL}px`,
+        left: ''
+      });
       this.pageContainers[newIndexL].$container.animate({width: `${newWidthL}px`}, speed, 'easeOutSine', () => {
         this.pageContainers[newIndexR].$container.css('zIndex', 2);
 

--- a/tests/jest/BookReader/Mode2Up.test.js
+++ b/tests/jest/BookReader/Mode2Up.test.js
@@ -54,7 +54,7 @@ describe('page flip directions', () => {
 
     const fake = sinon.fake();
     const fakeAnimWithCB = sinon.fake.yields();
-    const fakeAnim = sinon.fake((...args) => 
+    const fakeAnim = sinon.fake((...args) =>
       typeof args[args.length - 1] === 'function' ? fakeAnimWithCB(...args) : fake
     );
     sinon.replace(jQuery.prototype, 'animate', fakeAnim);
@@ -62,7 +62,7 @@ describe('page flip directions', () => {
     const fakeCSS = sinon.spy(jQuery.prototype, 'css');
 
     br.next();
-    
+
     expect(fakeAnimWithCB.callCount).toBe(2);
     // Find the call to .css() immediately preceding the second animation with a callback (i.e., the left page animation)
     const preSecondAnimCssCallIndex = fakeCSS.getCalls().findIndex(call => call.calledAfter(fakeAnimWithCB.getCall(1))) - 1;

--- a/tests/jest/BookReader/Mode2Up.test.js
+++ b/tests/jest/BookReader/Mode2Up.test.js
@@ -47,6 +47,29 @@ describe('zoom', () => {
   });
 });
 
+describe('page flip directions', () => {
+  test('animates the left page in the correct direction', () => {
+    const br = new BookReader({ data: SAMPLE_DATA });
+    br.init();
+
+    const fake = sinon.fake();
+    const fakeAnimWithCB = sinon.fake.yields();
+    const fakeAnim = sinon.fake((...args) => 
+      typeof args[args.length - 1] === 'function' ? fakeAnimWithCB(...args) : fake
+    );
+    sinon.replace(jQuery.prototype, 'animate', fakeAnim);
+
+    const fakeCSS = sinon.spy(jQuery.prototype, 'css');
+
+    br.next();
+    
+    expect(fakeAnimWithCB.callCount).toBe(2);
+    // Find the call to .css() immediately preceding the second animation with a callback (i.e., the left page animation)
+    const preSecondAnimCssCallIndex = fakeCSS.getCalls().findIndex(call => call.calledAfter(fakeAnimWithCB.getCall(1))) - 1;
+    expect(fakeCSS.getCall(preSecondAnimCssCallIndex).args[0].left).toBe('');
+  });
+});
+
 describe('prefetch', () => {
   test('loads nearby pages', () => {
     const br = new BookReader({ data: SAMPLE_DATA });


### PR DESCRIPTION
This issue affects right-to-left page flipping via the "next page" button in 2up mode. It mainly appears to affect texts with an even number of pages where the first and last pages present on their own.

If the new left page remains left-positioned upon flipping to the next page, its animation unfolds in the wrong direction. Ensuring before the animation that it is right-positioned at the center prevents this issue.

This PR should also address https://github.com/internetarchive/bookreader/issues/173 which appears to have the same root cause.

### Problem gif (left pages flip the wrong way following a wraparound from the end to the start of the book):
![bookreader-page-flip-anim-problem](https://user-images.githubusercontent.com/1619661/183789735-91456a26-e34d-4b52-9085-ab5fa1f3df09.gif)

### Corrected gif (pages always flip the right way):
![bookreader-page-flip-anim-corrected](https://user-images.githubusercontent.com/1619661/183790101-f9b7c57f-4ff1-4a0b-8d3b-6c397264cde2.gif)

### Testing
Preview app: https://deploy-preview-1077--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=CIA-RDP05S00620R000300830010-7

- Flip through all the pages of the given text until the end (e.g., with the right arrow key, clicking 'Next Page' button, or tapping/swiping right).
- From there, moving to the next page will wraparound to the beginning of the text.
- Continue moving to the next page repeatedly and verify that the page flip animations look correct -- after the right leaf has animated into the center, the left leaf should grow outward from the center (not inward from the left edge, as in the problem gif).
- Moving back a page (flipping left-to-right) at any point should also continue to look as expected, and not interfere with the forward movement animations after it.