### PR TITLE
Store selected TTS voice in localStorage

### DIFF
--- a/src/plugins/tts/AbstractTTSEngine.js
+++ b/src/plugins/tts/AbstractTTSEngine.js
@@ -142,7 +142,10 @@ export default class AbstractTTSEngine {
     // MS Edge fires voices changed randomly very often
     this.events.off('voiceschanged', this.updateBestVoice);
     this.voice = this.getVoices().find(voice => voice.voiceURI === voiceURI);
-    localStorage.setItem('BRplayback-voice', this.voice.voiceURI);
+    // if the current book has a language set, store the selected voice with the book language as a suffix
+    if (this.opts.bookLanguage) {
+      localStorage.setItem('BRplayback-voice-' + this.opts.bookLanguage, this.voice.voiceURI);
+    }
     if (this.activeSound) this.activeSound.setVoice(this.voice);
   }
 
@@ -222,8 +225,8 @@ export default class AbstractTTSEngine {
     // user languages that match the book language
     const matchingUserLangs = userLanguages.filter(lang => lang.startsWith(bookLanguage));
 
-    // First find the last chosen voice from localStorage
-    return AbstractTTSEngine.getMatchingStoredVoice(bookLangVoices)
+    // First try to find the last chosen voice from localStorage for the current book language
+    return AbstractTTSEngine.getMatchingStoredVoice(bookLangVoices, bookLanguage)
         // Try to find voices that intersect these two sets
         || AbstractTTSEngine.getMatchingVoice(matchingUserLangs, bookLangVoices)
         // no user languages match the books; let's return the best voice for the book language
@@ -237,13 +240,14 @@ export default class AbstractTTSEngine {
 
   /**
    * @private
-   * Get the voice string last selected by the user from localStorage.
-   * Returns undefined if no language is stored or found.
+   * Get the voice string last selected by the user for the book language from localStorage.
+   * Returns undefined if no voice is stored or found.
    * @param {SpeechSynthesisVoice[]} voices  browser voices to choose from
+   * @param {ISO6391} bookLanguage  book language to look for
    * @return {string | undefined}
    */
-  static getMatchingStoredVoice(voices) {
-    const storedVoice = localStorage.getItem('BRplayback-voice');
+  static getMatchingStoredVoice(voices, bookLanguage) {
+    const storedVoice = localStorage.getItem('BRplayback-voice-' + bookLanguage);
     return (storedVoice ? voices.find(v => v.voiceURI === storedVoice) : undefined);
   }
 

--- a/src/plugins/tts/AbstractTTSEngine.js
+++ b/src/plugins/tts/AbstractTTSEngine.js
@@ -240,11 +240,11 @@ export default class AbstractTTSEngine {
 
   /**
    * @private
-   * Get the voice string last selected by the user for the book language from localStorage.
+   * Get the voice last selected by the user for the book language from localStorage.
    * Returns undefined if no voice is stored or found.
    * @param {SpeechSynthesisVoice[]} voices  browser voices to choose from
    * @param {ISO6391} bookLanguage  book language to look for
-   * @return {string | undefined}
+   * @return {SpeechSynthesisVoice | undefined}
    */
   static getMatchingStoredVoice(voices, bookLanguage) {
     const storedVoice = localStorage.getItem('BRplayback-voice-' + bookLanguage);

--- a/src/plugins/tts/AbstractTTSEngine.js
+++ b/src/plugins/tts/AbstractTTSEngine.js
@@ -144,7 +144,7 @@ export default class AbstractTTSEngine {
     this.voice = this.getVoices().find(voice => voice.voiceURI === voiceURI);
     // if the current book has a language set, store the selected voice with the book language as a suffix
     if (this.opts.bookLanguage) {
-      localStorage.setItem('BRplayback-voice-' + this.opts.bookLanguage, this.voice.voiceURI);
+      localStorage.setItem(`BRtts-voice-${this.opts.bookLanguage}`, this.voice.voiceURI);
     }
     if (this.activeSound) this.activeSound.setVoice(this.voice);
   }
@@ -247,7 +247,7 @@ export default class AbstractTTSEngine {
    * @return {SpeechSynthesisVoice | undefined}
    */
   static getMatchingStoredVoice(voices, bookLanguage) {
-    const storedVoice = localStorage.getItem('BRplayback-voice-' + bookLanguage);
+    const storedVoice = localStorage.getItem(`BRtts-voice-${bookLanguage}`);
     return (storedVoice ? voices.find(v => v.voiceURI === storedVoice) : undefined);
   }
 

--- a/tests/jest/plugins/tts/AbstractTTSEngine.test.js
+++ b/tests/jest/plugins/tts/AbstractTTSEngine.test.js
@@ -111,6 +111,26 @@ for (const dummyVoice of [dummyVoiceHyphens, dummyVoiceUnderscores]) {
 
       expect(getBestBookVoice(voices, 'en', ['en-CA', 'en'])).toBe(voices[0]);
     });
+
+    test('choose stored language from localStorage', () => {
+      const voices = [
+        dummyVoice({lang: "en-US", voiceURI: "English US", default: true}),
+        dummyVoice({lang: "en-GB", voiceURI: "English GB",}),
+        dummyVoice({lang: "en-CA", voiceURI: "English CA",}),
+      ];
+      class DummyEngine extends AbstractTTSEngine {
+        getVoices() { return voices; }
+      };
+      const ttsEngine = new DummyEngine({...DUMMY_TTS_ENGINE_OPTS, bookLanguage: 'en'});
+      // simulates setting default voice on tts startup
+      ttsEngine.updateBestVoice();
+      // simulates user choosing a voice that matches the bookLanguage
+      // voice will be stored in localStorage
+      ttsEngine.setVoice(voices[2].voiceURI);
+
+      // expecting the voice to be selected by getMatchingStoredVoice and returned as best voice
+      expect(getBestBookVoice(voices, 'en', [])).toBe(voices[2]);
+    });
   });
 }
 

--- a/tests/jest/plugins/tts/AbstractTTSEngine.test.js
+++ b/tests/jest/plugins/tts/AbstractTTSEngine.test.js
@@ -115,12 +115,12 @@ for (const dummyVoice of [dummyVoiceHyphens, dummyVoiceUnderscores]) {
     test('choose stored language from localStorage', () => {
       const voices = [
         dummyVoice({lang: "en-US", voiceURI: "English US", default: true}),
-        dummyVoice({lang: "en-GB", voiceURI: "English GB",}),
-        dummyVoice({lang: "en-CA", voiceURI: "English CA",}),
+        dummyVoice({lang: "en-GB", voiceURI: "English GB"}),
+        dummyVoice({lang: "en-CA", voiceURI: "English CA"}),
       ];
       class DummyEngine extends AbstractTTSEngine {
         getVoices() { return voices; }
-      };
+      }
       const ttsEngine = new DummyEngine({...DUMMY_TTS_ENGINE_OPTS, bookLanguage: 'en'});
       // simulates setting default voice on tts startup
       ttsEngine.updateBestVoice();


### PR DESCRIPTION
Closes #1131 

TTS voice selection is stored after user selects from voice menu. On load, the last selected voice will attempt to be selected from localStorage and loaded as the active voice. If no voice is stored, the default will be selected.

Voice is stored under the localStorage key 'playback-voice'.