### PR TITLE
Fix SelectionObserver firing for any element

### DIFF
--- a/src/BookReader/utils/SelectionObserver.js
+++ b/src/BookReader/utils/SelectionObserver.js
@@ -30,8 +30,10 @@ export class SelectionObserver {
     const sel = window.getSelection();
 
     if (!this.selecting && sel.toString()) {
+      const target = $(sel.anchorNode).closest(this.selector)[0];
+      if (!target) return;
+      this.target = target;
       this.selecting = true;
-      this.target = $(sel.anchorNode).closest(this.selector)[0];
       this.handler('started', this.target);
     }
 

--- a/tests/jest/BookReader/utils/SelectionObserver.test.js
+++ b/tests/jest/BookReader/utils/SelectionObserver.test.js
@@ -40,4 +40,18 @@ describe("SelectionObserver", () => {
     observer._onSelectionChange();
     expect(handler.callCount).toBe(2);
   });
+
+  test('Only fires when selection started in selector', () => {
+    const handler = sinon.spy();
+    const observer = new SelectionObserver(".text-layer", handler);
+    const target = document.createElement("div");
+    target.classList.add("text-layer");
+
+    // stub window.getSelection
+    const getSelectionStub = sinon.stub(window, "getSelection");
+    getSelectionStub.returns({ toString: () => "test", anchorNode: document.body });
+    observer._onSelectionChange();
+    expect(handler.callCount).toBe(0);
+    expect(observer.selecting).toBe(false);
+  });
 });


### PR DESCRIPTION
Fix common sentry error. It doesn't impact users in any way, but just noisy. It errors when there's a text selection outside the BR!

Tested text selection mode changes still work on Win + FF/Chrome; iPad