### PR TITLE
Fix failing e2e tests

### DIFF
--- a/tests/e2e/autoplay.test.js
+++ b/tests/e2e/autoplay.test.js
@@ -2,8 +2,8 @@ import { ClientFunction } from 'testcafe';
 import params from './helpers/params';
 
 const getLocationHref = ClientFunction(() => window.location.href.toString());
-const FLIP_SPEED = 1000;
-const FIRST_PAGE_DELAY = 2000;
+const FLIP_SPEED = 2000;
+const FIRST_PAGE_DELAY = 6000;
 
 fixture `Autoplay plugin`.page `${params.baseUrl}/BookReaderDemo/demo-internetarchive.html?ocaid=goody&autoflip=1`;
 

--- a/tests/e2e/helpers/mockSearch.js
+++ b/tests/e2e/helpers/mockSearch.js
@@ -4,21 +4,18 @@ export const PAGE_FIRST_RESULT = 30;
 
 export const SEARCH_INSIDE_URL_RE  = /https:\/\/ia[0-9]+\.us\.archive\.org\/fulltext\/inside\.php\?item_id=.*/;
 
-//adding jQueryxxxxxxxx-xxxxxxxx (semi-random numbers) from request url to returned search request object
 /** Mock response for a matching search term. */
 export function mockResponseFound(req, res) {
-  const requestUrl = new URL(req.url);
-  const jqueryUrl = requestUrl.searchParams.get("callback");
-  const wholeString = jqueryUrl + '(' + JSON.stringify(MOCKED_RESPONSE_FOUND) + ')';
-  res.setBody(wholeString);
+  res.headers['Access-Control-Allow-Origin'] = '*';
+  res.headers['Content-Type'] = 'application/json';
+  res.setBody(JSON.stringify(MOCKED_RESPONSE_FOUND));
 }
 
 /** Mock response for a matching search term. */
 export function mockResponseNotFound(req, res) {
-  const requestUrl = new URL(req.url);
-  const jqueryUrl = requestUrl.searchParams.get("callback");
-  const wholeString = jqueryUrl + '(' + JSON.stringify(MOCKED_RESPONSE_NOT_FOUND) + ')';
-  res.setBody(wholeString);
+  res.headers['Access-Control-Allow-Origin'] = '*';
+  res.headers['Content-Type'] = 'application/json';
+  res.setBody(JSON.stringify(MOCKED_RESPONSE_NOT_FOUND));
 }
 
 const PAGE_FIRST_RESULT_ADJUSTED = PAGE_FIRST_RESULT + 12;


### PR DESCRIPTION
These were broken when we switched from JSONP requests to JSON requests as part of the CSP migration.