### PR TITLE
Don't limit autoFit zoom to real world size

### DIFF
--- a/src/BookReader/Mode2UpLit.js
+++ b/src/BookReader/Mode2UpLit.js
@@ -445,7 +445,6 @@ export class Mode2UpLit extends LitElement {
   computeScale(page, autoFit) {
     if (!page) return 1;
     const spread = page.spread;
-    // Default to real size if it fits, otherwise default to full height
     const bookWidth = this.computePositions(spread.left, spread.right).bookWidth;
     const bookHeight = this.computePageHeight(spread.left || spread.right);
     const BOOK_PADDING_PX = 10;
@@ -458,11 +457,11 @@ export class Mode2UpLit extends LitElement {
 
     let scale = realScale;
     if (autoFit == 'width') {
-      scale = Math.min(widthScale, 1);
+      scale = widthScale;
     } else if (autoFit == 'height') {
-      scale = Math.min(heightScale, 1);
+      scale = heightScale;
     } else if (autoFit == 'auto') {
-      scale = Math.min(widthScale, heightScale, 1);
+      scale = Math.min(widthScale, heightScale);
     } else if (autoFit == 'none') {
       scale = this.scale;
     } else {


### PR DESCRIPTION
Closes #1189

The UX design here had the book scale upto but not surpass its real-world size on initial page load. But there are too many books missing PPI entirely or having incorrect PPIs, so removing that check.

https://deploy-preview-1197--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=mss-25-rock-rule#mode/2up