### PR TITLE
Make reduceSet option allow a custom ReduceSet object.

### DIFF
--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -124,10 +124,14 @@ BookReader.prototype.setup = function(options) {
   this.defaults = options.defaults;
   this.padding = options.padding;
 
-  this.reduceSet = NAMED_REDUCE_SETS[options.reduceSet];
-  if (!this.reduceSet) {
-    console.warn(`Invalid reduceSet ${options.reduceSet}. Ignoring.`);
-    this.reduceSet = NAMED_REDUCE_SETS[DEFAULT_OPTIONS.reduceSet];
+  if (typeof(options.reduceSet) === 'string') {
+    this.reduceSet = NAMED_REDUCE_SETS[options.reduceSet];
+    if (!this.reduceSet) {
+      console.warn(`Invalid reduceSet ${options.reduceSet}. Ignoring.`);
+      this.reduceSet = NAMED_REDUCE_SETS[DEFAULT_OPTIONS.reduceSet];
+    }
+  } else {
+    this.reduceSet = options.reduceSet;
   }
 
   /** @type {number}

--- a/src/BookReader/options.js
+++ b/src/BookReader/options.js
@@ -49,7 +49,7 @@ export const DEFAULT_OPTIONS = {
    */
   imagesBaseURL: '/BookReader/images/',
 
-  /** @type {'pow2' | 'integer'} What reduces are valid for getURI. */
+  /** @type {'pow2' | 'integer' | import('./ReduceSet.js').ReduceSet} What reduces are valid for getURI. */
   reduceSet: 'pow2',
 
   /**


### PR DESCRIPTION
Besides the two default named options, `pow2` and `integer`, add another option for a custom ReduceSet object.