### PR TITLE
WEBDEV-5491 Ensure search results are sanitized

### DIFF
--- a/src/BookNavigator/search/a-search-result.js
+++ b/src/BookNavigator/search/a-search-result.js
@@ -1,4 +1,4 @@
-import { escapeHTML } from '../../BookReader/utils';
+import { escapeHTML } from '../../BookReader/utils.js';
 import { html, LitElement, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 /** @typedef {import('@/src/plugins/search/plugin.search.js').SearchInsideMatch} SearchInsideMatch */

--- a/src/BookNavigator/search/a-search-result.js
+++ b/src/BookNavigator/search/a-search-result.js
@@ -1,4 +1,6 @@
+import { escapeHTML } from '../../BookReader/utils';
 import { html, LitElement, nothing } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 /** @typedef {import('@/src/plugins/search/plugin.search.js').SearchInsideMatch} SearchInsideMatch */
 
 export class BookSearchResult extends LitElement {
@@ -26,29 +28,9 @@ export class BookSearchResult extends LitElement {
    * in the snippets intact (as inert text), rather than stripping them away with DOMPurify.
    */
   highlightedHit(hit) {
-    const matches = hit.matchAll(this.matchRegex);
-    const templates = [];
-
-    // Convert each match into an HTML template that includes:
-    //  - Everything from the end of the previous match (or the beginning of the
-    //      string) up to the current match, as raw text.
-    //  - The current match (excluding the curly braces) wrapped in a `<mark>` tag.
-    let index = 0;
-    for (const match of matches) {
-      if (match.index != null) {
-        templates.push(html`
-          ${hit.slice(index, match.index)}
-          <mark>${match[1]}</mark>
-        `);
-        index = match.index + match[0].length;
-      }
-    }
-
-    // Include any text from the last match to the end
-    templates.push(html`${hit.slice(index)}`);
-
-    // Squash everything into a single p template
-    return html`<p>${templates}</p>`;
+    return html`<p>
+      ${unsafeHTML(escapeHTML(hit).replace(this.matchRegex, '<mark>$1</mark>'))}
+    </p>`;
   }
 
   resultSelected() {

--- a/src/BookNavigator/search/a-search-result.js
+++ b/src/BookNavigator/search/a-search-result.js
@@ -1,5 +1,4 @@
 import { html, LitElement, nothing } from 'lit';
-import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 /** @typedef {import('@/src/plugins/search/plugin.search.js').SearchInsideMatch} SearchInsideMatch */
 
 export class BookSearchResult extends LitElement {
@@ -12,17 +11,44 @@ export class BookSearchResult extends LitElement {
   constructor() {
     super();
 
-    this.matchRegex = new RegExp('{{{(.+?)}}}', 'g');
+    this.matchRegex = new RegExp('{{{(.+?)}}}', 'gs');
   }
 
   createRenderRoot() {
     return this;
   }
 
+  /**
+   * Converts the search hit to a `<p>` template containing the full search result with all of
+   * its `{{{triple-brace-delimited}}}` matches replaced by `<mark>HTML mark tags</mark>`.
+   *
+   * This approach safely avoids the use of `unsafeHTML` and leaves any existing HTML tags
+   * in the snippets intact (as inert text), rather than stripping them away with DOMPurify.
+   */
   highlightedHit(hit) {
-    return html`
-      <p>${unsafeHTML(hit.replace(this.matchRegex, '<mark>$1</mark>'))}</p>
-    `;
+    const matches = hit.matchAll(this.matchRegex);
+    const templates = [];
+
+    // Convert each match into an HTML template that includes:
+    //  - Everything from the end of the previous match (or the beginning of the
+    //      string) up to the current match, as raw text.
+    //  - The current match (excluding the curly braces) wrapped in a `<mark>` tag.
+    let index = 0;
+    for (const match of matches) {
+      if (match.index != null) {
+        templates.push(html`
+          ${hit.slice(index, match.index)}
+          <mark>${match[1]}</mark>
+        `);
+        index = match.index + match[0].length;
+      }
+    }
+
+    // Include any text from the last match to the end
+    templates.push(html`${hit.slice(index)}`);
+
+    // Squash everything into a single p template
+    return html`<p>${templates}</p>`;
   }
 
   resultSelected() {


### PR DESCRIPTION
**Problem:** Search results are rendered using the `unsafeHTML` directive, which allows HTML tags present in the underlying document to be injected into the DOM when they appear in search results. This creates an XSS vulnerability when, e.g., the underlying document contains `<script>` tags that will be executed upon rendering the search results.

This PR ensures that search results are inserted into the DOM as raw text, with the only active markup present being the `<mark>` tags added to highlight the search keywords.