### PR TITLE
Ensure bookreader buttons inherit body font stack

### DIFF
--- a/src/BookNavigator/assets/button-base.js
+++ b/src/BookNavigator/assets/button-base.js
@@ -12,6 +12,7 @@ export default css`
     text-align: center;
     vertical-align: middle;
     font-size: 1.4rem;
+    font-family: inherit;
     display: inline-block;
     padding: .6rem 1.2rem;
     border: 1px solid transparent;


### PR DESCRIPTION
## Problem
Currently, the "Add bookmark" button in the side panel is defaulting to Arial for its font, when it should use the same Helvetica Neue font stack as the other buttons. 

It seems that this is because other buttons such as the "Login" button are actually `a` elements styled as buttons, so they correctly inherit the body font-stack:

<img width="275" alt="Login button" src="https://github.com/user-attachments/assets/97ac3b9b-9893-4b85-af8f-88538e099308">

Whereas the default `button` styles for the "Add bookmark" button seem to be overriding the inheritance and defaulting to Arial:

![Incorrect font image](https://github.com/user-attachments/assets/f8c95033-c460-47b7-8a37-539757a69730)

## Solution
Very simple! I just added `font-family: inherit` to the `ia-button` class, which should ensure this and any other `button.ia-button` elements in the side panel retain the correct inherited font:

<img width="192" alt="Button with correct font" src="https://github.com/user-attachments/assets/25efc38a-f9f6-437c-b2f8-246888a898e0">

## Testing
1. Go to the bookreader page for an always available book
2. Navigate to the bookmarks section on the side panel
3. Confirm that the font for "Add bookmark" is Helvetica Neue
4. Check out and confirm the fonts for a few other side panel buttons, by:
  - Navigating to downloads (see: "Get PDF" and/or "Get ePUb")
  - Logging out and looking at the bookmarks section for the same book (see: the "Login" button)
