### PR TITLE
Gitignore .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ BookReaderDev
 node_modules/
 .DS_Store
 coverage*/
+.env
 
 .vscode


### PR DESCRIPTION
Use this to store helpful env variables like browserstack keys. Gitiginore that.