### PR TITLE
Add ToC icon display if enableChaptersPlugin

### DIFF
--- a/src/BookNavigator/book-navigator.js
+++ b/src/BookNavigator/book-navigator.js
@@ -67,6 +67,7 @@ export class BookNavigator extends LitElement {
        * sets exit FS button (`this.fullscreenBranding1)
        * when `br.options.enableFSLogoShortcut`
        */
+      'chapters',
       'fullscreen',
       'volumes',
       'search',
@@ -359,7 +360,6 @@ export class BookNavigator extends LitElement {
     }
 
     this.menuShortcuts.push(this.menuProviders[menuId]);
-
     this.sortMenuShortcuts();
     this.emitMenuShortcutsUpdated();
   }

--- a/src/plugins/plugin.chapters.js
+++ b/src/plugins/plugin.chapters.js
@@ -76,6 +76,7 @@ BookReader.prototype._chaptersRender = function() {
     }}"
     />`,
   };
+  shell.addMenuShortcut('chapters');
   shell.updateMenuContents();
   this._tocEntries.forEach((tocEntry, i) => this._chaptersRenderMarker(tocEntry, i));
 };

--- a/tests/jest/BookNavigator/book-navigator.test.js
+++ b/tests/jest/BookNavigator/book-navigator.test.js
@@ -320,10 +320,13 @@ describe('<book-navigator>', () => {
       describe('Shortcuts', () => {
         test('has specific order of menu shortcuts to show', () => {
           const el = fixtureSync(container());
-          expect(el.shortcutOrder[0]).toEqual('fullscreen');
-          expect(el.shortcutOrder[1]).toEqual('volumes');
-          expect(el.shortcutOrder[2]).toEqual('search');
-          expect(el.shortcutOrder[3]).toEqual('bookmarks');
+          expect(el.shortcutOrder).toEqual([
+            'chapters',
+            'fullscreen',
+            'volumes',
+            'search',
+            'bookmarks'
+          ]);
         });
       });
 

--- a/tests/jest/plugins/plugin.chapters.test.js
+++ b/tests/jest/plugins/plugin.chapters.test.js
@@ -157,11 +157,13 @@ describe("BRChaptersPlugin", () => {
         _chaptersRenderMarker: sinon.stub(),
         shell: {
           menuProviders: {},
+          addMenuShortcut: sinon.stub(),
           updateMenuContents: sinon.stub(),
         }
       };
       BookReader.prototype._chaptersRender.call(fakeBR);
       expect(fakeBR.shell.menuProviders['chapters']).toBeTruthy();
+      expect(fakeBR.shell.addMenuShortcut.callCount).toBe(1);
       expect(fakeBR.shell.updateMenuContents.callCount).toBe(1);
       expect(fakeBR._chaptersRenderMarker.callCount).toBeGreaterThan(1);
     });


### PR DESCRIPTION
Testing:

- goto: https://deploy-preview-1289--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=adventureofsherl0000unse
- check if Table Of Contents icon is present in the sidebar menu
- then check other books without ToC like: https://deploy-preview-1289--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=goody
- the ToC icon should not be present in the page/book without ToC

