### PR TITLE
Search inside plugin listen to config

### DIFF
--- a/BookReaderDemo/IADemoBr.js
+++ b/BookReaderDemo/IADemoBr.js
@@ -36,7 +36,7 @@ iaBookReader.modal = modal;
 // Override options coming from IA
 BookReader.optionOverrides.imagesBaseURL = '/BookReader/images/';
 
-const initializeBookReader = (brManifest) => {
+const initializeBookReader = (brManifest, extraOptions = {}) => {
   console.log('initializeBookReader', brManifest);
   const br = new BookReader();
 
@@ -79,8 +79,13 @@ const initializeBookReader = (brManifest) => {
     options.ui = 'embed';
   }
 
+  const allOptions = {
+    ...options,
+    ...extraOptions,
+  }
+
   // we expect this at the global level
-  BookReaderJSIAinit(brManifest.data, options);
+  BookReaderJSIAinit(brManifest.data, allOptions);
 
   const isRestricted = brManifest.data.isRestricted;
   window.dispatchEvent(new CustomEvent('contextmenu', { detail: { isRestricted } }));
@@ -112,7 +117,18 @@ multiVolume.addEventListener('click', () => {
 });
 
 
-const fetchBookManifestAndInitializeBookreader = async (iaMetadata) => {
+const removeSearchPanel = document.querySelector('#remove-search-panel');
+removeSearchPanel.addEventListener('click', () => {
+  // remove everything
+  $('#BookReader').empty();
+  delete window.br;
+  // and re-mount with a new book
+  fetch(`https://archive.org/metadata/${ocaid}`)
+  .then(response => response.json())
+  .then(iaMetadata => fetchBookManifestAndInitializeBookreader(iaMetadata, { enableSearch: false }));
+});
+
+const fetchBookManifestAndInitializeBookreader = async (iaMetadata, extraOptions = {}) => {
   document.querySelector('input[name="itemMD"]').checked = true;
   iaBookReader.item = iaMetadata;
 
@@ -135,7 +151,7 @@ const fetchBookManifestAndInitializeBookreader = async (iaMetadata) => {
   const manifest = await fetch(iaManifestUrl).then(response => response.json());
   document.querySelector('input[name="bookManifest"]').checked = true;
 
-  initializeBookReader(manifest);
+  initializeBookReader(manifest, extraOptions);
 };
 
 // Temp; Circumvent bug in BookReaderJSIA code

--- a/BookReaderDemo/demo-internetarchive.html
+++ b/BookReaderDemo/demo-internetarchive.html
@@ -87,6 +87,9 @@
       <button id="start-fs">Start at Fullscreen</button>
     </div>
     <div class="demo">
+      <button id="remove-search-panel">Remove Search Panel</button>
+    </div>
+    <div class="demo">
       <h3 id="placeholder">please wait as we are fetching the following: </h3>
       <input type='checkbox' class='group1' name='itemMD' disabled>Item metadata</input><br>
       <input type='checkbox' class='group1' name='bookManifest' disabled> Book manifest</input><br>

--- a/src/BookNavigator/book-navigator.js
+++ b/src/BookNavigator/book-navigator.js
@@ -237,7 +237,11 @@ export class BookNavigator extends LitElement {
     }
 
     this.menuProviders = providers;
-    this.addMenuShortcut('search');
+    if (this.bookreader.options.enableSearch) {
+      this.addMenuShortcut('search');
+    } else {
+      this.removeMenuShortcut('search');
+    }
     this.addMenuShortcut('volumes');
     this.updateMenuContents();
   }

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -45,6 +45,13 @@ jQuery.extend(BookReader.defaultOptions, {
 /** @override */
 BookReader.prototype.setup = (function (super_) {
   return function (options) {
+    // override with config
+    if (options.enableSearch === false) {
+      jQuery.extend(BookReader.defaultOptions, {
+        enableSearch: false
+      });
+    }
+
     super_.call(this, options);
 
     this.searchTerm = '';

--- a/tests/jest/BookNavigator/book-navigator.test.js
+++ b/tests/jest/BookNavigator/book-navigator.test.js
@@ -161,29 +161,53 @@ describe('<book-navigator>', () => {
         expect(el.menuProviders.visualAdjustments).toBeInstanceOf(VisualAdjustmentsProvider);
       });
       describe('Loading Sub Menus By Plugin Flags', () => {
-        test('Search: uses `enableSearch` flag', async() => {
-          const el = fixtureSync(container());
-          const $brContainer = document.createElement('div');
-          const brStub = {
-            resize: sinon.fake(),
-            currentIndex: sinon.fake(),
-            jumpToIndex: sinon.fake(),
-            options: { enableSearch: true },
-            refs: {
-              $brContainer
-            }
-          };
-          el.bookreader = brStub;
-          await el.elementUpdated;
+        describe('Search Panel', () => {
+          test('Search: uses `enableSearch` flag', async() => {
+            const el = fixtureSync(container());
+            const $brContainer = document.createElement('div');
+            const brStub = {
+              resize: sinon.fake(),
+              currentIndex: sinon.fake(),
+              jumpToIndex: sinon.fake(),
+              options: { enableSearch: true },
+              refs: {
+                $brContainer
+              }
+            };
+            el.bookreader = brStub;
+            await el.elementUpdated;
 
-          el.initializeBookSubmenus();
-          await el.elementUpdated;
+            el.initializeBookSubmenus();
+            await el.elementUpdated;
 
-          expect(el.menuProviders.search).toBeDefined();
-          expect(el.menuProviders.search).toBeInstanceOf(SearchProvider);
+            expect(el.menuProviders.search).toBeDefined();
+            expect(el.menuProviders.search).toBeInstanceOf(SearchProvider);
 
-          // also adds a menu shortcut
-          expect(el.menuShortcuts.find(m => m.id === 'search')).toBeDefined();
+            // also adds a menu shortcut
+            expect(el.menuShortcuts.find(m => m.id === 'search')).toBeDefined();
+          });
+          test('Search: does not display when `enableSearch: false`', async() => {
+            const el = fixtureSync(container());
+            const $brContainer = document.createElement('div');
+            const brStub = {
+              resize: sinon.fake(),
+              currentIndex: sinon.fake(),
+              jumpToIndex: sinon.fake(),
+              options: { enableSearch: false },
+              refs: {
+                $brContainer
+              }
+            };
+            el.bookreader = brStub;
+            await el.elementUpdated;
+
+            el.initializeBookSubmenus();
+            await el.elementUpdated;
+
+            expect(el.menuProviders.search).toBeUndefined();
+            // also adds a menu shortcut
+            expect(el.menuShortcuts.find(m => m.id === 'search')).toBeUndefined();
+          });
         });
         test('Volumes/Multiple Books: uses `enableMultipleBooks` flag', async() => {
           const el = fixtureSync(container());

--- a/tests/jest/BookNavigator/book-navigator.test.js
+++ b/tests/jest/BookNavigator/book-navigator.test.js
@@ -205,7 +205,6 @@ describe('<book-navigator>', () => {
             await el.elementUpdated;
 
             expect(el.menuProviders.search).toBeUndefined();
-            // also adds a menu shortcut
             expect(el.menuShortcuts.find(m => m.id === 'search')).toBeUndefined();
           });
         });

--- a/tests/jest/plugins/search/plugin.search.test.js
+++ b/tests/jest/plugins/search/plugin.search.test.js
@@ -45,7 +45,7 @@ beforeEach(() => {
 
   $.fn.trigger = jest.fn();
   document.body.innerHTML = '<div id="BookReader">';
-  br = new BookReader();
+  br = new BookReader({ enableSearch: true });
   br.initToolbar = jest.fn();
   br.showProgressPopup = jest.fn();
   br.searchXHR = jest.fn();
@@ -53,11 +53,19 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.clearAllMocks();
+  br = undefined;
 });
 
 describe('Plugin: Search', () => {
   test('has option flag', () => {
     expect(BookReader.defaultOptions.enableSearch).toEqual(true);
+  });
+
+  test('Can turn off option by config even though plugin script has loaded', () => {
+    expect(BookReader.defaultOptions.enableSearch).toEqual(true);
+
+    br = new BookReader({ enableSearch: false });
+    expect(br.options.enableSearch).toEqual(false);
   });
 
   test('has added BR property: server', () => {


### PR DESCRIPTION
Now, search plugin instantiates by looking at `enableSearch` boolean flag inside Options config
+ demo
+ unit test for plugin
+ unit test for side panel

## Testing https://deploy-preview-1173--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=theworksofplato01platiala#mode/1up
- go to review app
- scroll down to "Remove Search Panel" -> click once
- ✅ book reloads with NO search shortcut & NO search side panel