### PR TITLE
1143/bugfix/2up in fullscreen

### DIFF
--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -465,8 +465,8 @@ BookReader.prototype.getInitialMode = function(params) {
   };
   if ('undefined' != typeof(params.mode)) {
     nextMode = params.mode;
-  } else if ((this.ui == 'full' && this.isFullscreenActive) || ifMobileBreakpoint()) {
-    // In full mode OR device width, we set the default based on width
+  } else if (this.ui == 'full' && this.isFullscreenActive && ifMobileBreakpoint()) {
+    // In full mode, we set the default based on width
     nextMode = this.constMode1up;
   } else {
     nextMode = this.constMode2up;

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -455,18 +455,17 @@ BookReader.prototype.readQueryString = function() {
  * @return {number} the mode
  */
 BookReader.prototype.getInitialMode = function(params) {
+  // Use params or browser width to set view mode
   let nextMode;
 
   // if mobile breakpoint, we always show this.constMode1up mode
   const ifMobileBreakpoint = () => {
-    // Use params or browser width to set view mode
     const windowWidth = $(window).width();
     return windowWidth && windowWidth <= this.onePageMinBreakpoint;
   };
   if ('undefined' != typeof(params.mode)) {
     nextMode = params.mode;
-  } else if (this.ui == 'full' && this.isFullscreenActive && ifMobileBreakpoint()) {
-    // In full mode, we set the default based on width
+  } else if (ifMobileBreakpoint()) {
     nextMode = this.constMode1up;
   } else {
     nextMode = this.constMode2up;


### PR DESCRIPTION
Closes #1143

Commit 19931be introduced a logic error in getInitialMode() that caused the mode to always be set to 1up if fullscreen mode was active, ignoring the mobile breakpoint.

Based on the comments in the new code and PR, the intention appears to have been to default to 1up whenever the screen size was within the mobile breakpoint (regardless of screen mode), but that's not what was happening. 

This PR removes the screen mode check, allowing the behavior intended by the previous PR. It also restores a comment that had gotten shifted from its intended location by a later edit.