### PR TITLE
Disable contextmenu on restricted books

### DIFF
--- a/BookReaderDemo/demo-internetarchive.html
+++ b/BookReaderDemo/demo-internetarchive.html
@@ -126,6 +126,11 @@
       const placeholder = document.querySelector('#placeholder');
       placeholder.innerHTML = 'Dependencies are complete, bookreader has loaded';
     });
+
+    // analytics stub
+    window.archive_analytics = {
+      send_event_no_sampling: (category, action, label) => console.log('~~~ NO SAMPLE EVENT CALLED: ', { category, action, label }),
+    }
   </script>
 
   <!-- IA fetch demo -->

--- a/BookReaderDemo/demo-internetarchive.html
+++ b/BookReaderDemo/demo-internetarchive.html
@@ -130,6 +130,8 @@
     // analytics stub
     window.archive_analytics = {
       send_event_no_sampling: (category, action, label) => console.log('~~~ NO SAMPLE EVENT CALLED: ', { category, action, label }),
+      send_event: (category, action, label) => console.log('~~~ send_event SAMPLE EVENT CALLED: ', { category, action, label }),
+      send_ping: (category, action, label) => console.log('~~~ send_ping SAMPLE EVENT CALLED: ', { category, action, label }),
     }
   </script>
 

--- a/src/BookNavigator/book-navigator.js
+++ b/src/BookNavigator/book-navigator.js
@@ -443,26 +443,29 @@ export class BookNavigator extends LitElement {
       this.downloadableTypes = downloadURLs;
       this.bookIsRestricted = isRestricted;
     });
-    document.addEventListener('contextmenu', (e) => {
-      if (window.archive_analytics) {
-        window.archive_analytics?.send_event_no_sampling(
-          'BookReader',
-          `contextmenu-${this.bookIsRestricted ? 'restricted' : 'unrestricted'}`,
-          e.target.classList.value
-        );
-      }
-      if (!this.bookIsRestricted) {
-        return;
-      }
+    window.addEventListener('contextmenu', (e) => this.manageContextMenuVisibility(e), { capture: true });
+  }
 
-      const imagePane = e.target.classList.value.match(/BRscreen|BRpageimage/g);
-      if (!imagePane) {
-        return;
-      }
+  /** Display an element's context menu */
+  manageContextMenuVisibility(e) {
+    if (window.archive_analytics) {
+      window.archive_analytics?.send_event_no_sampling(
+        'BookReader',
+        `contextmenu-${this.bookIsRestricted ? 'restricted' : 'unrestricted'}`,
+        e.target.classList.value
+      );
+    }
+    if (!this.bookIsRestricted) {
+      return;
+    }
 
-      e.preventDefault();
-      return false;
-    }, { capture: true });
+    const imagePane = e.target.classList.value.match(/BRscreen|BRpageimage/g);
+    if (!imagePane) {
+      return;
+    }
+
+    e.preventDefault();
+    return false;
   }
 
   loadSharedObserver() {

--- a/src/BookNavigator/book-navigator.js
+++ b/src/BookNavigator/book-navigator.js
@@ -443,6 +443,26 @@ export class BookNavigator extends LitElement {
       this.downloadableTypes = downloadURLs;
       this.bookIsRestricted = isRestricted;
     });
+    document.addEventListener('contextmenu', (e) => {
+      if (window.archive_analytics) {
+        window.archive_analytics?.send_event_no_sampling(
+          'BookReader',
+          `contextmenu-${this.bookIsRestricted ? 'restricted' : 'unrestricted'}`,
+          e.target.classList.value
+        );
+      }
+      if (!this.bookIsRestricted) {
+        return;
+      }
+
+      const imagePane = e.target.classList.value.match(/BRscreen|BRpageimage/g);
+      if (!imagePane) {
+        return;
+      }
+
+      e.preventDefault();
+      return false;
+    }, { capture: true });
   }
 
   loadSharedObserver() {

--- a/tests/jest/BookNavigator/book-navigator.test.js
+++ b/tests/jest/BookNavigator/book-navigator.test.js
@@ -591,5 +591,40 @@ describe('<book-navigator>', () => {
         expect(preventDefaultSpy.called).toEqual(true);
       });
     });
