### PR TITLE
side panels - show downloads before visual adjustments

### DIFF
--- a/src/BookNavigator/book-navigator.js
+++ b/src/BookNavigator/book-navigator.js
@@ -313,7 +313,7 @@ export class BookNavigator extends LitElement {
 
     if (this.shouldShowDownloadsMenu()) {
       downloads?.update(this.downloadableTypes);
-      availableMenus.splice(1, 0, downloads);
+      availableMenus.splice(-2, 0, downloads);
     }
 
     const event = new CustomEvent(


### PR DESCRIPTION
## Problem: Side panel -> Downloads panel gets inserted at wrong place.
This causes icons to "jump" when toggling between an side panel & shortcuts view
- incorrect:
<img height="180" alt="image" src="https://github.com/internetarchive/bookreader/assets/7840857/389bbf22-13bd-4eb9-a0a3-f61538cd2efe">


## Solution: Always put downloads panel, when available, Before Visual Adjustments
<img height="180" alt="image" src="https://github.com/internetarchive/bookreader/assets/7840857/1142344f-5dd2-4b70-9559-2088015a3080">

## Testing https://deploy-preview-1297--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=adventureofsherl0000unse
- open side panel, downloads is below bookmarks, above visual adjustments
- Click demo option "Toggle Logged In View" -> bookmarks panel changes to from Log in button to add a bookmark
  - add a bookmark (no XHR POST happens, just client side UI available)
  - Toggle side panel -> ✅ Bookmark Shortcut icon shows -> open side panel -> ✅ shortcut icons match open side panel icons & Downloads is before visual adjustments
  - 
<img width="183" alt="image" src="https://github.com/internetarchive/bookreader/assets/7840857/5a663b04-8061-4c68-88f8-3c1e17117b7f">
<img width="224" alt="image" src="https://github.com/internetarchive/bookreader/assets/7840857/edede999-9828-47e5-b3e3-9a287bc7efde">
<img width="314" alt="image" src="https://github.com/internetarchive/bookreader/assets/7840857/8b59a9f4-4b2b-4a5b-995b-6b45e22dda59">

