### PR TITLE
Disable tooltips on touchscreens + fix on IA

### DIFF
--- a/BookReaderDemo/toggle_controls.html
+++ b/BookReaderDemo/toggle_controls.html
@@ -40,7 +40,7 @@
           template: function(br) {
             return '<button class="BRicon ' + this.className + ' desktop-only js-tooltip" data-param="foo">' +
                 '<div class="icon icon-onepg"></div>' +
-                '<span class="tooltip">Overridden control</span>' +
+                '<span class="BRtooltip">Overridden control</span>' +
               '</button>';
           }
         },

--- a/src/BookReader/Navbar/Navbar.js
+++ b/src/BookReader/Navbar/Navbar.js
@@ -41,7 +41,7 @@ export class Navbar {
     return `<li>
       <button class="BRicon ${option.className}" title="${option.label}">
         <div class="icon icon-${option.iconClassName}"></div>
-        <span class="tooltip">${option.label}</span>
+        <span class="BRtooltip">${option.label}</span>
       </button>
     </li>`;
   }
@@ -130,7 +130,7 @@ export class Navbar {
       .removeClass()
       .addClass(`icon icon-${iconClass}`)
       .end()
-      .find('.tooltip')
+      .find('.BRtooltip')
       .text(tooltipText);
   }
 

--- a/src/css/_BRnav.scss
+++ b/src/css/_BRnav.scss
@@ -104,8 +104,11 @@
     border-radius: 2px;
     background: transparent;
     outline: none;
-    &:hover .tooltip {
-      display: block;
+    @media (hover: hover) {
+      /* styles to apply on devices that support hover */
+      &:hover .BRtooltip {
+        display: block;
+      }
     }
     &.hide {
       display: none;

--- a/src/css/_controls.scss
+++ b/src/css/_controls.scss
@@ -1,7 +1,7 @@
 .BRcontrols {
   width: 100%;
 
-  .tooltip {
+  .BRtooltip {
     display: none;
     position: absolute;
     width: auto;
@@ -14,9 +14,10 @@
     color: $controlsText;
     border-radius: 3px;
     background: $tooltipBG;
+    pointer-events: none;
   }
 
-  .full .tooltip {
+  .full .BRtooltip {
     left: auto;
     right: 0;
     transform: translateX(0);

--- a/src/plugins/tts/plugin.tts.js
+++ b/src/plugins/tts/plugin.tts.js
@@ -195,7 +195,7 @@ BookReader.prototype.initNavbar = (function (super_) {
       $(`<li>
           <button class="BRicon read js-tooltip" title="${tooltips.readAloud}">
             <div class="icon icon-read-aloud"></div>
-            <span class="tooltip">${tooltips.readAloud}</span>
+            <span class="BRtooltip">${tooltips.readAloud}</span>
           </button>
         </li>`).insertBefore($el.find('.BRcontrols .BRicon.zoom_out').closest('li'));
     }


### PR DESCRIPTION
- Disable them on touch screens ; they show up at an awkward time and can be difficult to dismiss
- On IA, the tooltips were there (potentially blocking other UI elements) but opacity: 0 due to a CSS classname clash with `.tooltip`. Fix that.