### PR TITLE
Downgrade core-js to fix esm.sh build issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "babel-loader": "9.1.2",
         "codecov": "^3.8.3",
         "concurrently": "7.4.0",
-        "core-js": "3.30.2",
+        "core-js": "3.27.1",
         "cpx2": "4.2.3",
         "eslint": "^7.32.0",
         "eslint-plugin-no-jquery": "^2.7.0",
@@ -5640,10 +5640,11 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.30.2",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.1.tgz",
+      "integrity": "sha512-GutwJLBChfGCpwwhbYoqfv03LAfmiz7e7D/BNxzeMxwQf10GRSzqiOjx7AmtEk+heiD/JWmBuyBPgFtx0Sg1ww==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -19094,7 +19095,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.30.2",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.1.tgz",
+      "integrity": "sha512-GutwJLBChfGCpwwhbYoqfv03LAfmiz7e7D/BNxzeMxwQf10GRSzqiOjx7AmtEk+heiD/JWmBuyBPgFtx0Sg1ww==",
       "dev": true
     },
     "core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "DOCS:update:test-deps": "If CI succeeds, these should be good to update",
     "update:test-deps": "npm i @babel/eslint-parser@latest @open-wc/testing-helpers@latest @types/jest@latest codecov@latest eslint@7 eslint-plugin-testcafe@latest jest@latest sinon@latest testcafe@latest",
     "DOCS:update:build-deps": "These can cause strange changes, so do an npm run build + check file size (git diff --stat), and check the site is as expected",
-    "update:build-deps": "npm i @babel/core@latest @babel/preset-env@latest @babel/plugin-proposal-class-properties@latest @babel/plugin-proposal-decorators@latest babel-loader@latest core-js@latest regenerator-runtime@latest sass@latest svgo@latest webpack@latest webpack-cli@latest",
+    "update:build-deps": "npm i @babel/core@latest @babel/preset-env@latest @babel/plugin-proposal-class-properties@latest @babel/plugin-proposal-decorators@latest babel-loader@latest core-js@3.27.1 regenerator-runtime@latest sass@latest svgo@latest webpack@latest webpack-cli@latest",
     "codecov": "npx codecov"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "babel-loader": "9.1.2",
     "codecov": "^3.8.3",
     "concurrently": "7.4.0",
-    "core-js": "3.30.2",
+    "core-js": "3.27.1",
     "cpx2": "4.2.3",
     "eslint": "^7.32.0",
     "eslint-plugin-no-jquery": "^2.7.0",


### PR DESCRIPTION
This was a strange issue.

So core-js in commit https://github.com/zloirock/core-js/commit/25e93739aa8623a47526cc65f2d8e5d68bd3b107 changed some code from `typeof global.process` to `typeof process`. Unfortunately this resulted in some part of esm.sh when transpiling for deno to think that the node library `process` needed to be imported. You can see it on the first line here: https://esm.sh/v130/@internetarchive/bookreader@5.0.0-64/deno/BookReader/BookReader.js . 

So for now rollback core-js to the previous version before this change was introduced. Not sure where the bug lies here ; whether this is an issue with core-js or esm.sh . But this is the quickest way for us to unblock our deploy flow to archive.org

Created an issue on core-js at least: https://github.com/zloirock/core-js/issues/1277