### PR TITLE
Remove most class shims + v5 BR deprecations

### DIFF
--- a/src/BookNavigator/bookmarks/ia-bookmarks.js
+++ b/src/BookNavigator/bookmarks/ia-bookmarks.js
@@ -213,8 +213,8 @@ class IABookmarks extends LitElement {
       color: this.getBookmarkColor(color) ? color : this.defaultColor.id,
     };
 
-    const page = IABookmarks.formatPage(this.bookreader._models.book.getPageNum(leafNum));
-    const thumbnail = this.bookreader._models.book.getPageURI(`${leafNum}`.replace(/\D/g, ''), 32); // Request thumbnail 1/32 the size of original image
+    const page = IABookmarks.formatPage(this.bookreader.book.getPageNum(leafNum));
+    const thumbnail = this.bookreader.book.getPageURI(`${leafNum}`.replace(/\D/g, ''), 32); // Request thumbnail 1/32 the size of original image
     const bookmark = {
       ...nomalizedParams,
       id: leafNum,
@@ -297,7 +297,7 @@ class IABookmarks extends LitElement {
       const pageBookmark = this.getBookmark(pageID);
       const bookmarkState = pageBookmark ? 'filled' : 'hollow';
       // eslint-disable-next-line
-      const pageData = this.bookreader._models.book.getPage(pageID);
+      const pageData = this.bookreader.book.getPage(pageID);
       const { isViewable } = pageData;
 
       if (!isViewable) { return; }
@@ -417,7 +417,7 @@ class IABookmarks extends LitElement {
 
   bookmarkSelected({ detail }) {
     const { leafNum } = detail.bookmark;
-    this.bookreader.jumpToPage(`${this.bookreader._models.book.getPageNum(`${leafNum}`.replace(/\D/g, ''))}`);
+    this.bookreader.jumpToPage(`${this.bookreader.book.getPageNum(`${leafNum}`.replace(/\D/g, ''))}`);
     this.activeBookmarkID = leafNum;
   }
 

--- a/src/BookNavigator/bookmarks/ia-bookmarks.js
+++ b/src/BookNavigator/bookmarks/ia-bookmarks.js
@@ -213,8 +213,8 @@ class IABookmarks extends LitElement {
       color: this.getBookmarkColor(color) ? color : this.defaultColor.id,
     };
 
-    const page = IABookmarks.formatPage(this.bookreader.getPageNum(leafNum));
-    const thumbnail = this.bookreader.getPageURI(`${leafNum}`.replace(/\D/g, ''), 32); // Request thumbnail 1/32 the size of original image
+    const page = IABookmarks.formatPage(this.bookreader._models.book.getPageNum(leafNum));
+    const thumbnail = this.bookreader._models.book.getPageURI(`${leafNum}`.replace(/\D/g, ''), 32); // Request thumbnail 1/32 the size of original image
     const bookmark = {
       ...nomalizedParams,
       id: leafNum,
@@ -417,7 +417,7 @@ class IABookmarks extends LitElement {
 
   bookmarkSelected({ detail }) {
     const { leafNum } = detail.bookmark;
-    this.bookreader.jumpToPage(`${this.bookreader.getPageNum(`${leafNum}`.replace(/\D/g, ''))}`);
+    this.bookreader.jumpToPage(`${this.bookreader._models.book.getPageNum(`${leafNum}`.replace(/\D/g, ''))}`);
     this.activeBookmarkID = leafNum;
   }
 

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -37,12 +37,7 @@ import { DEFAULT_OPTIONS } from './BookReader/options.js';
 /** @typedef {import('./BookReader/BookModel.js').PageIndex} PageIndex */
 import { EVENTS } from './BookReader/events.js';
 import { DebugConsole } from './BookReader/DebugConsole.js';
-import {
-  Toolbar,
-  blankInfoDiv,
-  blankShareDiv,
-  createPopup,
-} from './BookReader/Toolbar/Toolbar.js';
+import { Toolbar } from './BookReader/Toolbar/Toolbar.js';
 import { BookModel } from './BookReader/BookModel.js';
 import { Mode1Up } from './BookReader/Mode1Up.js';
 import { Mode2Up } from './BookReader/Mode2Up.js';
@@ -157,12 +152,7 @@ BookReader.prototype.setup = function(options) {
   this.thumbMaxLoading = options.thumbMaxLoading;
   this.thumbPadding = options.thumbPadding;
   this.displayedRows = [];
-
   this.displayedIndices = [];
-  /** @deprecated Unused; will be remove in v5 */
-  this.imgs = {};
-  /** @deprecated No longer used; will be remove in v5 */
-  this.prefetchedImgs = {}; //an object with numeric keys corresponding to page index, reduce
 
   this.animating = false;
   this.flipSpeed = options.flipSpeed;
@@ -1395,20 +1385,6 @@ BookReader.prototype._scrollAmount = function() {
 };
 
 /**
- * @deprecated No longer used; will be remove in v5
- */
-BookReader.prototype.prefetchImg = async function(index, fetchNow = false) {
-  console.warn('Call to deprecated function: BookReader.prefetchImg. No-op.');
-};
-
-/**
- * @deprecated No longer used; will be remove in v5
- */
-BookReader.prototype.pruneUnusedImgs = function() {
-  console.warn('Call to deprecated function: BookReader.pruneUnused. No-op.');
-};
-
-/**
  * Immediately stop flip animations.  Callbacks are triggered.
  */
 BookReader.prototype.stopFlipAnimations = function() {
@@ -1470,15 +1446,6 @@ BookReader.prototype.buildInfoDiv = Toolbar.prototype.buildInfoDiv;
 exposeOverrideableMethod(Toolbar, '_components.toolbar', 'buildInfoDiv');
 BookReader.prototype.getToolBarHeight = Toolbar.prototype.getToolBarHeight;
 exposeOverrideableMethod(Toolbar, '_components.toolbar', 'getToolBarHeight');
-/** @deprecated zoom no longer in toolbar */
-BookReader.prototype.updateToolbarZoom = Toolbar.prototype.updateToolbarZoom;
-exposeOverrideableMethod(Toolbar, '_components.toolbar', 'updateToolbarZoom');
-/** @deprecated unused */
-BookReader.prototype.blankInfoDiv = blankInfoDiv;
-/** @deprecated unused */
-BookReader.prototype.blankShareDiv = blankShareDiv;
-/** @deprecated unused */
-BookReader.prototype.createPopup = createPopup;
 
 /**
  * Bind navigation handlers
@@ -2021,31 +1988,6 @@ BookReader.prototype.canSwitchToMode = function(mode) {
   return true;
 };
 
-
-/**
- * @deprecated. Use PageModel.getURISrcSet. Slated for removal in v5.
- * Returns the srcset with correct URIs or void string if out of range
- * Also makes the reduce argument optional
- * @param {number} index
- * @param {number} [reduce]
- * @param {number} [rotate]
- * @return {string}
- */
-BookReader.prototype._getPageURISrcset = function(index, reduce, rotate) {
-  const page = this._models.book.getPage(index, false);
-  // Synthesize page
-  if (!page) return "";
-
-  // reduce not passed in
-  // $$$ this probably won't work for thumbnail mode
-  if ('undefined' == typeof(reduce)) {
-    reduce = page.height / this.twoPage.height;
-  }
-
-  return page.getURISrcSet(reduce, rotate);
-};
-
-
 /**
  * Returns the page URI or transparent image if out of range
  * Also makes the reduce argument optional
@@ -2384,13 +2326,6 @@ BookReader.prototype.queryStringFromParams = function(
  */
 BookReader.prototype.$ = function(selector) {
   return this.refs.$br.find(selector);
-};
-
-/**
- * Polyfill for deprecated method
- */
-jQuery.curCSS = function(element, prop, val) {
-  return jQuery(element).css(prop, val);
 };
 
 window.BookReader = BookReader;

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -30,7 +30,7 @@ import 'jquery-ui-touch-punch';
 import PACKAGE_JSON from '../package.json';
 import * as utils from './BookReader/utils.js';
 import { exposeOverrideable } from './BookReader/utils/classes.js';
-import { Navbar, getNavPageNumHtml } from './BookReader/Navbar/Navbar.js';
+import { Navbar } from './BookReader/Navbar/Navbar.js';
 import { DEFAULT_OPTIONS } from './BookReader/options.js';
 /** @typedef {import('./BookReader/options.js').BookReaderOptions} BookReaderOptions */
 /** @typedef {import('./BookReader/options.js').ReductionFactor} ReductionFactor */
@@ -537,7 +537,7 @@ BookReader.prototype.init = function() {
   }
 
   // Switch navbar controls on mobile/desktop
-  this.switchNavbarControls();
+  this._components.navbar.switchNavbarControls();
 
   this.resizeBRcontainer();
   this.updateFromParams(params);
@@ -621,7 +621,7 @@ BookReader.prototype.resize = function() {
   this.resizeBRcontainer();
 
   // Switch navbar controls on mobile/desktop
-  this.switchNavbarControls();
+  this._components.navbar.switchNavbarControls();
 
   if (this.constMode1up == this.mode) {
     if (this.onePage.autofit != 'none') {
@@ -1262,7 +1262,7 @@ BookReader.prototype.updateFirstIndex = function(
     this.suppressFragmentChange = false;
   }
   this.trigger('pageChanged');
-  this.updateNavIndexThrottled(index);
+  this._components.navbar.updateNavIndexThrottled(index);
 };
 
 /**
@@ -1453,27 +1453,9 @@ function exposeOverrideableMethod(Class, classKey, method, brMethod = method) {
 /***********************/
 /** Navbar extensions **/
 /***********************/
+/** This cannot be removed yet because plugin.tts.js overrides it */
 BookReader.prototype.initNavbar = Navbar.prototype.init;
 exposeOverrideableMethod(Navbar, '_components.navbar', 'init', 'initNavbar');
-BookReader.prototype.switchNavbarControls = Navbar.prototype.switchNavbarControls;
-exposeOverrideableMethod(Navbar, '_components.navbar', 'switchNavbarControls');
-BookReader.prototype.updateViewModeButton = Navbar.prototype.updateViewModeButton;
-exposeOverrideableMethod(Navbar, '_components.navbar', 'updateViewModeButton');
-BookReader.prototype.getNavPageNumString = Navbar.prototype.getNavPageNumString;
-exposeOverrideableMethod(Navbar, '_components.navbar', 'getNavPageNumString');
-/** @deprecated unused */
-BookReader.prototype.getNavPageNumHtml = getNavPageNumHtml;
-/** @deprecated unused outside this file */
-BookReader.prototype.updateNavPageNum = Navbar.prototype.updateNavPageNum;
-exposeOverrideableMethod(Navbar, '_components.navbar', 'updateNavPageNum');
-/** @deprecated unused outside this file */
-BookReader.prototype.updateNavIndex = Navbar.prototype.updateNavIndex;
-exposeOverrideableMethod(Navbar, '_components.navbar', 'updateNavIndex');
-/** @deprecated unused outside this file */
-BookReader.prototype.updateNavIndexThrottled = utils.throttle(BookReader.prototype.updateNavIndex, 250, false);
-/** @deprecated unused */
-BookReader.prototype.updateNavIndexDebounced = utils.debounce(BookReader.prototype.updateNavIndex, 500, false);
-
 
 /************************/
 /** Toolbar extensions **/

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -211,15 +211,6 @@ BookReader.prototype.setup = function(options) {
 
   // Assign the data methods
   this.data = options.data;
-  if (options.getNumLeafs) BookReader.prototype.getNumLeafs = options.getNumLeafs;
-  if (options.getPageWidth) BookReader.prototype.getPageWidth = options.getPageWidth;
-  if (options.getPageHeight) BookReader.prototype.getPageHeight = options.getPageHeight;
-  if (options.getPageURI) BookReader.prototype.getPageURI = options.getPageURI;
-  if (options.getPageSide) BookReader.prototype.getPageSide = options.getPageSide;
-  if (options.getPageNum) BookReader.prototype.getPageNum = options.getPageNum;
-  if (options.getPageProp) BookReader.prototype.getPageProp = options.getPageProp;
-  if (options.getSpreadIndices) BookReader.prototype.getSpreadIndices = options.getSpreadIndices;
-  if (options.leafNumToIndex) BookReader.prototype.leafNumToIndex = options.leafNumToIndex;
 
   /** @type {{[name: string]: JQuery}} */
   this.refs = {};
@@ -231,6 +222,15 @@ BookReader.prototype.setup = function(options) {
   this._models = {
     book: new BookModel(this),
   };
+  if (options.getNumLeafs) this._models.book.getNumLeafs = options.getNumLeafs.bind(this);
+  if (options.getPageWidth) this._models.book.getPageWidth = options.getPageWidth.bind(this);
+  if (options.getPageHeight) this._models.book.getPageHeight = options.getPageHeight.bind(this);
+  if (options.getPageURI) this._models.book.getPageURI = options.getPageURI.bind(this);
+  if (options.getPageSide) this._models.book.getPageSide = options.getPageSide.bind(this);
+  if (options.getPageNum) this._models.book.getPageNum = options.getPageNum.bind(this);
+  if (options.getPageProp) this._models.book.getPageProp = options.getPageProp.bind(this);
+  if (options.getSpreadIndices) this._models.book.getSpreadIndices = options.getSpreadIndices.bind(this);
+  if (options.leafNumToIndex) this._models.book.leafNumToIndex = options.leafNumToIndex.bind(this);
 
   /**
    * @private Components are 'subchunks' of bookreader functionality, usually UI related
@@ -1944,46 +1944,11 @@ BookReader.prototype.lastDisplayableIndex = function() {
 /**************************/
 /** BookModel extensions **/
 /**************************/
-/** @deprecated not used outside */
-BookReader.prototype.getMedianPageSize = BookModel.prototype.getMedianPageSize;
-exposeOverrideableMethod(BookModel, '_models.book', 'getMedianPageSize');
-BookReader.prototype._getPageWidth = BookModel.prototype._getPageWidth;
-exposeOverrideableMethod(BookModel, '_models.book', '_getPageWidth');
-BookReader.prototype._getPageHeight = BookModel.prototype._getPageHeight;
-exposeOverrideableMethod(BookModel, '_models.book', '_getPageHeight');
-BookReader.prototype.getPageIndex = BookModel.prototype.getPageIndex;
-exposeOverrideableMethod(BookModel, '_models.book', 'getPageIndex');
-/** @deprecated not used outside */
-BookReader.prototype.getPageIndices = BookModel.prototype.getPageIndices;
-exposeOverrideableMethod(BookModel, '_models.book', 'getPageIndices');
-BookReader.prototype.getPageName = BookModel.prototype.getPageName;
-exposeOverrideableMethod(BookModel, '_models.book', 'getPageName');
-BookReader.prototype.getNumLeafs = BookModel.prototype.getNumLeafs;
-exposeOverrideableMethod(BookModel, '_models.book', 'getNumLeafs');
-BookReader.prototype.getPageWidth = BookModel.prototype.getPageWidth;
-exposeOverrideableMethod(BookModel, '_models.book', 'getPageWidth');
-BookReader.prototype.getPageHeight = BookModel.prototype.getPageHeight;
-exposeOverrideableMethod(BookModel, '_models.book', 'getPageHeight');
+// Must modify petabox extension, which expects this on the prototype
+// before removing.
 BookReader.prototype.getPageURI = BookModel.prototype.getPageURI;
 exposeOverrideableMethod(BookModel, '_models.book', 'getPageURI');
-BookReader.prototype.getPageSide = BookModel.prototype.getPageSide;
-exposeOverrideableMethod(BookModel, '_models.book', 'getPageSide');
-BookReader.prototype.getPageNum = BookModel.prototype.getPageNum;
-exposeOverrideableMethod(BookModel, '_models.book', 'getPageNum');
-BookReader.prototype.getPageProp = BookModel.prototype.getPageProp;
-exposeOverrideableMethod(BookModel, '_models.book', 'getPageProp');
-BookReader.prototype.getSpreadIndices = BookModel.prototype.getSpreadIndices;
-exposeOverrideableMethod(BookModel, '_models.book', 'getSpreadIndices');
-BookReader.prototype.leafNumToIndex = BookModel.prototype.leafNumToIndex;
-exposeOverrideableMethod(BookModel, '_models.book', 'leafNumToIndex');
-BookReader.prototype.parsePageString = BookModel.prototype.parsePageString;
-exposeOverrideableMethod(BookModel, '_models.book', 'parsePageString');
-/** @deprecated unused */
-BookReader.prototype._getDataFlattened = BookModel.prototype._getDataFlattened;
-exposeOverrideableMethod(BookModel, '_models.book', '_getDataFlattened');
-/** @deprecated unused */
-BookReader.prototype._getDataProp = BookModel.prototype._getDataProp;
-exposeOverrideableMethod(BookModel, '_models.book', '_getDataProp');
+
 
 // Parameter related functions
 

--- a/src/BookReader/BookModel.js
+++ b/src/BookReader/BookModel.js
@@ -26,37 +26,8 @@ export class BookModel {
 
     /** @type {{width: number, height: number}} memoize storage */
     this._medianPageSize = null;
-    /** @deprecated @type {{width: number, height: number}} memoize storage */
-    this._medianPageSizePixels = null;
     /** @type {[PageData[], number]} */
     this._getDataFlattenedCached = null;
-  }
-
-  /**
-   * @deprecated Use getMedianPageSizeInches
-   * Memoized
-   * @return {{width: number, height: number}}
-   */
-  getMedianPageSize() {
-    if (this._medianPageSizePixels) {
-      return this._medianPageSizePixels;
-    }
-
-    // A little expensive but we just do it once
-    const widths = [];
-    const heights = [];
-    for (let i = 0; i < this.getNumLeafs(); i++) {
-      widths.push(this.getPageWidth(i));
-      heights.push(this.getPageHeight(i));
-    }
-
-    widths.sort();
-    heights.sort();
-    this._medianPageSizePixels = {
-      width: widths[Math.floor(widths.length / 2)],
-      height: heights[Math.floor(heights.length / 2)]
-    };
-    return this._medianPageSizePixels;
   }
 
   /** Get median width/height of page in inches. Memoized for performance. */

--- a/src/BookReader/Mode1UpLit.js
+++ b/src/BookReader/Mode1UpLit.js
@@ -205,7 +205,7 @@ export class Mode1UpLit extends LitElement {
       this.throttledUpdateRenderedPages();
       this.br.displayedIndices = this.visiblePages.map(p => p.index);
       this.br.updateFirstIndex(this.br.displayedIndices[0]);
-      this.br.updateNavIndexThrottled();
+      this.br._components.navbar.updateNavIndexThrottled();
     }
     if (changedProps.has('scale')) {
       const oldVal = changedProps.get('scale');

--- a/src/BookReader/Mode2Up.js
+++ b/src/BookReader/Mode2Up.js
@@ -90,7 +90,6 @@ export class Mode2Up {
 
     this.displayedIndices = [this.br.twoPage.currentIndexL, this.br.twoPage.currentIndexR];
     this.br.displayedIndices = this.displayedIndices;
-    this.br.updateToolbarZoom(this.br.reduce);
     this.br.trigger('pageChanged');
   }
 
@@ -241,7 +240,6 @@ export class Mode2Up {
     this.br.displayedIndices = [];
 
     this.drawLeafs();
-    this.br.updateToolbarZoom(this.br.reduce);
     this.br.updateBrClasses();
 
     this.smoothZoomer = this.smoothZoomer || new ModeSmoothZoom(this);
@@ -561,7 +559,7 @@ export class Mode2Up {
       if (prev.pageSide == 'R') index--;
     }
 
-    this.br.updateNavIndexThrottled(index);
+    this.br._components.navbar.updateNavIndexThrottled(index);
 
     const previousIndices = this.book.getSpreadIndices(index);
 
@@ -759,7 +757,7 @@ export class Mode2Up {
     }
     if (index > this.br.lastDisplayableIndex()) return;
 
-    this.br.updateNavIndexThrottled(index);
+    this.br._components.navbar.updateNavIndexThrottled(index);
 
     this.br.animating = true;
 

--- a/src/BookReader/Mode2Up.js
+++ b/src/BookReader/Mode2Up.js
@@ -118,7 +118,7 @@ export class Mode2Up {
 
     // Prepare view with new center to minimize visual glitches
     const drawNewSpread = true;
-    this.prepareTwoPageView(oldCenter.percentageX, oldCenter.percentageY, drawNewSpread);
+    this.prepare(oldCenter.percentageX, oldCenter.percentageY, drawNewSpread);
   }
 
   /**
@@ -150,7 +150,7 @@ export class Mode2Up {
    * @param {number} centerPercentageY
    * @param {Boolean} drawNewSpread
    */
-  prepareTwoPageView(centerPercentageX, centerPercentageY, drawNewSpread = false) {
+  prepare(centerPercentageX, centerPercentageY, drawNewSpread = false) {
     // Some decisions about two page view:
     //
     // Both pages will be displayed at the same height, even if they were different physical/scanned
@@ -391,7 +391,7 @@ export class Mode2Up {
 
     // Leaf edges
     this.br.twoPage.edgeWidth = spreadSize.totalLeafEdgeWidth; // The combined width of both edges
-    this.br.twoPage.leafEdgeWidthL = this.br.leafEdgeWidth(this.br.twoPage.currentIndexL);
+    this.br.twoPage.leafEdgeWidthL = this.leafEdgeWidth(this.br.twoPage.currentIndexL);
     this.br.twoPage.leafEdgeWidthR = this.br.twoPage.edgeWidth - this.br.twoPage.leafEdgeWidthL;
 
 
@@ -528,21 +528,6 @@ export class Mode2Up {
     return spreadSize.reduce;
   }
 
-  /**
-   * Returns true if the pages extend past the edge of the view
-   * @deprecated slated for deprecation by v5.0.0
-   * @return {boolean}
-   */
-  isZoomedIn() {
-    let isZoomedIn = false;
-    if (this.br.twoPage.autofit != 'auto') {
-      if (this.br.reduce < this.getAutofitReduce()) {
-        isZoomedIn = true;
-      }
-    }
-    return isZoomedIn;
-  }
-
   calculateReductionFactors() {
     this.br.twoPage.reductionFactors = this.br.reductionFactors.concat([
       {
@@ -551,14 +536,6 @@ export class Mode2Up {
       }
     ]);
     this.br.twoPage.reductionFactors.sort(this.br._reduceSort);
-  }
-
-  /**
-   * Set the cursor for two page view
-   * @deprecated Since version 4.3.3. Will be deleted in version 5.0
-   */
-  setCursor() {
-    console.warn('Call to deprecated method, Mode2Up.setCursor. No-op.');
   }
 
   /**
@@ -614,8 +591,8 @@ export class Mode2Up {
     this.br.refs.$brContainer.addClass("BRpageFlipping");
     const leftLeaf = this.br.twoPage.currentIndexL;
 
-    const oldLeafEdgeWidthL = this.br.leafEdgeWidth(this.br.twoPage.currentIndexL);
-    const newLeafEdgeWidthL = this.br.leafEdgeWidth(newIndexL);
+    const oldLeafEdgeWidthL = this.leafEdgeWidth(this.br.twoPage.currentIndexL);
+    const newLeafEdgeWidthL = this.leafEdgeWidth(newIndexL);
     const leafEdgeTmpW = oldLeafEdgeWidthL - newLeafEdgeWidthL;
 
     const currWidthL   = this.getPageWidth(leftLeaf);
@@ -808,9 +785,9 @@ export class Mode2Up {
   flipRightToLeft(newIndexL, newIndexR) {
     this.br.refs.$brContainer.addClass("BRpageFlipping");
 
-    const oldLeafEdgeWidthL = this.br.leafEdgeWidth(this.br.twoPage.currentIndexL);
+    const oldLeafEdgeWidthL = this.leafEdgeWidth(this.br.twoPage.currentIndexL);
     const oldLeafEdgeWidthR = this.br.twoPage.edgeWidth - oldLeafEdgeWidthL;
-    const newLeafEdgeWidthL = this.br.leafEdgeWidth(newIndexL);
+    const newLeafEdgeWidthL = this.leafEdgeWidth(newIndexL);
     const newLeafEdgeWidthR = this.br.twoPage.edgeWidth - newLeafEdgeWidthL;
 
     const leafEdgeTmpW = oldLeafEdgeWidthR - newLeafEdgeWidthR;

--- a/src/BookReader/ModeThumb.js
+++ b/src/BookReader/ModeThumb.js
@@ -177,7 +177,7 @@ export class ModeThumb {
             // shift viewModeOrder after clicking on thumbsnail leaf
             const nextModeID = this.br.viewModeOrder.shift();
             this.br.viewModeOrder.push(nextModeID);
-            this.br.updateViewModeButton($('.viewmode'), 'twopg', 'Two-page view');
+            this.br._components.navbar.updateViewModeButton($('.viewmode'), 'twopg', 'Two-page view');
 
             this.br.trigger(EVENTS.fragmentChange);
             event.stopPropagation();
@@ -215,8 +215,6 @@ export class ModeThumb {
 
     // highlight current page
     this.br.$('.pagediv' + this.br.currentIndex()).addClass('BRpagedivthumb_highlight');
-
-    this.br.updateToolbarZoom(this.br.reduce);
   }
 
   /**

--- a/src/BookReader/Navbar/Navbar.js
+++ b/src/BookReader/Navbar/Navbar.js
@@ -4,6 +4,7 @@ import 'jquery-ui/ui/widget.js';
 import 'jquery-ui/ui/widgets/mouse.js';
 import 'jquery-ui/ui/widgets/slider.js';
 import { EVENTS } from '../events.js';
+import { throttle } from '../utils.js';
 
 export class Navbar {
   /**
@@ -27,6 +28,8 @@ export class Navbar {
     this.maximumControls = [
       'book_left', 'book_right', 'zoom_in', 'zoom_out', 'onepg', 'twopg', 'thumb'
     ];
+
+    this.updateNavIndexThrottled = throttle(this.updateNavIndex.bind(this), 250, false);
   }
 
   controlFor(controlName) {
@@ -213,7 +216,7 @@ export class Navbar {
     const $slider = this.$root.find('.BRpager').slider({
       animate: true,
       min: 0,
-      max: br.getNumLeafs() - 1,
+      max: br._models.book.getNumLeafs() - 1,
       value: br.currentIndex(),
       range: "min"
     });
@@ -248,16 +251,16 @@ export class Navbar {
   getNavPageNumString(index) {
     const { br } = this;
     // Accessible index starts at 0 (alas) so we add 1 to make human
-    const pageNum = br.getPageNum(index);
-    const pageType = br.getPageProp(index, 'pageType');
-    const numLeafs = br.getNumLeafs();
+    const pageNum = br._models.book.getPageNum(index);
+    const pageType = br._models.book.getPageProp(index, 'pageType');
+    const numLeafs = br._models.book.getNumLeafs();
 
     if (!this.maxPageNum) {
       // Calculate Max page num (used for pagination display)
       let maxPageNum = 0;
       let pageNumVal;
       for (let i = 0; i < numLeafs; i++) {
-        pageNumVal = br.getPageNum(i);
+        pageNumVal = br._models.book.getPageNum(i);
         if (!isNaN(pageNumVal) && pageNumVal > maxPageNum) {
           maxPageNum = pageNumVal;
         }

--- a/src/BookReader/Navbar/Navbar.js
+++ b/src/BookReader/Navbar/Navbar.js
@@ -216,7 +216,7 @@ export class Navbar {
     const $slider = this.$root.find('.BRpager').slider({
       animate: true,
       min: 0,
-      max: br._models.book.getNumLeafs() - 1,
+      max: br.book.getNumLeafs() - 1,
       value: br.currentIndex(),
       range: "min"
     });
@@ -251,16 +251,16 @@ export class Navbar {
   getNavPageNumString(index) {
     const { br } = this;
     // Accessible index starts at 0 (alas) so we add 1 to make human
-    const pageNum = br._models.book.getPageNum(index);
-    const pageType = br._models.book.getPageProp(index, 'pageType');
-    const numLeafs = br._models.book.getNumLeafs();
+    const pageNum = br.book.getPageNum(index);
+    const pageType = br.book.getPageProp(index, 'pageType');
+    const numLeafs = br.book.getNumLeafs();
 
     if (!this.maxPageNum) {
       // Calculate Max page num (used for pagination display)
       let maxPageNum = 0;
       let pageNumVal;
       for (let i = 0; i < numLeafs; i++) {
-        pageNumVal = br._models.book.getPageNum(i);
+        pageNumVal = br.book.getPageNum(i);
         if (!isNaN(pageNumVal) && pageNumVal > maxPageNum) {
           maxPageNum = pageNumVal;
         }

--- a/src/BookReader/Toolbar/Toolbar.js
+++ b/src/BookReader/Toolbar/Toolbar.js
@@ -189,7 +189,7 @@ export class Toolbar {
       const params = {};
       params.mode = $(form.find('.fieldset-embed input[name=pages]:checked')).val();
       if (form.find('.fieldset-embed input[name=thispage]').prop('checked')) {
-        params.page = br._models.book.getPageNum(br.currentIndex());
+        params.page = br.book.getPageNum(br.currentIndex());
       }
 
       if (br.getEmbedCode) {

--- a/src/BookReader/Toolbar/Toolbar.js
+++ b/src/BookReader/Toolbar/Toolbar.js
@@ -75,8 +75,6 @@ export class Toolbar {
     br.$('.BRnavCntl').addClass('BRup');
     br.$('.pause').hide();
 
-    this.updateToolbarZoom(br.reduce); // Pretty format
-
     // We build in mode 2
     br.refs.$BRtoolbar.append();
 
@@ -125,31 +123,6 @@ export class Toolbar {
         br.trigger(EVENTS.stop);
       }
     });
-  }
-
-  /**
-   * @deprecated
-   * @todo .BRzoom doesn't exist anywhere, so this is likely dead code
-   * Update the displayed zoom factor based on reduction factor
-   * @param {number} reduce
-   */
-  updateToolbarZoom(reduce) {
-    const { br } = this;
-    // $$$ TODO preserve zoom/fit for each mode
-    const autofit = br.mode == br.constMode2up ? br.twoPage.autofit : br.onePage.autofit;
-    /** @type {string} */
-    let value;
-    if (autofit) {
-      value = autofit.slice(0,1).toUpperCase() + autofit.slice(1);
-    } else {
-      value = (100 / reduce)
-        .toFixed(2)
-        // Strip trailing zeroes and decimal if all zeroes
-        .replace(/0+$/,'')
-        .replace(/\.$/,'')
-        + '%';
-    }
-    br.$('.BRzoom').text(value);
   }
 
   /**
@@ -216,7 +189,7 @@ export class Toolbar {
       const params = {};
       params.mode = $(form.find('.fieldset-embed input[name=pages]:checked')).val();
       if (form.find('.fieldset-embed input[name=thispage]').prop('checked')) {
-        params.page = br.getPageNum(br.currentIndex());
+        params.page = br._models.book.getPageNum(br.currentIndex());
       }
 
       if (br.getEmbedCode) {
@@ -331,7 +304,7 @@ export class Toolbar {
   }
 }
 
-export function blankInfoDiv() {
+function blankInfoDiv() {
   return $(`
     <div class="BRfloat BRinfo">
       <div class="BRfloatHead">About this book
@@ -351,7 +324,7 @@ export function blankInfoDiv() {
     </div>`);
 }
 
-export function blankShareDiv() {
+function blankShareDiv() {
   return $(`
     <div class="BRfloat BRshare">
       <div class="BRfloatHead">

--- a/src/plugins/plugin.autoplay.js
+++ b/src/plugins/plugin.autoplay.js
@@ -81,7 +81,7 @@ BookReader.prototype.autoToggle = function(overrides) {
   }
 
   // Change to autofit if book is too large
-  if (this.reduce < this.twoPageGetAutofitReduce()) {
+  if (this.reduce < this._modes.mode2Up.getAutofitReduce()) {
     this.zoom('auto');
   }
 
@@ -94,7 +94,7 @@ BookReader.prototype.autoToggle = function(overrides) {
       // don't flip immediately -- wait until timer fires
     } else {
       // flip immediately
-      this.flipFwdToIndex();
+      this.next({ triggerStop: false });
     }
 
     this.$('.play').hide();
@@ -103,9 +103,9 @@ BookReader.prototype.autoToggle = function(overrides) {
       if (this.animating) return;
 
       if (Math.max(this.twoPage.currentIndexL, this.twoPage.currentIndexR) >= this.lastDisplayableIndex()) {
-        this.flipBackToIndex(1); // $$$ really what we want?
+        this.prev({ triggerStop: false }); // $$$ really what we want?
       } else {
-        this.flipFwdToIndex();
+        this.next({ triggerStop: false });
       }
     }, this.flipDelay);
   } else {

--- a/src/plugins/plugin.chapters.js
+++ b/src/plugins/plugin.chapters.js
@@ -53,7 +53,7 @@ BookReader.prototype.init = (function(super_) {
  */
 BookReader.prototype.addChapter = function(chapterTitle, pageNumber, pageIndex) {
   const uiStringPage = 'Page'; // i18n
-  const percentThrough = BookReader.util.cssPercentage(pageIndex, this.getNumLeafs() - 1);
+  const percentThrough = BookReader.util.cssPercentage(pageIndex, this._models.book.getNumLeafs() - 1);
   const jumpToChapter = (event) => {
     this.jumpToIndex($(event.delegateTarget).data('pageIndex'));
     $('.current-chapter').removeClass('current-chapter');
@@ -151,7 +151,7 @@ BookReader.prototype.updateTOC = function(tocEntries) {
  * @param {TocEntry} tocEntryObject
  */
 BookReader.prototype.addChapterFromEntry = function(tocEntryObject) {
-  tocEntryObject.pageIndex = this.getPageIndex(tocEntryObject['pagenum']);
+  tocEntryObject.pageIndex = this._models.book.getPageIndex(tocEntryObject['pagenum']);
   //creates a string with non-void tocEntryObject.label and tocEntryObject.title
   const chapterStr = [tocEntryObject.label, tocEntryObject.title]
     .filter(x => x)

--- a/src/plugins/plugin.chapters.js
+++ b/src/plugins/plugin.chapters.js
@@ -53,7 +53,7 @@ BookReader.prototype.init = (function(super_) {
  */
 BookReader.prototype.addChapter = function(chapterTitle, pageNumber, pageIndex) {
   const uiStringPage = 'Page'; // i18n
-  const percentThrough = BookReader.util.cssPercentage(pageIndex, this._models.book.getNumLeafs() - 1);
+  const percentThrough = BookReader.util.cssPercentage(pageIndex, this.book.getNumLeafs() - 1);
   const jumpToChapter = (event) => {
     this.jumpToIndex($(event.delegateTarget).data('pageIndex'));
     $('.current-chapter').removeClass('current-chapter');
@@ -151,7 +151,7 @@ BookReader.prototype.updateTOC = function(tocEntries) {
  * @param {TocEntry} tocEntryObject
  */
 BookReader.prototype.addChapterFromEntry = function(tocEntryObject) {
-  tocEntryObject.pageIndex = this._models.book.getPageIndex(tocEntryObject['pagenum']);
+  tocEntryObject.pageIndex = this.book.getPageIndex(tocEntryObject['pagenum']);
   //creates a string with non-void tocEntryObject.label and tocEntryObject.title
   const chapterStr = [tocEntryObject.label, tocEntryObject.title]
     .filter(x => x)

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -297,7 +297,7 @@ export function marshallSearchResults(results, displayPageNumberFn) {
  * @param {boolean} options.goToFirstResult
  */
 BookReader.prototype.BRSearchCallback = function(results, options) {
-  marshallSearchResults(results, pageNum => this.getPageNum(this.leafNumToIndex(pageNum)));
+  marshallSearchResults(results, pageNum => this._models.book.getPageNum(this._models.book.leafNumToIndex(pageNum)));
   this.searchResults = results || [];
 
   this.updateSearchHilites();
@@ -357,7 +357,7 @@ BookReader.prototype.updateSearchHilites = function() {
   // Group by pageIndex
   for (const match of matches) {
     for (const box of match.par[0].boxes) {
-      const pageIndex = this.leafNumToIndex(box.page);
+      const pageIndex = this._models.book.leafNumToIndex(box.page);
       const pageBoxes = boxesByIndex[pageIndex] || (boxesByIndex[pageIndex] = []);
       pageBoxes.push(box);
     }
@@ -392,8 +392,8 @@ BookReader.prototype.removeSearchHilites = function() {
  */
 BookReader.prototype._searchPluginGoToResult = async function (matchIndex) {
   const match = this.searchResults?.matches[matchIndex];
-  const pageIndex = this.leafNumToIndex(match.par[0].page);
   const { book } = this._models;
+  const pageIndex = book.leafNumToIndex(match.par[0].page);
   const page = book.getPage(pageIndex);
   const onNearbyPage = Math.abs(this.currentIndex() - pageIndex) < 3;
   let makeUnviewableAtEnd = false;
@@ -478,7 +478,7 @@ BookReader.prototype.searchHighlightVisible = function() {
 
   results.matches.some(match => {
     return match.par[0].boxes.some(box => {
-      const pageIndex = this.leafNumToIndex(box.page);
+      const pageIndex = this._models.book.leafNumToIndex(box.page);
       if (jQuery.inArray(pageIndex, visiblePages) >= 0) {
         return true;
       }

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -297,7 +297,7 @@ export function marshallSearchResults(results, displayPageNumberFn) {
  * @param {boolean} options.goToFirstResult
  */
 BookReader.prototype.BRSearchCallback = function(results, options) {
-  marshallSearchResults(results, pageNum => this._models.book.getPageNum(this._models.book.leafNumToIndex(pageNum)));
+  marshallSearchResults(results, pageNum => this.book.getPageNum(this.book.leafNumToIndex(pageNum)));
   this.searchResults = results || [];
 
   this.updateSearchHilites();
@@ -357,7 +357,7 @@ BookReader.prototype.updateSearchHilites = function() {
   // Group by pageIndex
   for (const match of matches) {
     for (const box of match.par[0].boxes) {
-      const pageIndex = this._models.book.leafNumToIndex(box.page);
+      const pageIndex = this.book.leafNumToIndex(box.page);
       const pageBoxes = boxesByIndex[pageIndex] || (boxesByIndex[pageIndex] = []);
       pageBoxes.push(box);
     }
@@ -366,7 +366,7 @@ BookReader.prototype.updateSearchHilites = function() {
   // update any already created pages
   for (const [pageIndexString, boxes] of Object.entries(boxesByIndex)) {
     const pageIndex = parseFloat(pageIndexString);
-    const page = this._models.book.getPage(pageIndex);
+    const page = this.book.getPage(pageIndex);
     const pageContainers = this.getActivePageContainerElementsForIndex(pageIndex);
     for (const container of pageContainers) {
       renderBoxesInPageContainerLayer('searchHiliteLayer', boxes, page, container, boxes.map(b => `match-index-${b.matchIndex}`));
@@ -392,7 +392,7 @@ BookReader.prototype.removeSearchHilites = function() {
  */
 BookReader.prototype._searchPluginGoToResult = async function (matchIndex) {
   const match = this.searchResults?.matches[matchIndex];
-  const { book } = this._models;
+  const book = this.book;
   const pageIndex = book.leafNumToIndex(match.par[0].page);
   const page = book.getPage(pageIndex);
   const onNearbyPage = Math.abs(this.currentIndex() - pageIndex) < 3;
@@ -478,7 +478,7 @@ BookReader.prototype.searchHighlightVisible = function() {
 
   results.matches.some(match => {
     return match.par[0].boxes.some(box => {
-      const pageIndex = this._models.book.leafNumToIndex(box.page);
+      const pageIndex = this.book.leafNumToIndex(box.page);
       if (jQuery.inArray(pageIndex, visiblePages) >= 0) {
         return true;
       }

--- a/src/plugins/search/view.js
+++ b/src/plugins/search/view.js
@@ -231,10 +231,10 @@ class SearchView {
   renderPins(matches) {
     matches.forEach((match) => {
       const queryString = match.text;
-      const pageIndex = this.br.leafNumToIndex(match.par[0].page);
+      const pageIndex = this.br._models.book.leafNumToIndex(match.par[0].page);
       const uiStringSearch = "Search result"; // i18n
 
-      const percentThrough = this.br.constructor.util.cssPercentage(pageIndex, this.br.getNumLeafs() - 1);
+      const percentThrough = this.br.constructor.util.cssPercentage(pageIndex, this.br._models.book.getNumLeafs() - 1);
 
       const escapedQueryString = escapeHTML(queryString);
       const queryStringWithB = escapedQueryString.replace(this.matcher, '<b>$1</b>');

--- a/src/plugins/search/view.js
+++ b/src/plugins/search/view.js
@@ -231,10 +231,10 @@ class SearchView {
   renderPins(matches) {
     matches.forEach((match) => {
       const queryString = match.text;
-      const pageIndex = this.br._models.book.leafNumToIndex(match.par[0].page);
+      const pageIndex = this.br.book.leafNumToIndex(match.par[0].page);
       const uiStringSearch = "Search result"; // i18n
 
-      const percentThrough = this.br.constructor.util.cssPercentage(pageIndex, this.br._models.book.getNumLeafs() - 1);
+      const percentThrough = this.br.constructor.util.cssPercentage(pageIndex, this.br.book.getNumLeafs() - 1);
 
       const escapedQueryString = escapeHTML(queryString);
       const queryStringWithB = escapedQueryString.replace(this.matcher, '<b>$1</b>');

--- a/src/plugins/tts/plugin.tts.js
+++ b/src/plugins/tts/plugin.tts.js
@@ -224,7 +224,7 @@ BookReader.prototype.ttsStart = function (startTTSEngine = true) {
   this.$('.BRicon.read').addClass('unread active');
   this.ttsSendAnalyticsEvent('Start');
   if (startTTSEngine)
-    this.ttsEngine.start(this.currentIndex(), this.getNumLeafs());
+    this.ttsEngine.start(this.currentIndex(), this._models.book.getNumLeafs());
 };
 
 BookReader.prototype.ttsJumpForward = function () {

--- a/src/plugins/tts/plugin.tts.js
+++ b/src/plugins/tts/plugin.tts.js
@@ -224,7 +224,7 @@ BookReader.prototype.ttsStart = function (startTTSEngine = true) {
   this.$('.BRicon.read').addClass('unread active');
   this.ttsSendAnalyticsEvent('Start');
   if (startTTSEngine)
-    this.ttsEngine.start(this.currentIndex(), this._models.book.getNumLeafs());
+    this.ttsEngine.start(this.currentIndex(), this.book.getNumLeafs());
 };
 
 BookReader.prototype.ttsJumpForward = function () {
@@ -326,7 +326,7 @@ BookReader.prototype.ttsHighlightChunk = function(chunk) {
   // update any already created pages
   for (const [pageIndexString, boxes] of Object.entries(this._ttsBoxesByIndex)) {
     const pageIndex = parseFloat(pageIndexString);
-    const page = this._models.book.getPage(pageIndex);
+    const page = this.book.getPage(pageIndex);
     const pageContainers = this.getActivePageContainerElementsForIndex(pageIndex);
     pageContainers.forEach(container => renderBoxesInPageContainerLayer('ttsHiliteLayer', boxes, page, container));
   }

--- a/tests/jest/BookReader.test.js
+++ b/tests/jest/BookReader.test.js
@@ -157,41 +157,6 @@ test('does not add q= term to urlMode=hash query string', () => {
   )).toBe('?name=value');
 });
 
-test('_getPageURISrcset with 0 page book', () => {
-  br._models.book.getNumLeafs = jest.fn(() => 0);
-  br._models.book.getPageURI = jest.fn((index, scale, rotate) => "correctURL.png&scale=" + scale);
-  br.init();
-  expect(br._getPageURISrcset(5, undefined, undefined)).toBe("");
-});
-
-test('_getPageURISrcset with negative index', () => {
-  br._models.book.getNumLeafs = jest.fn(() => 0);
-  br._models.book.getPageURI = jest.fn((index, scale, rotate) => "correctURL.png&scale=" + scale);
-  br.init();
-  expect(br._getPageURISrcset(-7, undefined, undefined)).toBe("");
-});
-
-test('_getPageURISrcset with 0 elements in srcset', () => {
-  br._models.book.getNumLeafs = jest.fn(() => 30);
-  br._models.book.getPageURI = jest.fn((index, scale, rotate) => "correctURL.png&scale=" + scale);
-  br.init();
-  expect(br._getPageURISrcset(5, 1, undefined)).toBe("");
-});
-
-test('_getPageURISrcset with 2 elements in srcset', () => {
-  br._models.book.getNumLeafs = jest.fn(() => 30);
-  br._models.book.getPageURI = jest.fn((index, scale, rotate) => "correctURL.png&scale=" + scale);
-  br.init();
-  expect(br._getPageURISrcset(5, 5, undefined)).toBe("correctURL.png&scale=2 2x, correctURL.png&scale=1 4x");
-});
-
-test('_getPageURISrcset with the most elements in srcset', () => {
-  br._models.book.getNumLeafs = jest.fn(() => 30);
-  br._models.book.getPageURI = jest.fn((index, scale, rotate) => "correctURL.png&scale=" + scale);
-  br.init();
-  expect(br._getPageURISrcset(5, 35, undefined)).toBe("correctURL.png&scale=16 2x, correctURL.png&scale=8 4x, correctURL.png&scale=4 8x, correctURL.png&scale=2 16x, correctURL.png&scale=1 32x");
-});
-
 describe('Navigation Bars', () => {
   test('Standard navigation is being used by default', () => {
     br.initNavbar = jest.fn();

--- a/tests/jest/BookReader/BookReaderPublicFunctions.test.js
+++ b/tests/jest/BookReader/BookReaderPublicFunctions.test.js
@@ -140,14 +140,14 @@ describe('`BookReader.prototype.prev`', () => {
   const br = new BookReader();
   global.br = br;
   br.trigger = sinon.fake();
-  br.flipBackToIndex = sinon.fake();
+  br._modes.mode2Up.flipBackToIndex = sinon.fake();
   br.jumpToIndex = sinon.fake();
 
   test('does not take action if user is on front page', () => {
     br.firstIndex = 0;
     br.prev();
     expect(br.trigger.callCount).toBe(0);
-    expect(br.flipBackToIndex.callCount).toBe(0);
+    expect(br._modes.mode2Up.flipBackToIndex.callCount).toBe(0);
     expect(br.jumpToIndex.callCount).toBe(0);
   });
 
@@ -158,7 +158,7 @@ describe('`BookReader.prototype.prev`', () => {
       br.prev();
       expect(br.jumpToIndex.callCount).toBe(0); // <--  does not get called
       expect(br.trigger.callCount).toBe(1);
-      expect(br.flipBackToIndex.callCount).toBe(1);
+      expect(br._modes.mode2Up.flipBackToIndex.callCount).toBe(1);
     });
   });
 
@@ -169,7 +169,7 @@ describe('`BookReader.prototype.prev`', () => {
       br.prev();
       expect(br.jumpToIndex.callCount).toBe(1);  // <--  gets called
       expect(br.trigger.callCount).toBe(1); // <-- gets called by `jumpToIndex` internally
-      expect(br.flipBackToIndex.callCount).toBe(1); // <-- gets called by `jumpToIndex` internally
+      expect(br._modes.mode2Up.flipBackToIndex.callCount).toBe(1); // <-- gets called by `jumpToIndex` internally
     });
   });
 });

--- a/tests/jest/BookReader/Mode1UpLit.test.js
+++ b/tests/jest/BookReader/Mode1UpLit.test.js
@@ -22,7 +22,11 @@ const SAMPLE_DATA = [
 function make_dummy_br(overrides = {}) {
   return Object.assign({
     updateFirstIndex() {},
-    updateNavIndexThrottled() {},
+    _components: {
+      navbar: {
+        updateNavIndexThrottled() {},
+      }
+    },
     data: []
   }, overrides);
 }

--- a/tests/jest/BookReader/Mode2Up.test.js
+++ b/tests/jest/BookReader/Mode2Up.test.js
@@ -145,13 +145,13 @@ describe('2up Container sizing', () => {
   test('baseLeafCss', () => {
     const br = new BookReader({ data: SAMPLE_DATA });
     br.init();
-    br.calculateSpreadSize();
+    br._modes.mode2Up.calculateSpreadSize();
     expect(Object.keys(br._modes.mode2Up.baseLeafCss)).toEqual(['position', 'right', 'top', 'zIndex']);
   });
   test('heightCss', () => {
     const br = new BookReader({ data: SAMPLE_DATA });
     br.init();
-    br.calculateSpreadSize();
+    br._modes.mode2Up.calculateSpreadSize();
     const heightStub = 1000;
     br.twoPage.height = heightStub;
     expect(Object.keys(br._modes.mode2Up.heightCss)).toEqual(['height']);
@@ -160,7 +160,7 @@ describe('2up Container sizing', () => {
   describe('left side', () => {
     const br = new BookReader({ data: SAMPLE_DATA });
     br.init();
-    br.calculateSpreadSize();
+    br._modes.mode2Up.calculateSpreadSize();
 
     test('leftLeafCss', () => {
       expect(Object.keys(br._modes.mode2Up.leftLeafCss)).toEqual([
@@ -186,7 +186,7 @@ describe('2up Container sizing', () => {
   describe('right side', () => {
     const br = new BookReader({ data: SAMPLE_DATA });
     br.init();
-    br.calculateSpreadSize();
+    br._modes.mode2Up.calculateSpreadSize();
 
     test('rightLeafCss', () => {
       expect(Object.keys(br._modes.mode2Up.rightLeafCss)).toEqual([
@@ -213,20 +213,20 @@ describe('2up Container sizing', () => {
     test('mainContainerCss', () => {
       const br = new BookReader({ data: SAMPLE_DATA });
       br.init();
-      br.calculateSpreadSize();
+      br._modes.mode2Up.calculateSpreadSize();
 
       expect(Object.keys(br._modes.mode2Up.mainContainerCss)).toEqual(['height', 'width', 'position']);
     });
     test('spreadCoverCss', () => {
       const br = new BookReader({ data: SAMPLE_DATA });
       br.init();
-      br.calculateSpreadSize();
+      br._modes.mode2Up.calculateSpreadSize();
       expect(Object.keys(br._modes.mode2Up.spreadCoverCss)).toEqual(['width', 'height', 'visibility']);
     });
     test('spineCss', () => {
       const br = new BookReader({ data: SAMPLE_DATA });
       br.init();
-      br.calculateSpreadSize();
+      br._modes.mode2Up.calculateSpreadSize();
       expect(Object.keys(br._modes.mode2Up.spineCss)).toEqual(['width', 'height', 'left', 'top']);
     });
   });
@@ -247,7 +247,7 @@ describe('prepareTwoPageView', () => {
       const preparePopUp = sinon.spy(mode2Up, 'preparePopUp');
       const updateBrClasses = sinon.spy(br, 'updateBrClasses');
 
-      br.prepareTwoPageView(undefined, undefined, true);
+      mode2Up.prepare(undefined, undefined, true);
       expect(prefetch.callCount).toBe(1);
 
       expect(resizeSpread.callCount).toBe(0);

--- a/tests/jest/plugins/plugin.autoplay.test.js
+++ b/tests/jest/plugins/plugin.autoplay.test.js
@@ -38,12 +38,12 @@ describe('Plugin: Menu Toggle', () => {
   });
   test('autoplay will run without `flipSpeed` parameters', () => {
     const initialAutoTimer = br.autoTimer;
-    br.flipFwdToIndex = jest.fn();
+    br.next = jest.fn();
     br.autoStop = jest.fn();
     br.init();
     br.autoToggle();
     // internally referenced functions that fire
-    expect(br.flipFwdToIndex).toHaveBeenCalledTimes(1);
+    expect(br.next).toHaveBeenCalledTimes(1);
 
     expect(initialAutoTimer).toBeFalsy();
     // br.autoTimer changes when autoToggle turns on

--- a/tests/jest/plugins/plugin.chapters.test.js
+++ b/tests/jest/plugins/plugin.chapters.test.js
@@ -98,7 +98,7 @@ describe('updateTOCState', () => {
 
   beforeEach(() => {
     window.HTMLElement.prototype.scrollIntoView = sinon.stub();
-    br._models.book.getPageIndex = (str) => parseFloat(str);
+    br.book.getPageIndex = (str) => parseFloat(str);
     br.init();
   });
 

--- a/tests/jest/plugins/plugin.chapters.test.js
+++ b/tests/jest/plugins/plugin.chapters.test.js
@@ -55,6 +55,7 @@ const SAMPLE_TOC_UNDEF = [
   }
 ];
 
+/** @type {BookReader} */
 let br;
 beforeEach(() => {
   $.ajax = jest.fn().mockImplementation((args) => {
@@ -97,9 +98,7 @@ describe('updateTOCState', () => {
 
   beforeEach(() => {
     window.HTMLElement.prototype.scrollIntoView = sinon.stub();
-    //Sinon is not used because this function is imported from BookModel with exposeOverrideableMethod()
-    //which has a getter and setter
-    br.getPageIndex = (str) => parseFloat(str);
+    br._models.book.getPageIndex = (str) => parseFloat(str);
     br.init();
   });
 


### PR DESCRIPTION
These were added as part of the v5 transition to avoid breaking changes. Let's get rid of as many as possible.

A few are left because they are used in petabox, or because they were overriden in plugins.