### PR TITLE
Fix Toolbar requiring SearchView.init having already been called

### DIFF
--- a/BookReaderDemo/IADemoBr.js
+++ b/BookReaderDemo/IADemoBr.js
@@ -45,6 +45,14 @@ const initializeBookReader = (brManifest) => {
     flipDelay: urlParams.flipDelay || 5000
   };
 
+  function getFromUrl(name, def) {
+    if (urlParams.has(name)) {
+      return urlParams.get(name);
+    } else {
+      return def;
+    }
+  }
+
   const options = {
     el: '#BookReader',
     /* Url plugin - IA uses History mode for URL */
@@ -62,7 +70,7 @@ const initializeBookReader = (brManifest) => {
     initialSearchTerm: searchTerm ? searchTerm : '',
     // leaving this option commented out bc we change given user agent on archive.org
     // onePage: { autofit: <?=json_encode($this->ios ? 'width' : 'auto')?> },
-    showToolbar: false,
+    showToolbar: getFromUrl('options.showToolbar', 'false') === 'true',
     /* Multiple volumes */
     // To show multiple volumes:
     enableMultipleBooks: false, // turn this on

--- a/BookReaderDemo/IADemoBr.js
+++ b/BookReaderDemo/IADemoBr.js
@@ -5,6 +5,13 @@ import { extraVolOptions, custvolumesManifest } from './ia-multiple-volumes-mani
  * This is how Internet Archive loads bookreader
  */
 const urlParams = new URLSearchParams(window.location.search);
+function getFromUrl(name, def) {
+  if (urlParams.has(name)) {
+    return urlParams.get(name);
+  } else {
+    return def;
+  }
+}
 
 const ocaid = urlParams.get('ocaid');
 const openFullImmersionTheater = urlParams.get('view') === 'theater';
@@ -41,17 +48,9 @@ const initializeBookReader = (brManifest) => {
 
   const customAutoflipParams = {
     autoflip: !!autoflip,
-    flipSpeed: urlParams.flipSpeed || 2000,
-    flipDelay: urlParams.flipDelay || 5000
+    flipSpeed: parseFloat(getFromUrl('flipSpeed', '2000')),
+    flipDelay: parseFloat(getFromUrl('flipDelay', '5000')),
   };
-
-  function getFromUrl(name, def) {
-    if (urlParams.has(name)) {
-      return urlParams.get(name);
-    } else {
-      return def;
-    }
-  }
 
   const options = {
     el: '#BookReader',

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -66,7 +66,17 @@ BookReader.prototype.setup = (function (super_) {
     /** @type { {[pageIndex: number]: SearchInsideMatchBox[]} } */
     this._searchBoxesByIndex = {};
 
-    this.searchView = undefined;
+    if (this.enableSearch) {
+      this.searchView = new SearchView({
+        br: this,
+        searchCancelledCallback: () => {
+          this._cancelSearch();
+          this.trigger('SearchCanceled', { term: this.searchTerm, instance: this });
+        }
+      });
+    } else {
+      this.searchView = null;
+    }
   };
 })(BookReader.prototype.setup);
 
@@ -74,15 +84,10 @@ BookReader.prototype.setup = (function (super_) {
 BookReader.prototype.init = (function (super_) {
   return function () {
     super_.call(this);
-    // give SearchView the most complete bookreader state
-    this.searchView = new SearchView({
-      br: this,
-      searchCancelledCallback: () => {
-        this._cancelSearch();
-        this.trigger('SearchCanceled', { term: this.searchTerm, instance: this });
-      }
-    });
-    if (this.options.enableSearch && this.options.initialSearchTerm) {
+    if (!this.enableSearch) return;
+
+    this.searchView.init();
+    if (this.options.initialSearchTerm) {
       /**
        * this.search() take two parameter
        * 1. this.options.initialSearchTerm - search term

--- a/src/plugins/search/view.js
+++ b/src/plugins/search/view.js
@@ -11,8 +11,11 @@ class SearchView {
     this.br = br;
     this.matches = [];
     this.cacheDOMElements();
-    this.bindEvents();
     this.cancelSearch = searchCancelledCallback;
+  }
+
+  init() {
+    this.bindEvents();
   }
 
   cacheDOMElements() {


### PR DESCRIPTION
Closes #1344

QA: https://deploy-preview-1345--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=cu31924009344999&options.showToolbar=true

Note the `options.showToolbar=true` option; that enables the code path that caused this to error