### PR TITLE
Bump babel minimums; remove over 100kb from bundles!

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,7 @@ module.exports = {
       "@babel/preset-env",
       process.env.NODE_ENV == "test" ? { targets: { node: process.version } } :
         process.env.NODE_ENV == "development" ? { targets: "last 2 Chrome versions, last 2 Firefox versions, last 2 Safari versions, last 2 Edge versions" } : {
-          targets: "> 2%, ie 11, edge 14, samsung > 9, OperaMini all, UCAndroid > 12, Safari >= 9",
+          targets: "> 2%, edge >= 14, samsung > 9, UCAndroid > 12, Safari >= 10",
           useBuiltIns: "usage",
           corejs: 3
         }


### PR DESCRIPTION
Remove ie 11, opera mini, iOS9 ; no longer supported by archive.org and currently not working.

Deploy with care ; because of these we were basically getting _every_ polyfill. Even though these 3 specific version are no longer supported, removing their polyfills could cause other browsers to break, so: deploy with care.