### PR TITLE
Fix TTS play/pause button remaining in paused state after re-opening

### DIFF
--- a/src/plugins/tts/AbstractTTSEngine.js
+++ b/src/plugins/tts/AbstractTTSEngine.js
@@ -80,6 +80,7 @@ export default class AbstractTTSEngine {
    */
   start(leafIndex, numLeafs) {
     this.playing = true;
+    this.paused = false;
     this.opts.onLoadingStart();
 
     this._chunkIterator = new PageChunkIterator(numLeafs, leafIndex, {
@@ -95,6 +96,7 @@ export default class AbstractTTSEngine {
   stop() {
     if (this.activeSound) this.activeSound.stop();
     this.playing = false;
+    this.paused = true;
     this._chunkIterator = null;
     this.activeSound = null;
     this.events.trigger('stop');

--- a/src/plugins/tts/plugin.tts.js
+++ b/src/plugins/tts/plugin.tts.js
@@ -251,7 +251,7 @@ BookReader.prototype.ttsPlayPause = function() {
     this.ttsToggle();
   } else {
     this.ttsEngine.togglePlayPause();
-    this.ttsUpdateState(this.ttsEngine.paused);
+    this.ttsUpdateState();
   }
 };
 


### PR DESCRIPTION
Closes #1247 

Previously the play/pause button for TTS would remain in the paused state after pausing TTS and closing/re-opening. This forced the user to click twice to pause playback.

Testing:

- Open TTS on a book
- Pause TTS playback
- Close TTS by selecting the 'Read aloud' button
- Re-open by selecting the 'Read aloud' button
- Verify that the button is in the correct state (playing)
- Verify that clicking the pause button actually pauses playback