### PR TITLE
WEBDEV-5660 Replace dotAll (`s`) flag in search result regexes with better-supported alternative

### DIFF
--- a/src/BookNavigator/search/a-search-result.js
+++ b/src/BookNavigator/search/a-search-result.js
@@ -13,7 +13,7 @@ export class BookSearchResult extends LitElement {
   constructor() {
     super();
 
-    this.matchRegex = new RegExp('{{{(.+?)}}}', 'gs');
+    this.matchRegex = new RegExp('{{{([^]+?)}}}', 'g'); // [^] matches any character, including line breaks
   }
 
   createRenderRoot() {

--- a/src/plugins/search/view.js
+++ b/src/plugins/search/view.js
@@ -15,7 +15,7 @@ class SearchView {
     // Search results are returned as a text blob with the hits wrapped in
     // triple mustaches. Hits occasionally include text beyond the search
     // term, so everything within the staches is captured and wrapped.
-    this.matcher = new RegExp('{{{(.+?)}}}', 'gs');
+    this.matcher = new RegExp('{{{([^]+?)}}}', 'g'); // [^] matches any character, including line breaks
     this.matches = [];
     this.cacheDOMElements();
     this.bindEvents();


### PR DESCRIPTION
BookReader’s search result components use regexes to match `{{{}}}`-delimited keywords for conversion into highlighted text. Since these keyword matches can (rarely) include line breaks, the regexes have the `s` (“dotAll”) flag set that allows `.` to match line breaks. However, the `s` flag’s browser support only goes back a few years, and older browsers panic out entirely when they encounter it.

A viable alternative (that even _much_ older browsers support) is simply to use `[^]` (an empty negated character class) in place of `.` to match any character, including line breaks. This removes any need for the `s` flag.