### PR TITLE
Add Custom TTS Speed

### DIFF
--- a/src/plugins/tts/plugin.tts.js
+++ b/src/plugins/tts/plugin.tts.js
@@ -131,6 +131,7 @@ BookReader.prototype.initNavbar = (function (super_) {
               <option value="1.5">1.5x</option>
               <option value="1.75">1.75x</option>
               <option value="2">2x</option>
+              <option value="custom">Custom</option>
             </select>
           </li>
           <li>
@@ -198,6 +199,43 @@ BookReader.prototype.initNavbar = (function (super_) {
             <span class="tooltip">${tooltips.readAloud}</span>
           </button>
         </li>`).insertBefore($el.find('.BRcontrols .BRicon.zoom_out').closest('li'));
+
+      this.refs.$BRReadAloudToolbar.find('.playback-speed').parent().after(`
+        <li>
+          <input type="number" class="custom-speed-input" min="0.01" max="5" step="0.01" pattern="^[1-5](\\.\\d{1,2})?$" style="display: none" placeholder="Enter speed (e.g., 1.1)" />
+          <button type="button" class="confirm-speed-btn" style="display: none">Confirm</button>
+          <span class="custom-speed-label" style="display: none">Custom</span>
+        </li>
+      `);
+
+      const $customSpeedInput = this.refs.$BRReadAloudToolbar.find('.custom-speed-input');
+      const $confirmSpeedBtn = this.refs.$BRReadAloudToolbar.find('.confirm-speed-btn');
+      const $customSpeedLabel = this.refs.$BRReadAloudToolbar.find('.custom-speed-label');
+      const $playbackSpeedDropdown = this.refs.$BRReadAloudToolbar.find('.playback-speed');
+
+      $playbackSpeedDropdown.on('change', function() {
+        if ($(this).val() === 'custom') {
+          $customSpeedInput.show();
+          $confirmSpeedBtn.show();
+        } else {
+          $customSpeedInput.hide();
+          $confirmSpeedBtn.hide();
+          $customSpeedLabel.hide();
+        }
+      });
+
+      $confirmSpeedBtn.on('click', function() {
+        const customSpeed = parseFloat($customSpeedInput.val());
+        const isValid = $customSpeedInput[0].checkValidity();
+        if (isValid && !isNaN(customSpeed) && customSpeed >= 0.01 && customSpeed <= 5) {
+          this.ttsEngine.setPlaybackRate(customSpeed);
+          $customSpeedLabel.text(`${customSpeed}x`).show();
+          $customSpeedInput.hide();
+          $confirmSpeedBtn.hide();
+        } else {
+          alert('Please enter a valid speed value between 0 and 5 with up to two decimal places.');
+        }
+      }.bind(this));
     }
     return $el;
   };


### PR DESCRIPTION
Fixes #1211

Adds Custom option to html,
injects html for confirm button and number box. 

If the below code does fit standards and does not break any tests:
users will be able to have custom TTS speeds. 


Here are below photos of implementation. 

<img width="705" alt="Screenshot 2023-08-12 at 21 30 18" src="https://github.com/internetarchive/bookreader/assets/137233276/a3929d74-a839-4ea8-b34b-5adf85f514db">

<img width="718" alt="Screenshot 2023-08-12 at 21 29 14" src="https://github.com/internetarchive/bookreader/assets/137233276/6885ced9-cf3c-407a-b4e3-119d9d93cee0">

<img width="706" alt="Screenshot 2023-08-12 at 21 29 02" src="https://github.com/internetarchive/bookreader/assets/137233276/6f5b8add-4bf5-45b7-a9ce-d17664b32b0c">

<img width="693" alt="Screenshot 2023-08-12 at 21 30 39" src="https://github.com/internetarchive/bookreader/assets/137233276/d292a74c-8030-4ee7-bff1-634f5aeb5bcc">

<img width="696" alt="Screenshot 2023-08-12 at 21 30 49" src="https://github.com/internetarchive/bookreader/assets/137233276/657231e1-a94d-4692-8edf-b7c3e28c5ab5">


