### PR TITLE
Fix default iOS voice missing from menu

### DIFF
--- a/tests/jest/plugins/tts/WebTTSEngine.test.js
+++ b/tests/jest/plugins/tts/WebTTSEngine.test.js
@@ -41,7 +41,7 @@ describe('WebTTSEngine', () => {
         voiceURI: "com.apple.voice.compact.bg-BG.Daria",
       }
     ];
-    const voices = WebTTSEngine.prototype.getVoices(null);
+    const voices = WebTTSEngine.prototype.getVoices();
     expect(voices.length).toBe(3);
     expect(voices[0].voiceURI).toBe('bookreader.SystemDefault');
   });
@@ -63,7 +63,7 @@ describe('WebTTSEngine', () => {
         voiceURI: "com.apple.voice.compact.bg-BG.Daria",
       }
     ];
-    const voices = WebTTSEngine.prototype.getVoices(null);
+    const voices = WebTTSEngine.prototype.getVoices();
     expect(voices.length).toBe(2);
   });
 });


### PR DESCRIPTION
iOS 16 seems to somehow not show the default OS voice in the menu (Usually Samantha or Samantha Enhanced). So include an options specifically on these devices for the system default. This sets the voice to `null` under the hood when the speech utterance is made.