### PR TITLE
Fix positioning during page flip for large books

### DIFF
--- a/src/BookReader/Mode2Up.js
+++ b/src/BookReader/Mode2Up.js
@@ -847,7 +847,7 @@ export class Mode2Up {
       // Ensure the new left leaf is right-positioned before animating its width.
       // Otherwise, it animates in the wrong direction.
       this.pageContainers[newIndexL].$container.css({
-        right: `${newWidthL}px`,
+        right: `${$twoPageViewEl.prop('clientWidth') - gutter}px`,
         left: ''
       });
       this.pageContainers[newIndexL].$container.animate({width: `${newWidthL}px`}, speed, 'easeOutSine', () => {


### PR DESCRIPTION
Large books with leaf edges had weird page offsets/shifts during the
page flip animation as a result of the previous anim fix.
This change ensures the page is positioned correctly throughout the
animation regardless of whether leaf edges are present.

## Problem:

In [my earlier fix for page flipping animations](https://github.com/internetarchive/bookreader/pull/1077), I applied an incorrect offset to the left page as it flips leftward, which is noticeable mainly in longer books that have clickable leaf edges. This results in some undesirable page shifting upon the animations completing and everything snapping into place:
![bookreader-page-flip-anim-problem2](https://user-images.githubusercontent.com/1619661/184449392-665d9950-34e7-40cb-b4c9-51325ce07db9.gif)

## Acceptance:

The pages should animate to their correctly-offset position smoothly and not have any jarring snaps at the end when flipping right through the book.

## Testing:

Code-wise, this is just a quick one-liner fix to apply the correct offset to the page before it animates.

QA:

- Visit the testing app: https://deploy-preview-1078--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=theworksofplato01platiala
- Check that flipping rightward through the book doesn’t have the page snapping like the gif above. The flipping should appear smooth and continuous.
- Check that jumping to a distant page (e.g., via the seek bar or by clicking into the leaf edge) also doesn't cause any jarring page layout shifts after the animation completes

![bookreader-page-flip-anim-corrected2](https://user-images.githubusercontent.com/1619661/184449467-bb646fc5-df78-4612-9c4d-0dcaf05fc1d0.gif)

(I've found the book as a whole occasionally has layout shifts due to differing page sizes/recentering, but those are unrelated to this fix and probably expected)