+    it('Allows unrestricted books access to context menu', async () => {
+      window.archive_analytics = { send_event_no_sampling: sinon.fake() };
+
+      const el = fixtureSync(container());
+      const brStub = {
+        options: { restricted: false },
+      };
+
+      el.bookreader = brStub;
+      el.bookIsRestricted = false;
+
+      await el.elementUpdated;
+
+      expect(window.archive_analytics.send_event_no_sampling.called).toEqual(
+        false
+      );
+
+      const body = document.querySelector('body');
+      // const element stub for img.BRpageimage
+      const imgBRpageimage = document.createElement('img');
+      imgBRpageimage.classList.add('not-targeted-element');
+      body.appendChild(imgBRpageimage);
+      const contextMenuEvent = new Event('contextmenu', { bubbles: true });
+
+      // Set spy on contextMenuEvent to check if `preventDefault` is called
+      const preventDefaultSpy = sinon.spy(contextMenuEvent, 'preventDefault');
+      expect(preventDefaultSpy.called).toEqual(false);
+
+      imgBRpageimage.dispatchEvent(contextMenuEvent);
+
+      // analytics fires
+      expect(window.archive_analytics.send_event_no_sampling.called).toEqual(true);
+      // we do not prevent default
+      expect(preventDefaultSpy.called).toEqual(false);
+    });
   });
 });

--- a/tests/jest/BookNavigator/book-navigator.test.js
+++ b/tests/jest/BookNavigator/book-navigator.test.js
@@ -513,4 +513,83 @@ describe('<book-navigator>', () => {
       expect(el.manageFullScreenBehavior.callCount).toEqual(1);
     });
   });
+  describe('Handles Restricted Books', () => {
+    describe('contextMenu is prevented when book is restricted', () => {
+      it('watches on `div.BRscreen`', async () => {
+        window.archive_analytics = { send_event_no_sampling: sinon.fake() };
+
+        const el = fixtureSync(container());
+        const brStub = {
+          options: { restricted: true },
+        };
+
+        el.bookreader = brStub;
+        el.bookIsRestricted = true;
+
+        const elSpy = sinon.spy(el.manageContextMenuVisibility);
+        await el.elementUpdated;
+
+        expect(window.archive_analytics.send_event_no_sampling.called).toEqual(
+          false
+        );
+        expect(elSpy.called).toEqual(false);
+
+        const body = document.querySelector('body');
+
+        const divBRscreen = document.createElement('div');
+        divBRscreen.classList.add('BRscreen');
+        body.appendChild(divBRscreen);
+
+        const contextMenuEvent = new Event('contextmenu', { bubbles: true });
+
+        // Set spy on contextMenuEvent to check if `preventDefault` is called
+        const preventDefaultSpy = sinon.spy(contextMenuEvent, 'preventDefault');
+        expect(preventDefaultSpy.called).toEqual(false);
+
+        divBRscreen.dispatchEvent(contextMenuEvent);
+
+        // analytics fires
+        expect(window.archive_analytics.send_event_no_sampling.called).toEqual(
+          true
+        );
+        // we prevent default
+        expect(preventDefaultSpy.called).toEqual(true);
+      });
+      it('watches on `img.BRpageimage`', async () => {
+        window.archive_analytics = { send_event_no_sampling: sinon.fake() };
+
+        const el = fixtureSync(container());
+        const brStub = {
+          options: { restricted: true },
+        };
+
+        el.bookreader = brStub;
+        el.bookIsRestricted = true;
+
+        await el.elementUpdated;
+
+        expect(window.archive_analytics.send_event_no_sampling.called).toEqual(
+          false
+        );
+
+        const body = document.querySelector('body');
+        // const element stub for img.BRpageimage
+        const imgBRpageimage = document.createElement('img');
+        imgBRpageimage.classList.add('BRpageimage');
+        body.appendChild(imgBRpageimage);
+        const contextMenuEvent = new Event('contextmenu', { bubbles: true });
+
+        // Set spy on contextMenuEvent to check if `preventDefault` is called
+        const preventDefaultSpy = sinon.spy(contextMenuEvent, 'preventDefault');
+        expect(preventDefaultSpy.called).toEqual(false);
+
+        imgBRpageimage.dispatchEvent(contextMenuEvent);
+
+        // analytics fires
+        expect(window.archive_analytics.send_event_no_sampling.called).toEqual(true);
+        // we prevent default
+        expect(preventDefaultSpy.called).toEqual(true);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## TESTING inside of BR's in-repo demo app

Restricted book https://deploy-preview-1080--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=sim_gramophone_1926-01_3_8 
- once book loads, open dev console
- ✅ right click on image => console.log output notes `~~~ NO SAMPLE EVENT CALLED:  ` + GA event details
  -   `{category: 'BookReader', action: 'contextmenu-restricted', label: 'BRscreen'}`
- ✅ NO context menu shows up to allow for image download
- ✅ works in 2up, 1up, thumb


Unrestricted book https://deploy-preview-1080--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=goody#page/n22/mode/2up 
- ✅ right click on image => console.log output notes `~~~ NO SAMPLE EVENT CALLED:  ` + GA event details
- ✅ YES context menu shows up to allow for image download
- ✅ works in 2up, 1up, thumb