### PR TITLE
Bump cache action to v4

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -20,7 +20,7 @@ jobs:
         # Keep in sync with netlify.toml
         node-version: 20.x
     - name: Cache node_modules
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache
       with:
         # Caching node_modules isn't recommended because it can break across
@@ -42,13 +42,13 @@ jobs:
       with:
         node-version: 20.x
     - name: Load node_modules from cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         # Use node_modules from previous jobs
         path: 'node_modules'
         key: ${{ runner.os }}-node-20-${{ hashFiles('package*.json') }}
     - name: Cache BookReader/
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: build-cache
       with:
         # Cache the build files so we don't have to build twice for e2e tests
@@ -66,7 +66,7 @@ jobs:
       with:
         node-version: 20.x
     - name: Load node_modules from cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         # Use node_modules from previous jobs
         path: 'node_modules'
@@ -86,13 +86,13 @@ jobs:
       with:
         node-version: 20.x
     - name: Load node_modules from cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         # Use node_modules from previous jobs
         path: 'node_modules'
         key: ${{ runner.os }}-node-20-${{ hashFiles('package*.json') }}
     - name: Load BookReader/ from cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         # Cache the build files so we don't have to build twice for e2e tests
         path: 'BookReader'


### PR DESCRIPTION
There don't appear to be any breaking [changes between v3 and v4 as of writing](https://github.com/actions/cache/releases).

Fixes this warning:
> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/cache@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

https://github.com/internetarchive/bookreader/actions/runs/10930025193
