### PR TITLE
Search inside option for {{{/}}} + http support

### DIFF
--- a/src/BookNavigator/search/search-results.js
+++ b/src/BookNavigator/search/search-results.js
@@ -1,5 +1,4 @@
 /* eslint-disable class-methods-use-this */
-import { escapeHTML } from '../../BookReader/utils.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { css, html, LitElement, nothing } from 'lit';
 import '@internetarchive/ia-activity-indicator/ia-activity-indicator';
@@ -146,12 +145,7 @@ export class IABookSearchResults extends LitElement {
               ${match.cover ? html`<img src="${match.cover}" />` : nothing}
               <h4>${match.title || nothing}</h4>
               <p class="page-num">Page ${match.displayPageNumber}</p>
-              <p>
-                ${
-                  // [^] matches any character, including line breaks
-                  unsafeHTML(escapeHTML(match.text).replace(/{{{([^]+?)}}}/g, '<mark>$1</mark>'))
-                }
-              </p>
+              <p>${unsafeHTML(match.html)}</p>
             </li>
           `)}
       </ul>

--- a/src/BookReader/utils.js
+++ b/src/BookReader/utils.js
@@ -278,3 +278,13 @@ export function promisifyEvent(target, eventType) {
     target.addEventListener(eventType, resolver);
   });
 }
+
+/**
+ * Escapes regex special characters in a string. Allows for safe usage in regexes.
+ * Src: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions
+ * @param {string} string
+ * @returns {string}
+ */
+export function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
+}

--- a/src/css/_BRnav.scss
+++ b/src/css/_BRnav.scss
@@ -77,8 +77,8 @@
 }
 
 @keyframes fadeUp {
-  from { opacity: 0; transform: translateY(10px); }
-  to { opacity: 1; transform: translateY(0); }
+  from { opacity: 0; translate: 0 10px; }
+  to { opacity: 1; translate: 0 0; }
 }
 
 .BRfooter {

--- a/src/css/_BRsearch.scss
+++ b/src/css/_BRsearch.scss
@@ -1,26 +1,45 @@
+@mixin ellipsis-lines($lines: 4) {
+  display: -webkit-box;
+  -webkit-line-clamp: $lines;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 %timeline-tooltip {
   display: none;
   position: absolute;
   bottom: calc(100% + 5px);
   left: 50%;
   transform: translateX(-50%);
-  width: 230px;
+  width: 350px;
+  max-width: 100vw;
   padding: 12px 14px;
+  padding-bottom: 10px;
   color: $tooltipText;
-  font-weight: bold;
   background: $tooltipBG;
   box-shadow: 0 2px 4px rgba(0, 0, 0, .5);
+  border-radius: 4px;
+  animation: fadeUp 0.2s;
+
+  // Disable text selection
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+
+  // Create a triangle under the tooltip using clip-path
+  // This makes it possible to move the mouse onto the tooltip
   &:after {
-    display: none;
     position: absolute;
-    top: 100%;
-    left: 50%;
-    transform: translateX(-50%);
     content: "";
-    border: 7px solid transparent;
-    border-width: 7px 4px;
-    border-bottom: none;
-    border-top-color: $tooltipBG;
+    bottom: -9px;
+    left: 50%;
+    margin-left: -1px;
+    transform: translateX(-50%);
+    width: 30px;
+    height: 10px;
+    clip-path: polygon(0 0, 100% 0, 50% 100%);
   }
 }
 
@@ -105,7 +124,16 @@
   }
   .BRquery {
     @extend %timeline-tooltip;
-    b {
+    main {
+      @include ellipsis-lines(4);
+      margin-bottom: 6px;
+    }
+    footer {
+      text-align: center;
+      font-weight: bold;
+      font-size: 0.9em;
+    }
+    mark {
       color: $searchResultText;
       font-weight: bold;
       background-color: $searchResultBG;

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -24,9 +24,10 @@
  * @event BookReader:SearchCanceled - When no results found. Receives
  *   `instance`
  */
-import { escapeHTML, escapeRegExp, poll } from '../../BookReader/utils.js';
+import { poll } from '../../BookReader/utils.js';
 import { renderBoxesInPageContainerLayer } from '../../BookReader/PageContainer.js';
 import SearchView from './view.js';
+import { marshallSearchResults } from './utils.js';
 /** @typedef {import('../../BookReader/PageContainer').PageContainer} PageContainer */
 /** @typedef {import('../../BookReader/BookModel').PageIndex} PageIndex */
 /** @typedef {import('../../BookReader/BookModel').LeafNum} LeafNum */
@@ -277,48 +278,6 @@ BookReader.prototype.cancelSearchRequest = function () {
  * @property {SearchInsideMatch[]} matches
  * @property {boolean} indexed
  */
-
-/**
- * @param {string} match
- * @param {string} preTag
- * @param {string} postTag
- * @returns {string}
- */
-export function renderMatch(match, preTag, postTag) {
-  // Search results are returned as a text blob with the hits wrapped in
-  // triple mustaches. Hits occasionally include text beyond the search
-  // term, so everything within the staches is captured and wrapped.
-  const preTagRe = escapeRegExp(preTag);
-  const postTagRe = escapeRegExp(postTag);
-  // [^] matches any character, including line breaks
-  const regex = new RegExp(`${preTagRe}([^]+?)${postTagRe}`, 'g');
-  return escapeHTML(match)
-    .replace(regex, '<mark>$1</mark>')
-    // Fix trailing hyphens. This over-corrects but is net useful.
-    .replace(/(\b)- /g, '$1');
-}
-
-/**
- * Attach some fields to search inside results
- * @param {SearchInsideResults} results
- * @param {(pageNum: LeafNum) => PageNumString} displayPageNumberFn
- * @param {string} preTag
- * @param {string} postTag
- */
-export function marshallSearchResults(results, displayPageNumberFn, preTag, postTag) {
-  // Attach matchIndex to a few things to make it easier to identify
-  // an active/selected match
-  for (const [index, match] of results.matches.entries()) {
-    match.matchIndex = index;
-    match.displayPageNumber = displayPageNumberFn(match.par[0].page);
-    match.html = renderMatch(match.text, preTag, postTag);
-    for (const par of match.par) {
-      for (const box of par.boxes) {
-        box.matchIndex = index;
-      }
-    }
-  }
-}
 
 /**
  * Search Results return handler

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -38,6 +38,7 @@ jQuery.extend(BookReader.defaultOptions, {
   subPrefix: '',
   bookPath: '',
   enableSearch: true,
+  searchInsideProtocol: 'https',
   searchInsideUrl: '/fulltext/inside.php',
   searchInsidePreTag: '{{{',
   searchInsidePostTag: '}}}',
@@ -172,7 +173,7 @@ BookReader.prototype.search = async function(term = '', overrides = {}) {
 
   // Remove the port and userdir
   const serverPath = this.server.replace(/:.+/, '');
-  const baseUrl = `https://${serverPath}${this.searchInsideUrl}?`;
+  const baseUrl = `${this.options.searchInsideProtocol}://${serverPath}${this.searchInsideUrl}?`;
 
   // Remove subPrefix from end of path
   let path = this.bookPath;

--- a/src/plugins/search/utils.js
+++ b/src/plugins/search/utils.js
@@ -10,8 +10,8 @@ export function renderMatch(match, preTag, postTag) {
   // Search results are returned as a text blob with the hits wrapped in
   // triple mustaches. Hits occasionally include text beyond the search
   // term, so everything within the staches is captured and wrapped.
-  const preTagRe = escapeRegExp(preTag);
-  const postTagRe = escapeRegExp(postTag);
+  const preTagRe = escapeRegExp(escapeHTML(preTag));
+  const postTagRe = escapeRegExp(escapeHTML(postTag));
   // [^] matches any character, including line breaks
   const regex = new RegExp(`${preTagRe}([^]+?)${postTagRe}`, 'g');
   return escapeHTML(match)

--- a/src/plugins/search/utils.js
+++ b/src/plugins/search/utils.js
@@ -1,0 +1,43 @@
+import { escapeHTML, escapeRegExp } from '../../BookReader/utils.js';
+
+/**
+ * @param {string} match
+ * @param {string} preTag
+ * @param {string} postTag
+ * @returns {string}
+ */
+export function renderMatch(match, preTag, postTag) {
+  // Search results are returned as a text blob with the hits wrapped in
+  // triple mustaches. Hits occasionally include text beyond the search
+  // term, so everything within the staches is captured and wrapped.
+  const preTagRe = escapeRegExp(preTag);
+  const postTagRe = escapeRegExp(postTag);
+  // [^] matches any character, including line breaks
+  const regex = new RegExp(`${preTagRe}([^]+?)${postTagRe}`, 'g');
+  return escapeHTML(match)
+    .replace(regex, '<mark>$1</mark>')
+    // Fix trailing hyphens. This over-corrects but is net useful.
+    .replace(/(\b)- /g, '$1');
+}
+
+/**
+ * Attach some fields to search inside results
+ * @param {SearchInsideResults} results
+ * @param {(pageNum: LeafNum) => PageNumString} displayPageNumberFn
+ * @param {string} preTag
+ * @param {string} postTag
+ */
+export function marshallSearchResults(results, displayPageNumberFn, preTag, postTag) {
+  // Attach matchIndex to a few things to make it easier to identify
+  // an active/selected match
+  for (const [index, match] of results.matches.entries()) {
+    match.matchIndex = index;
+    match.displayPageNumber = displayPageNumberFn(match.par[0].page);
+    match.html = renderMatch(match.text, preTag, postTag);
+    for (const par of match.par) {
+      for (const box of par.boxes) {
+        box.matchIndex = index;
+      }
+    }
+  }
+}

--- a/src/plugins/search/view.js
+++ b/src/plugins/search/view.js
@@ -1,5 +1,3 @@
-import { escapeHTML } from "../../BookReader/utils.js";
-
 class SearchView {
   /**
    * @param {object} params
@@ -11,11 +9,6 @@ class SearchView {
    */
   constructor({ br, searchCancelledCallback = () => {} }) {
     this.br = br;
-
-    // Search results are returned as a text blob with the hits wrapped in
-    // triple mustaches. Hits occasionally include text beyond the search
-    // term, so everything within the staches is captured and wrapped.
-    this.matcher = new RegExp('{{{([^]+?)}}}', 'g'); // [^] matches any character, including line breaks
     this.matches = [];
     this.cacheDOMElements();
     this.bindEvents();
@@ -230,26 +223,20 @@ class SearchView {
    */
   renderPins(matches) {
     matches.forEach((match) => {
-      const queryString = match.text;
       const pageIndex = this.br.book.leafNumToIndex(match.par[0].page);
       const uiStringSearch = "Search result"; // i18n
-
       const percentThrough = this.br.constructor.util.cssPercentage(pageIndex, this.br.book.getNumLeafs() - 1);
 
-      const escapedQueryString = escapeHTML(queryString);
-      const queryStringWithB = escapedQueryString.replace(this.matcher, '<b>$1</b>');
-
-      let queryStringWithBTruncated = '';
-
-      if (queryString.length > 100) {
-        queryStringWithBTruncated = queryString.replace(/^(.{100}[^\s]*).*/, "$1");
-
-        // If truncating, we must escape *after* truncation occurs (but before wrapping in <b>)
-        queryStringWithBTruncated = escapeHTML(queryStringWithBTruncated)
-          .replace(this.matcher, '<b>$1</b>')
-          + '...';
+      let html = match.html;
+      if (html.length > 200) {
+        const start = Math.max(0, html.indexOf('<mark>') - 100);
+        if (start != 0) {
+          html = '…' + match.html
+            .substring(start)
+            // Make sure at word boundary though
+            .replace(/^\S+/, '');
+        }
       }
-
       // draw marker
       $('<div>')
         .addClass('BRsearch')
@@ -259,8 +246,8 @@ class SearchView {
         .attr('title', uiStringSearch)
         .append(`
           <div class="BRquery">
-            <div>${queryStringWithBTruncated || queryStringWithB}</div>
-            <div>Page ${match.displayPageNumber}</div>
+            <main>${html}</main>
+            <footer>Page ${match.displayPageNumber}</footer>
           </div>
         `)
         .appendTo(this.br.$('.BRnavline'))

--- a/tests/e2e/helpers/desktopSearch.js
+++ b/tests/e2e/helpers/desktopSearch.js
@@ -29,8 +29,8 @@ export function runDesktopSearchTests(br) {
       await t.pressKey('enter');
 
       await t.expect(nav.desktop.searchPin.exists).ok();
-      await t.expect(nav.desktop.searchPin.child('.BRquery').child('div').exists).ok();
-      await t.expect(nav.desktop.searchPin.child('.BRquery').child('div').innerText).contains(TEST_TEXT_FOUND);
+      await t.expect(nav.desktop.searchPin.child('.BRquery').child('main').exists).ok();
+      await t.expect(nav.desktop.searchPin.child('.BRquery').child('main').innerText).contains(TEST_TEXT_FOUND);
       await t.expect(nav.desktop.searchNavigation.exists).ok();
       await t.expect(nav.desktop.searchNavigation.find('[data-id="resultsCount"]').exists).ok();
       await t.expect(nav.desktop.searchNavigation.find('[data-id="resultsCount"]').innerText).contains(SEARCH_MATCHES_LENGTH);
@@ -63,7 +63,7 @@ export function runDesktopSearchTests(br) {
       // FIXME: Why is it only typing every other letter?!?!
       await t.typeText(nav.desktop.searchBox, TEST_TEXT_NOT_FOUND.split('').join('_'));
       await t.pressKey('enter');
-      await t.expect(nav.desktop.searchPin.child('.BRquery').child('div').withText(TEST_TEXT_NOT_FOUND).exists).notOk();
+      await t.expect(nav.desktop.searchPin.child('.BRquery').child('main').withText(TEST_TEXT_NOT_FOUND).exists).notOk();
 
       const getPageUrl = ClientFunction(() => window.location.href.toString());
       await t.expect(getPageUrl()).contains(TEST_TEXT_NOT_FOUND);

--- a/tests/jest/BookNavigator/search/search-results.test.js
+++ b/tests/jest/BookNavigator/search/search-results.test.js
@@ -5,6 +5,7 @@ import {
 } from '@open-wc/testing-helpers';
 import sinon from 'sinon';
 import { IABookSearchResults } from '@/src/BookNavigator/search/search-results.js';
+import { marshallSearchResults } from '@/src/plugins/search/utils.js';
 
 const container = (results = [], query = '') => (
   html`<ia-book-search-results .results=${results} .query=${query}></ia-book-search-results>`
@@ -43,8 +44,10 @@ const results = [{
     l: 432,
     page_height: 5357,
     page: 86,
-  }],
+  }]
 }];
+
+marshallSearchResults({ matches: results }, () => '', '{{{', '}}}');
 
 const resultWithScript = [{
   text: `foo bar <script>const msg = 'test' + ' failure'; document.write(msg);</script> {{{${searchQuery}}}} baz`,
@@ -64,6 +67,8 @@ const resultWithScript = [{
     page: 24,
   }],
 }];
+
+marshallSearchResults({ matches: resultWithScript }, () => '', '{{{', '}}}');
 
 describe('<ia-book-search-results>', () => {
   afterEach(() => {

--- a/tests/jest/BookReader/utils.test.js
+++ b/tests/jest/BookReader/utils.test.js
@@ -7,6 +7,7 @@ import {
   decodeURIComponentPlus,
   encodeURIComponentPlus,
   escapeHTML,
+  escapeRegExp,
   getActiveElement,
   isInputActive,
   poll,
@@ -213,5 +214,16 @@ describe('promisifyEvent', () => {
 
     await afterEventLoop();
     expect(resolveSpy.callCount).toBe(1);
+  });
+});
+
+describe('escapeRegex', () => {
+  test('Escapes regex', () => {
+    expect(escapeRegExp('.*')).toBe('\\.\\*');
+    expect(escapeRegExp('foo')).toBe('foo');
+    expect(escapeRegExp('foo.bar')).toBe('foo\\.bar');
+    expect(escapeRegExp('{{{')).toBe('\\{\\{\\{');
+    expect(escapeRegExp('')).toBe('');
+    expect(escapeRegExp('https://example.com')).toBe('https://example\\.com');
   });
 });

--- a/tests/jest/plugins/search/plugin.search.test.js
+++ b/tests/jest/plugins/search/plugin.search.test.js
@@ -1,7 +1,7 @@
 import BookReader from '@/src/BookReader.js';
-import '@/src/plugins/plugin.mobile_nav.js';
-import { marshallSearchResults } from '@/src/plugins/search/plugin.search.js';
+import '@/src/plugins/search/plugin.search.js';
 import { deepCopy } from '../../utils.js';
+import { DUMMY_RESULTS } from './utils.js';
 
 jest.mock('@/src/plugins/search/view.js');
 
@@ -12,28 +12,6 @@ const triggeredEvents = () => {
     if (typeof params[0] === 'string') { return params[0]; }
     return params[0].type;
   });
-};
-
-const DUMMY_RESULTS = {
-  ia: "adventuresofoli00dick",
-  q: "child",
-  indexed: true,
-  page_count: 644,
-  body_length: 666,
-  leaf0_missing: false,
-  matches: [{
-    text: 'For a long; time after it was ushered into this world of sorrow and trouble, by the parish surgeon, it remained a matter of considerable doubt wliether the {{{child}}} Avould survi^ e to bear any name at all; in which case it is somewhat more than probable that these memoirs would never have appeared; or, if they had, that being comprised within a couple of pages, they would have possessed the inestimable meiit of being the most concise and faithful specimen of biography, extant in the literature of any age or country.',
-    par: [{
-      boxes: [{r: 1221, b: 2121, t: 2075, page: 37, l: 1107}],
-      b: 2535,
-      t: 1942,
-      page_width: 1790,
-      r: 1598,
-      l: 50,
-      page_height: 2940,
-      page: 37
-    }]
-  }]
 };
 
 beforeEach(() => {
@@ -163,20 +141,5 @@ describe('Plugin: Search', () => {
     br.init();
     await br.search('foo');
     expect(triggeredEvents()).toContain(`${namespace}SearchCallbackEmpty`);
-  });
-});
-
-describe('marshallSearchResults', () => {
-  test('Adds match index', () => {
-    const results = deepCopy(DUMMY_RESULTS);
-    marshallSearchResults(results, x => x.toString());
-    expect(results.matches[0]).toHaveProperty('matchIndex', 0);
-    expect(results.matches[0].par[0].boxes[0]).toHaveProperty('matchIndex', 0);
-  });
-
-  test('Adds display page number', () => {
-    const results = deepCopy(DUMMY_RESULTS);
-    marshallSearchResults(results, x => `n${x}`);
-    expect(results.matches[0]).toHaveProperty('displayPageNumber', 'n37');
   });
 });

--- a/tests/jest/plugins/search/plugin.search.view.test.js
+++ b/tests/jest/plugins/search/plugin.search.view.test.js
@@ -2,6 +2,7 @@
 import BookReader from '@/src/BookReader.js';
 import '@/src/plugins/plugin.mobile_nav.js';
 import '@/src/plugins/search/plugin.search.js';
+import { marshallSearchResults } from '@/src/plugins/search/utils.js';
 import '@/src/plugins/search/view.js';
 
 let br;
@@ -27,6 +28,8 @@ const results = {
     }]
   }]
 };
+
+marshallSearchResults(results, () => '', '{{{', '}}}');
 const resultWithScript = {
   ia: "adventuresofoli00dick",
   q: "child",
@@ -48,6 +51,8 @@ const resultWithScript = {
     }]
   }]
 };
+
+marshallSearchResults(resultWithScript, () => '', '{{{', '}}}');
 beforeEach(() => {
   $.ajax = jest.fn().mockImplementation(() => {
     // return from:

--- a/tests/jest/plugins/search/utils.js
+++ b/tests/jest/plugins/search/utils.js
@@ -1,0 +1,25 @@
+import { marshallSearchResults } from "@/src/plugins/search/utils";
+
+export const DUMMY_RESULTS = {
+  ia: "adventuresofoli00dick",
+  q: "child",
+  indexed: true,
+  page_count: 644,
+  body_length: 666,
+  leaf0_missing: false,
+  matches: [{
+    text: 'For a long; time after it was ushered into this world of sorrow and trouble, by the parish surgeon, it remained a matter of considerable doubt wliether the {{{child}}} Avould survi^ e to bear any name at all; in which case it is somewhat more than probable that these memoirs would never have appeared; or, if they had, that being comprised within a couple of pages, they would have possessed the inestimable meiit of being the most concise and faithful specimen of biography, extant in the literature of any age or country.',
+    par: [{
+      boxes: [{r: 1221, b: 2121, t: 2075, page: 37, l: 1107}],
+      b: 2535,
+      t: 1942,
+      page_width: 1790,
+      r: 1598,
+      l: 50,
+      page_height: 2940,
+      page: 37
+    }]
+  }]
+};
+
+marshallSearchResults(DUMMY_RESULTS, () => '', '{{{', '}}}');

--- a/tests/jest/plugins/search/utils.test.js
+++ b/tests/jest/plugins/search/utils.test.js
@@ -1,0 +1,18 @@
+import { marshallSearchResults } from '@/src/plugins/search/utils.js';
+import { deepCopy } from '@/tests/jest/utils.js';
+import { DUMMY_RESULTS } from './utils.js';
+
+describe('marshallSearchResults', () => {
+  test('Adds match index', () => {
+    const results = deepCopy(DUMMY_RESULTS);
+    marshallSearchResults(results, x => x.toString(), '{{{', '}}}');
+    expect(results.matches[0]).toHaveProperty('matchIndex', 0);
+    expect(results.matches[0].par[0].boxes[0]).toHaveProperty('matchIndex', 0);
+  });
+
+  test('Adds display page number', () => {
+    const results = deepCopy(DUMMY_RESULTS);
+    marshallSearchResults(results, x => `n${x}`, '{{{', '}}}');
+    expect(results.matches[0]).toHaveProperty('displayPageNumber', 'n37');
+  });
+});

--- a/tests/jest/plugins/search/utils.test.js
+++ b/tests/jest/plugins/search/utils.test.js
@@ -1,6 +1,17 @@
-import { marshallSearchResults } from '@/src/plugins/search/utils.js';
+import { marshallSearchResults, renderMatch } from '@/src/plugins/search/utils.js';
 import { deepCopy } from '@/tests/jest/utils.js';
 import { DUMMY_RESULTS } from './utils.js';
+
+describe('renderMatch', () => {
+  test('Supports custom pre/post tags', () => {
+    const matchText = DUMMY_RESULTS.matches[0].text
+      .replace(/\{\{\{/g, '<IA_FTS_MATCH>')
+      .replace(/\}\}\}/g, '</IA_FTS_MATCH>');
+    const html = renderMatch(matchText, '<IA_FTS_MATCH>', '</IA_FTS_MATCH>');
+    expect(html).toContain('<mark>');
+    expect(html).toContain('</mark>');
+  });
+});
 
 describe('marshallSearchResults', () => {
   test('Adds match index', () => {


### PR DESCRIPTION
Also closes #1188 

We will be switching from {{{/}}} to a less common string, since issues arise when the original OCR contains eg `{{{`.

Changes:
- New options for `searchInsidePreTag: {{{`, `searchInsidePostTag: }}}`
- DRY where a search is rendered
- Small style tweaks to search hover cards
- Also new option `searchInsideProtocol` for #1188 .