### PR TITLE
Fix 1up zoom wrong on start/entering fs

### DIFF
--- a/src/BookReader/Mode1Up.js
+++ b/src/BookReader/Mode1Up.js
@@ -77,7 +77,7 @@ export class Mode1Up {
   jumpToIndex(index, pageX, pageY, noAnimate) {
     // Only smooth for small distances
     const distance = Math.abs(this.br.currentIndex() - index);
-    const smooth = !noAnimate && distance <= 4;
+    const smooth = !noAnimate && distance > 0 && distance <= 4;
     this.mode1UpLit.jumpToIndex(index, { smooth });
   }
 

--- a/src/BookReader/Mode1UpLit.js
+++ b/src/BookReader/Mode1UpLit.js
@@ -350,7 +350,7 @@ export class Mode1UpLit extends LitElement {
    */
   computeDefaultScale(page) {
     // Default to real size if it fits, otherwise default to full width
-    const containerWidthIn = this.coordSpace.visiblePixelsToWorldUnits(this.htmlDimensionsCacher.clientWidth);
+    const containerWidthIn = this.coordSpace.renderedPixelsToWorldUnits(this.clientWidth);
     return Math.min(1, containerWidthIn / (page.widthInches + 2 * this.SPACING_IN)) || 1;
   }
 


### PR DESCRIPTION
Closes #1130 .

Also fixes runaway scroll when going FS on mobile from 2up.

| Before on page load | After on page load |
| --- | -- |
| ![image](https://github.com/internetarchive/bookreader/assets/6251786/b24a4283-4e63-451c-ada9-8640594dc13a) | ![image](https://github.com/internetarchive/bookreader/assets/6251786/e1c8f9f2-1f10-46ce-aeda-535cf6a48c0f) |

Tested on:
- Windows/FF
- Windows/Chrome
- Windows/Edge
- Android/FF
- Android/Chrome
- Android/Edge
- Android/Samsung Internet
- iPad 16.6/Safari
- iPad 16.6/Chrome
- Mac/Safari 16.5 (BS)
- iPhone 14/Safari