### PR TITLE
Fix page/nundefined errors causing blackscreen

### DIFF
--- a/src/BookReader/Mode1Up.js
+++ b/src/BookReader/Mode1Up.js
@@ -58,6 +58,9 @@ export class Mode1Up {
         });
       }
       this.mode1UpLit.jumpToIndex(startLeaf);
+      // Must explicitly call updateVisibleRegion, since no
+      // scroll event seems to fire.
+      this.mode1UpLit.updateVisibleRegion();
     });
     this.br.updateBrClasses();
   }

--- a/src/BookReader/Mode1UpLit.js
+++ b/src/BookReader/Mode1UpLit.js
@@ -203,9 +203,12 @@ export class Mode1UpLit extends LitElement {
     }
     if (changedProps.has('visiblePages')) {
       this.throttledUpdateRenderedPages();
-      this.br.displayedIndices = this.visiblePages.map(p => p.index);
-      this.br.updateFirstIndex(this.br.displayedIndices[0]);
-      this.br._components.navbar.updateNavIndexThrottled();
+      if (this.visiblePages.length) {
+        // unclear why this is ever really happening
+        this.br.displayedIndices = this.visiblePages.map(p => p.index);
+        this.br.updateFirstIndex(this.br.displayedIndices[0]);
+        this.br._components.navbar.updateNavIndexThrottled();
+      }
     }
     if (changedProps.has('scale')) {
       const oldVal = changedProps.get('scale');


### PR DESCRIPTION
It seems like a scroll event isn't fired when we set scrollTop before it's rendered. This is causing black screens and the url to change from eg `/page/n53/mode/1up` to `/page/nundefined/mode/1up`.

Testing:

- https://deploy-preview-1177--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=pinehurstestates.preplat.1997 renders correctly (note master, removing `deploy-preview-1177--`, black screens)