### PR TITLE
Rephrase visual adjustment text to improve consistency

### DIFF
--- a/src/BookNavigator/visual-adjustments/visual-adjustments-provider.js
+++ b/src/BookNavigator/visual-adjustments/visual-adjustments-provider.js
@@ -20,11 +20,11 @@ const visualAdjustmentOptions = [{
   value: 100,
 }, {
   id: 'invert',
-  name: 'Inverted colors (dark mode)',
+  name: 'Invert colors (dark mode)',
   active: false,
 }, {
   id: 'grayscale',
-  name: 'Grayscale',
+  name: 'Convert to grayscale',
   active: false,
 }];
 

--- a/src/BookNavigator/visual-adjustments/visual-adjustments.js
+++ b/src/BookNavigator/visual-adjustments/visual-adjustments.js
@@ -157,7 +157,7 @@ export class IABookVisualAdjustments extends LitElement {
 
   get zoomControls() {
     return html`
-      <h4>Zoom</h4>
+      <h4>Adjust zoom</h4>
       <button class="zoom_out" @click=${this.emitZoomOut} title="zoom out">
         <ia-icon-magnify-minus></ia-icon-magnify-minus>
       </button>

--- a/tests/jest/BookNavigator/visual-adjustments.test.js
+++ b/tests/jest/BookNavigator/visual-adjustments.test.js
@@ -16,7 +16,7 @@ const options = [{
   value: 100,
 }, {
   id: 'invert',
-  name: 'Invert colors',
+  name: 'Invert colors (dark mode)',
   active: false,
 }, {
   id: 'brightness',


### PR DESCRIPTION
## Problem
The visual adjustment text in the side panel is currently grammatically inconsistent, which can make it a bit confusing for readers:

![Current visual adjustment UI](https://github.com/user-attachments/assets/e05d5297-f9a7-4ab5-aec5-b8cd1cd89257)

## Solution
Simply rephrase a few of the phrases to make them all consistent:
- “Inverted colors (dark mode)” should read → “Invert colors (dark mode)”
- “Grayscale” should read → “Convert to grayscale”
- “Zoom” should read → “Adjust zoom”

## UI Result

<img width="279" alt="New visual adjustment text" src="https://github.com/user-attachments/assets/b6a26c24-0a6a-4430-b8d6-d95ce653882c">

## Technical Notes
Probably unnecessary, but I also updated the text in `visual-adjustments.test.js` just in case.

## QA
1. Go to the [PR bookreader instance](https://deploy-preview-1338--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=adventureofsherl0000unse#page/28/mode/2up)
2. Navigate to the Visual Adjustments in the side panel
3. Confirm that they now read:
 - Adjust brightness
 - Adjust contrast
 - Invert colors (dark mode)
 - Convert to grayscale
 - Adjust zoom
 4. Confirm that each of the adjustments still works as expected