### PR TITLE
WEBDEV-7113 Switch to new Thorium URL

### DIFF
--- a/src/BookNavigator/downloads/downloads.js
+++ b/src/BookNavigator/downloads/downloads.js
@@ -75,7 +75,7 @@ export class IABookDownloads extends LitElement {
     <ul>
       <li><a href="https://librarysimplified.org/simplye/" rel="noopener noreferrer nofollow" target="_blank">Install SimplyE</a></li>
       <li><a href="https://www.demarque.com/en-aldiko" rel="noopener noreferrer nofollow" target="_blank">Install Aldiko</a></li>
-      <li><a href="https://www.edrlab.org/software/thorium-reader/" rel="noopener noreferrer nofollow" target="_blank">Install Thorium</a></li>
+      <li><a href="https://thorium.edrlab.org/" rel="noopener noreferrer nofollow" target="_blank">Install Thorium</a></li>
     </ul>
   `;
   }


### PR DESCRIPTION
Currently, our "Install Thorium" link takes you to a more general [about page](https://www.edrlab.org/software/thorium-reader/). To avoid patron confusion, we should instead link to their new [download page](https://thorium.edrlab.org/).