### PR TITLE
Fix Mode1Up initial zoom

### DIFF
--- a/src/BookReader/Mode1UpLit.js
+++ b/src/BookReader/Mode1UpLit.js
@@ -372,7 +372,7 @@ export class Mode1UpLit extends LitElement {
    */
   computeDefaultScale(page) {
     // Default to real size if it fits, otherwise default to full width
-    const containerWidthIn = this.visiblePixelsToWorldUnits(this.htmlDimensionsCacher.clientWidth);
+    const containerWidthIn = this.renderedPixelsToWorldUnits(this.htmlDimensionsCacher.clientWidth);
     return Math.min(1, containerWidthIn / (page.widthInches + 2 * this.SPACING_IN)) || 1;
   }
 


### PR DESCRIPTION
Closes #1130 .

Also fixes runaway scroll when going FS on mobile from 2up.

| Before on page load | After on page load |
| --- | -- |
| ![image](https://github.com/internetarchive/bookreader/assets/6251786/b24a4283-4e63-451c-ada9-8640594dc13a) | ![image](https://github.com/internetarchive/bookreader/assets/6251786/e1c8f9f2-1f10-46ce-aeda-535cf6a48c0f) |

Tested on:
- Windows/FF
- Windows/Chrome