### PR TITLE
ia analytics, move to 1% sampled bucket

### DIFF
--- a/BookReaderDemo/IADemoBr.js
+++ b/BookReaderDemo/IADemoBr.js
@@ -82,6 +82,8 @@ const initializeBookReader = (brManifest) => {
   // we expect this at the global level
   BookReaderJSIAinit(brManifest.data, options);
 
+  const isRestricted = brManifest.data.isRestricted;
+  window.dispatchEvent(new CustomEvent('contextmenu', { detail: { isRestricted } }));
   if (customAutoflipParams.autoflip) {
     br.autoToggle(customAutoflipParams);
   }

--- a/src/BookNavigator/book-navigator.js
+++ b/src/BookNavigator/book-navigator.js
@@ -449,7 +449,7 @@ export class BookNavigator extends LitElement {
   /** Display an element's context menu */
   manageContextMenuVisibility(e) {
     if (window.archive_analytics) {
-      window.archive_analytics?.send_event_no_sampling(
+      window.archive_analytics?.send_event(
         'BookReader',
         `contextmenu-${this.bookIsRestricted ? 'restricted' : 'unrestricted'}`,
         e.target.classList.value

--- a/src/BookNavigator/book-navigator.js
+++ b/src/BookNavigator/book-navigator.js
@@ -452,7 +452,7 @@ export class BookNavigator extends LitElement {
       window.archive_analytics?.send_event(
         'BookReader',
         `contextmenu-${this.bookIsRestricted ? 'restricted' : 'unrestricted'}`,
-        e.target.classList.value
+        e.target?.classList?.value
       );
     }
     if (!this.bookIsRestricted) {

--- a/src/BookNavigator/volumes/volumes-provider.js
+++ b/src/BookNavigator/volumes/volumes-provider.js
@@ -104,7 +104,7 @@ export default class VolumesProvider {
     if (!window.archive_analytics) {
       return;
     }
-    window.archive_analytics?.send_event_no_sampling(
+    window.archive_analytics?.send_event(
       'BookReader',
       `VolumesSort|${orderBy}`,
       window.location.path,

--- a/tests/jest/BookNavigator/book-navigator.test.js
+++ b/tests/jest/BookNavigator/book-navigator.test.js
@@ -550,7 +550,7 @@ describe('<book-navigator>', () => {
 
         // analytics fires
         expect(window.archive_analytics.send_event_no_sampling.called).toEqual(
-          true
+          false
         );
         // we prevent default
         expect(preventDefaultSpy.called).toEqual(true);
@@ -622,7 +622,7 @@ describe('<book-navigator>', () => {
       imgBRpageimage.dispatchEvent(contextMenuEvent);
 
       // analytics fires
-      expect(window.archive_analytics.send_event_no_sampling.called).toEqual(true);
+      expect(window.archive_analytics.send_event_no_sampling.called).toEqual(false);
       // we do not prevent default
       expect(preventDefaultSpy.called).toEqual(false);
     });

--- a/tests/jest/BookNavigator/book-navigator.test.js
+++ b/tests/jest/BookNavigator/book-navigator.test.js
@@ -51,7 +51,7 @@ beforeEach(() => {
     send_event_no_sampling: sinon.fake(),
     send_event: sinon.fake()
   };
-})
+});
 
 afterEach(() => {
   window.br = null;

--- a/tests/jest/BookNavigator/book-navigator.test.js
+++ b/tests/jest/BookNavigator/book-navigator.test.js
@@ -46,6 +46,13 @@ window.ResizeObserver = class ResizeObserver {
   disconnect = sinon.fake()
 };
 
+beforeEach(() => {
+  window.archive_analytics = {
+    send_event_no_sampling: sinon.fake(),
+    send_event: sinon.fake()
+  };
+})
+
 afterEach(() => {
   window.br = null;
   fixtureCleanup();
@@ -516,8 +523,6 @@ describe('<book-navigator>', () => {
   describe('Handles Restricted Books', () => {
     describe('contextMenu is prevented when book is restricted', () => {
       it('watches on `div.BRscreen`', async () => {
-        window.archive_analytics = { send_event_no_sampling: sinon.fake() };
-
         const el = fixtureSync(container());
         const brStub = {
           options: { restricted: true },
@@ -529,9 +534,8 @@ describe('<book-navigator>', () => {
         const elSpy = sinon.spy(el.manageContextMenuVisibility);
         await el.elementUpdated;
 
-        expect(window.archive_analytics.send_event_no_sampling.called).toEqual(
-          false
-        );
+        expect(window.archive_analytics.send_event_no_sampling.called).toEqual(false);
+        expect(window.archive_analytics.send_event.called).toEqual(false);
         expect(elSpy.called).toEqual(false);
 
         const body = document.querySelector('body');
@@ -552,12 +556,11 @@ describe('<book-navigator>', () => {
         expect(window.archive_analytics.send_event_no_sampling.called).toEqual(
           false
         );
+        expect(window.archive_analytics.send_event.called).toEqual(true);
         // we prevent default
         expect(preventDefaultSpy.called).toEqual(true);
       });
       it('watches on `img.BRpageimage`', async () => {
-        window.archive_analytics = { send_event_no_sampling: sinon.fake() };
-
         const el = fixtureSync(container());
         const brStub = {
           options: { restricted: true },
@@ -568,9 +571,8 @@ describe('<book-navigator>', () => {
 
         await el.elementUpdated;
 
-        expect(window.archive_analytics.send_event_no_sampling.called).toEqual(
-          false
-        );
+        expect(window.archive_analytics.send_event_no_sampling.called).toEqual(false);
+        expect(window.archive_analytics.send_event.called).toEqual(false);
 
         const body = document.querySelector('body');
         // const element stub for img.BRpageimage
@@ -586,14 +588,13 @@ describe('<book-navigator>', () => {
         imgBRpageimage.dispatchEvent(contextMenuEvent);
 
         // analytics fires
-        expect(window.archive_analytics.send_event_no_sampling.called).toEqual(true);
+        expect(window.archive_analytics.send_event_no_sampling.called).toEqual(false);
+        expect(window.archive_analytics.send_event.called).toEqual(true);
         // we prevent default
         expect(preventDefaultSpy.called).toEqual(true);
       });
     });
     it('Allows unrestricted books access to context menu', async () => {
-      window.archive_analytics = { send_event_no_sampling: sinon.fake() };
-
       const el = fixtureSync(container());
       const brStub = {
         options: { restricted: false },
@@ -607,6 +608,8 @@ describe('<book-navigator>', () => {
       expect(window.archive_analytics.send_event_no_sampling.called).toEqual(
         false
       );
+      expect(window.archive_analytics.send_event.called).toEqual(false);
+
 
       const body = document.querySelector('body');
       // const element stub for img.BRpageimage
@@ -623,6 +626,7 @@ describe('<book-navigator>', () => {
 
       // analytics fires
       expect(window.archive_analytics.send_event_no_sampling.called).toEqual(false);
+      expect(window.archive_analytics.send_event.called).toEqual(true);
       // we do not prevent default
       expect(preventDefaultSpy.called).toEqual(false);
     });


### PR DESCRIPTION
Calls transferred to 1% sample bucket:
- on load, signal when book is restricted
- volume sorting when viewing a multi-volume book