### PR TITLE
Search inside option for {{{/}}} + http support

### DIFF
--- a/src/BookNavigator/search/search-results.js
+++ b/src/BookNavigator/search/search-results.js
@@ -1,5 +1,4 @@
 /* eslint-disable class-methods-use-this */
-import { escapeHTML } from '../../BookReader/utils.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { css, html, LitElement, nothing } from 'lit';
 import '@internetarchive/ia-activity-indicator/ia-activity-indicator';
@@ -146,12 +145,7 @@ export class IABookSearchResults extends LitElement {
               ${match.cover ? html`<img src="${match.cover}" />` : nothing}
               <h4>${match.title || nothing}</h4>
               <p class="page-num">Page ${match.displayPageNumber}</p>
-              <p>
-                ${
-                  // [^] matches any character, including line breaks
-                  unsafeHTML(escapeHTML(match.text).replace(/{{{([^]+?)}}}/g, '<mark>$1</mark>'))
-                }
-              </p>
+              <p>${unsafeHTML(match.html)}</p>
             </li>
           `)}
       </ul>

--- a/src/BookReader/utils.js
+++ b/src/BookReader/utils.js
@@ -278,3 +278,13 @@ export function promisifyEvent(target, eventType) {
     target.addEventListener(eventType, resolver);
   });
 }
+
+/**
+ * Escapes regex special characters in a string. Allows for safe usage in regexes.
+ * Src: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions
+ * @param {string} string
+ * @returns {string}
+ */
+export function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
+}

--- a/src/css/_BRnav.scss
+++ b/src/css/_BRnav.scss
@@ -77,8 +77,8 @@
 }
 
 @keyframes fadeUp {
-  from { opacity: 0; transform: translateY(10px); }
-  to { opacity: 1; transform: translateY(0); }
+  from { opacity: 0; translate: 0 10px; }
+  to { opacity: 1; translate: 0 0; }
 }
 
 .BRfooter {

--- a/src/css/_BRsearch.scss
+++ b/src/css/_BRsearch.scss
@@ -4,23 +4,37 @@
   bottom: calc(100% + 5px);
   left: 50%;
   transform: translateX(-50%);
-  width: 230px;
+  width: 350px;
+  max-width: 100vw;
   padding: 12px 14px;
+  padding-bottom: 10px;
   color: $tooltipText;
-  font-weight: bold;
   background: $tooltipBG;
   box-shadow: 0 2px 4px rgba(0, 0, 0, .5);
+  border-radius: 4px;
+  animation: fadeUp 0.2s;
+
+  // Disable text selection
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+
+  // Create a triangle under the tooltip using clip-path
+  // This makes it possible to move the mouse onto the tooltip
   &:after {
-    display: none;
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    transform: translateX(-50%);
     content: "";
-    border: 7px solid transparent;
-    border-width: 7px 4px;
-    border-bottom: none;
-    border-top-color: $tooltipBG;
+    position: absolute;
+    bottom: -9px;
+    left: 50%;
+    margin-left: -1px;
+    box-shadow: inherit;
+    transform: translateX(-50%);
+    width: 30px;
+    height: 10px;
+    clip-path: polygon(0 0, 100% 0, 50% 100%);
+    background-color: transparent;
   }
 }
 
@@ -105,7 +119,19 @@
   }
   .BRquery {
     @extend %timeline-tooltip;
-    b {
+    main {
+      display: -webkit-box;
+      -webkit-line-clamp: 4;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      margin-bottom: 6px;
+    }
+    footer {
+      text-align: center;
+      font-weight: bold;
+      font-size: 0.9em;
+    }
+    mark {
       color: $searchResultText;
       font-weight: bold;
       background-color: $searchResultBG;

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -38,6 +38,7 @@ jQuery.extend(BookReader.defaultOptions, {
   subPrefix: '',
   bookPath: '',
   enableSearch: true,
+  searchInsideProtocol: 'https',
   searchInsideUrl: '/fulltext/inside.php',
   searchInsidePreTag: '{{{',
   searchInsidePostTag: '}}}',
@@ -172,7 +173,7 @@ BookReader.prototype.search = async function(term = '', overrides = {}) {
 
   // Remove the port and userdir
   const serverPath = this.server.replace(/:.+/, '');
-  const baseUrl = `https://${serverPath}${this.searchInsideUrl}?`;
+  const baseUrl = `${this.options.searchInsideProtocol}://${serverPath}${this.searchInsideUrl}?`;
 
   // Remove subPrefix from end of path
   let path = this.bookPath;

--- a/src/plugins/search/view.js
+++ b/src/plugins/search/view.js
@@ -1,5 +1,3 @@
-import { escapeHTML } from "../../BookReader/utils.js";
-
 class SearchView {
   /**
    * @param {object} params
@@ -11,11 +9,6 @@ class SearchView {
    */
   constructor({ br, searchCancelledCallback = () => {} }) {
     this.br = br;
-
-    // Search results are returned as a text blob with the hits wrapped in
-    // triple mustaches. Hits occasionally include text beyond the search
-    // term, so everything within the staches is captured and wrapped.
-    this.matcher = new RegExp('{{{([^]+?)}}}', 'g'); // [^] matches any character, including line breaks
     this.matches = [];
     this.cacheDOMElements();
     this.bindEvents();
@@ -230,26 +223,20 @@ class SearchView {
    */
   renderPins(matches) {
     matches.forEach((match) => {
-      const queryString = match.text;
       const pageIndex = this.br.book.leafNumToIndex(match.par[0].page);
       const uiStringSearch = "Search result"; // i18n
-
       const percentThrough = this.br.constructor.util.cssPercentage(pageIndex, this.br.book.getNumLeafs() - 1);
 
-      const escapedQueryString = escapeHTML(queryString);
-      const queryStringWithB = escapedQueryString.replace(this.matcher, '<b>$1</b>');
-
-      let queryStringWithBTruncated = '';
-
-      if (queryString.length > 100) {
-        queryStringWithBTruncated = queryString.replace(/^(.{100}[^\s]*).*/, "$1");
-
-        // If truncating, we must escape *after* truncation occurs (but before wrapping in <b>)
-        queryStringWithBTruncated = escapeHTML(queryStringWithBTruncated)
-          .replace(this.matcher, '<b>$1</b>')
-          + '...';
+      let html = match.html;
+      if (html.length > 200) {
+        const start = Math.max(0, html.indexOf('<mark>') - 100);
+        if (start != 0) {
+          html = '…' + match.html
+            .substring(start)
+            // Make sure at word boundary though
+            .replace(/^\S+/, '');
+        }
       }
-
       // draw marker
       $('<div>')
         .addClass('BRsearch')
@@ -259,8 +246,8 @@ class SearchView {
         .attr('title', uiStringSearch)
         .append(`
           <div class="BRquery">
-            <div>${queryStringWithBTruncated || queryStringWithB}</div>
-            <div>Page ${match.displayPageNumber}</div>
+            <main>${html}</main>
+            <footer>Page ${match.displayPageNumber}</footer>
           </div>
         `)
         .appendTo(this.br.$('.BRnavline'))


### PR DESCRIPTION
Also closes #1188 

We will be switching from {{{/}}} to a less common string, since issues arise when the original OCR contains eg `{{{`.

Changes:
- New options for `searchInsidePreTag: {{{`, `searchInsidePostTag: }}}`
- DRY where a search is rendered
- Small style tweaks to search hover cards
- Also new option `searchInsideProtocol` for #1188 .