### PR TITLE
Escape search results being shown in the footer bar

### DIFF
--- a/src/plugins/search/view.js
+++ b/src/plugins/search/view.js
@@ -245,9 +245,8 @@ class SearchView {
         queryStringWithBTruncated = queryString.replace(/^(.{100}[^\s]*).*/, "$1");
 
         // If truncating, we must escape *after* truncation occurs (but before wrapping in <b>)
-        queryStringWithBTruncated = escapeHTML(queryStringWithBTruncated);
-
-        queryStringWithBTruncated = queryStringWithBTruncated.replace(this.matcher, '<b>$1</b>')
+        queryStringWithBTruncated = escapeHTML(queryStringWithBTruncated)
+          .replace(this.matcher, '<b>$1</b>')
           + '...';
       }
 

--- a/src/plugins/search/view.js
+++ b/src/plugins/search/view.js
@@ -1,3 +1,5 @@
+import { escapeHTML } from "../../BookReader/utils.js";
+
 class SearchView {
   /**
    * @param {object} params
@@ -13,7 +15,7 @@ class SearchView {
     // Search results are returned as a text blob with the hits wrapped in
     // triple mustaches. Hits occasionally include text beyond the search
     // term, so everything within the staches is captured and wrapped.
-    this.matcher = new RegExp('{{{(.+?)}}}', 'g');
+    this.matcher = new RegExp('{{{(.+?)}}}', 'gs');
     this.matches = [];
     this.cacheDOMElements();
     this.bindEvents();
@@ -234,15 +236,19 @@ class SearchView {
 
       const percentThrough = this.br.constructor.util.cssPercentage(pageIndex, this.br.getNumLeafs() - 1);
 
-      const queryStringWithB = queryString.replace(this.matcher, '<b>$1</b>');
+      const escapedQueryString = escapeHTML(queryString);
+      const queryStringWithB = escapedQueryString.replace(this.matcher, '<b>$1</b>');
 
       let queryStringWithBTruncated = '';
 
       if (queryString.length > 100) {
-        queryStringWithBTruncated = queryString
-          .replace(/^(.{100}[^\s]*).*/, "$1")
-          .replace(this.matcher, '<b>$1</b>')
-                + '...';
+        queryStringWithBTruncated = queryString.replace(/^(.{100}[^\s]*).*/, "$1");
+
+        // If truncating, we must escape *after* truncation occurs (but before wrapping in <b>)
+        queryStringWithBTruncated = escapeHTML(queryStringWithBTruncated);
+
+        queryStringWithBTruncated = queryStringWithBTruncated.replace(this.matcher, '<b>$1</b>')
+          + '...';
       }
 
       // draw marker

--- a/tests/jest/plugins/search/plugin.search.view.test.js
+++ b/tests/jest/plugins/search/plugin.search.view.test.js
@@ -27,6 +27,27 @@ const results = {
     }]
   }]
 };
+const resultWithScript = {
+  ia: "adventuresofoli00dick",
+  q: "child",
+  indexed: true,
+  page_count: 644,
+  body_length: 666,
+  leaf0_missing: false,
+  matches: [{
+    text: 'foo bar <script>alert(1);</script> {{{keyword}}} baz',
+    par: [{
+      boxes: [{r: 1221, b: 2121, t: 2075, page: 37, l: 1107}],
+      b: 2535,
+      t: 1942,
+      page_width: 1790,
+      r: 1598,
+      l: 50,
+      page_height: 2940,
+      page: 37
+    }]
+  }]
+};
 beforeEach(() => {
   $.ajax = jest.fn().mockImplementation(() => {
     // return from:
@@ -80,6 +101,14 @@ describe('View: Plugin: Search', () => {
       expect(searchResultsNav.querySelector('.toggle-sidebar')).toBeDefined();
       expect(searchResultsNav.querySelector('.prev')).toBeDefined();
       expect(searchResultsNav.querySelector('.next')).toBeDefined();
+    });
+    test('disallows xss from search results', () => {
+      br.init();
+      const event = new CustomEvent(`${namespace}SearchCallback`);
+      const options = { goToFirstResult: false };
+      br.searchView.handleSearchCallback(event, { results: resultWithScript, options });
+
+      expect(br.searchView.dom.searchNavigation.parent().html()).not.toContain('<script>alert(1);</script>');
     });
 
     describe('Click events handlers', () => {


### PR DESCRIPTION
Follow-up to #1088 -- unescaped search results appear in the footer bar as well. This PR ensures they are escaped before being inserted into the DOM.

**Testing:** Visit https://deploy-preview-1091--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=book-reader-test-1234#mode/1up/search/searching and verify that no browser alert occurs (initially or upon performing different searches).