### PR TITLE
Migrate AutoplayPlugin to BookReaderPlugin

### DIFF
--- a/src/BookReader/Mode2UpLit.js
+++ b/src/BookReader/Mode2UpLit.js
@@ -493,13 +493,14 @@ export class Mode2UpLit extends LitElement {
   /**
    * @param {'left' | 'right' | 'next' | 'prev' | PageIndex | PageModel | {left: PageModel | null, right: PageModel | null}} nextSpread
    */
-  async flipAnimation(nextSpread, { animate = true } = {}) {
+  async flipAnimation(nextSpread, { animate = true, flipSpeed = this.flipSpeed } = {}) {
     const curSpread = (this.pageLeft || this.pageRight)?.spread;
     if (!curSpread) {
       // Nothings been actually rendered yet! Will be corrected during initFirstRender
       return;
     }
 
+    flipSpeed = flipSpeed || this.flipSpeed; // Handle null
     nextSpread = this.parseNextSpread(nextSpread);
     if (this.activeFlip || !nextSpread) return;
 
@@ -559,7 +560,7 @@ export class Mode2UpLit extends LitElement {
 
       /** @type {KeyframeAnimationOptions} */
       const animationStyle = {
-        duration: this.flipSpeed + this.activeFlip.pagesFlippingCount,
+        duration: flipSpeed + this.activeFlip.pagesFlippingCount,
         easing: 'ease-in',
         fill: 'none',
       };

--- a/src/BookReader/options.js
+++ b/src/BookReader/options.js
@@ -143,6 +143,8 @@ export const DEFAULT_OPTIONS = {
   plugins: {
     /** @type {import('../plugins/plugin.archive_analytics.js').ArchiveAnalyticsPlugin['options']}*/
     archiveAnalytics: null,
+    /** @type {import('../plugins/plugin.autoplay.js').AutoplayPlugin['options']}*/
+    autoplay: null,
     /** @type {import('../plugins/plugin.text_selection.js').TextSelectionPlugin['options']} */
     textSelection: null,
   },

--- a/src/BookReader/utils.js
+++ b/src/BookReader/utils.js
@@ -288,3 +288,13 @@ export function promisifyEvent(target, eventType) {
 export function escapeRegExp(string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
 }
+
+/**
+ * @param {number | 'fast' | 'slow' | string} speed
+ * Parsing of the jquery animation speed; see https://api.jquery.com/animate/
+ */
+export function parseAnimationSpeed(speed) {
+  if (speed === 'slow') return 600;
+  if (speed === 'fast') return 200;
+  return parseInt(speed, 10);
+}

--- a/src/BookReaderPlugin.js
+++ b/src/BookReaderPlugin.js
@@ -33,4 +33,7 @@ export class BookReaderPlugin {
    */
   _configurePageContainer(pageContainer) {
   }
+
+  /** @abstract @protected */
+  _bindNavigationHandlers() {}
 }

--- a/src/plugins/plugin.autoplay.js
+++ b/src/plugins/plugin.autoplay.js
@@ -21,13 +21,13 @@ export class AutoplayPlugin extends BookReaderPlugin {
     urlParams: true,
   }
 
-  autoTimer = null;
+  timer = null;
 
   /** @override */
   init() {
     if (!this.options.enabled) return;
 
-    this.br.bind(EVENTS.stop, () => this.autoStop());
+    this.br.bind(EVENTS.stop, () => this.stop());
 
     if (this.options.urlParams) {
       const urlParams = new URLSearchParams(window.location.search);
@@ -38,7 +38,7 @@ export class AutoplayPlugin extends BookReaderPlugin {
         this.options.flipDelay = parseAnimationSpeed(urlParams.get('flipDelay')) || this.options.flipDelay;
       }
       if (urlParams.get('autoflip') === '1') {
-        this.autoToggle();
+        this.toggle();
       }
     }
   }
@@ -50,12 +50,12 @@ export class AutoplayPlugin extends BookReaderPlugin {
     const jIcons = this.br.$('.BRicon');
 
     jIcons.filter('.play').on('click', () => {
-      this.autoToggle();
+      this.toggle();
       return false;
     });
 
     jIcons.filter('.pause').on('click', () => {
-      this.autoToggle();
+      this.toggle();
       return false;
     });
   }
@@ -66,7 +66,7 @@ export class AutoplayPlugin extends BookReaderPlugin {
    * @param {number} overrides.flipSpeed
    * @param {number} overrides.flipDelay
    */
-  autoToggle(overrides = null) {
+  toggle(overrides = null) {
     if (!this.options.enabled) return;
 
     Object.assign(this.options, overrides);
@@ -78,7 +78,7 @@ export class AutoplayPlugin extends BookReaderPlugin {
       this.br.switchMode(this.br.constMode2up);
     }
 
-    if (null == this.autoTimer) {
+    if (null == this.timer) {
       // $$$ Draw events currently cause layout problems when they occur during animation.
       //     There is a specific problem when changing from 1-up immediately to autoplay in RTL so
       //     we workaround for now by not triggering immediate animation in that case.
@@ -92,7 +92,7 @@ export class AutoplayPlugin extends BookReaderPlugin {
 
       this.br.$('.play').hide();
       this.br.$('.pause').show();
-      this.autoTimer = setInterval(() => {
+      this.timer = setInterval(() => {
         if (this.br.animating) return;
 
         if (Math.max(this.br.twoPage.currentIndexL, this.br.twoPage.currentIndexR) >= this.br.book.getNumLeafs() - 1) {
@@ -102,21 +102,21 @@ export class AutoplayPlugin extends BookReaderPlugin {
         }
       }, parseAnimationSpeed(this.options.flipDelay));
     } else {
-      this.autoStop();
+      this.stop();
     }
   }
 
   /**
    * Stop autoplay mode, allowing animations to finish
    */
-  autoStop() {
+  stop() {
     if (!this.options.enabled) return;
 
-    if (null != this.autoTimer) {
-      clearInterval(this.autoTimer);
+    if (null != this.timer) {
+      clearInterval(this.timer);
       this.br.$('.pause').hide();
       this.br.$('.play').show();
-      this.autoTimer = null;
+      this.timer = null;
     }
   }
 }

--- a/src/plugins/plugin.autoplay.js
+++ b/src/plugins/plugin.autoplay.js
@@ -12,9 +12,8 @@ export class AutoplayPlugin extends BookReaderPlugin {
     /**
      * @type {number | 'fast' | 'slow'}
      * How quickly the flip animation should run.
-     * Defaults to global BookReader flipSpeed option if unspecified
      **/
-    flipSpeed: null,
+    flipSpeed: 1500,
     /** How long to pause on each page between flips */
     flipDelay: 5000,
     /** Allow controlling the autoflip/speed/delay from the url */

--- a/src/plugins/plugin.autoplay.js
+++ b/src/plugins/plugin.autoplay.js
@@ -1,128 +1,125 @@
-/*global BookReader */
+// @ts-check
+import { EVENTS } from "../BookReader/events";
+import { parseAnimationSpeed } from "../BookReader/utils";
+import { BookReaderPlugin } from "../BookReaderPlugin";
 
 /**
  * Plugin which adds an autoplay feature. Useful for kiosk situations.
  */
-jQuery.extend(BookReader.defaultOptions, {
-  enableAutoPlayPlugin: true,
-});
-
-/**
- * @override BookReader.setup
- */
-BookReader.prototype.setup = (function(super_) {
-  return function (options) {
-    super_.call(this, options);
-
-    this.autoTimer = null;
-    this.flipDelay = 5000;
-  };
-})(BookReader.prototype.setup);
-
-/**
- * @override BookReader.init
- */
-BookReader.prototype.init = (function(super_) {
-  return function (options) {
-    super_.call(this, options);
-
-    if (!this.options.enableAutoPlayPlugin) return;
-
-    this.bind(BookReader.eventNames.stop, () => this.autoStop());
-
-    const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.get('autoflip') === '1') {
-      this.autoToggle();
-    }
-  };
-})(BookReader.prototype.init);
-
-/**
- * @override BookReader.bindNavigationHandlers
- */
-BookReader.prototype.bindNavigationHandlers = (function(super_) {
-  return function() {
-    super_.call(this);
-
-    if (!this.options.enableAutoPlayPlugin) return;
-
-    const jIcons = this.$('.BRicon');
-
-    jIcons.filter('.play').click(() => {
-      this.autoToggle();
-      return false;
-    });
-
-    jIcons.filter('.pause').click(() => {
-      this.autoToggle();
-      return false;
-    });
-  };
-})(BookReader.prototype.bindNavigationHandlers);
-
-/**
- * Starts autoplay mode
- * @param {object} overrides
- * @param {number} overrides.flipSpeed
- * @param {number} overrides.flipDelay
- */
-BookReader.prototype.autoToggle = function(overrides) {
-  if (!this.options.enableAutoPlayPlugin) return;
-
-  const options = $.extend({
-    flipSpeed: this.flipSpeed,
-    flipDelay: this.flipDelay,
-  }, overrides);
-
-  this.flipSpeed = typeof options.flipSpeed === "number" ? options.flipSpeed : this.flipSpeed;
-  this.flipDelay = typeof options.flipDelay === "number" ? options.flipDelay : this.flipDelay;
-  this.trigger(BookReader.eventNames.stop);
-
-  let bComingFrom1up = false;
-  if (this.constMode2up != this.mode) {
-    bComingFrom1up = true;
-    this.switchMode(this.constMode2up);
+export class AutoplayPlugin extends BookReaderPlugin {
+  options = {
+    enabled: true,
+    /**
+     * @type {number | 'fast' | 'slow'}
+     * How quickly the flip animation should run.
+     * Defaults to global BookReader flipSpeed option if unspecified
+     **/
+    flipSpeed: null,
+    /** How long to pause on each page between flips */
+    flipDelay: 5000,
+    /** Allow controlling the autoflip/speed/delay from the url */
+    urlParams: true,
   }
 
-  if (null == this.autoTimer) {
-    // $$$ Draw events currently cause layout problems when they occur during animation.
-    //     There is a specific problem when changing from 1-up immediately to autoplay in RTL so
-    //     we workaround for now by not triggering immediate animation in that case.
-    //     See https://bugs.launchpad.net/gnubook/+bug/328327
-    if (('rl' == this.pageProgression) && bComingFrom1up) {
-      // don't flip immediately -- wait until timer fires
-    } else {
-      // flip immediately
-      this.next({ triggerStop: false });
-    }
+  autoTimer = null;
 
-    this.$('.play').hide();
-    this.$('.pause').show();
-    this.autoTimer = setInterval(() => {
-      if (this.animating) return;
+  /** @override */
+  init() {
+    if (!this.options.enabled) return;
 
-      if (Math.max(this.twoPage.currentIndexL, this.twoPage.currentIndexR) >= this.book.getNumLeafs() - 1) {
-        this.prev({ triggerStop: false }); // $$$ really what we want?
-      } else {
-        this.next({ triggerStop: false });
+    this.br.bind(EVENTS.stop, () => this.autoStop());
+
+    if (this.options.urlParams) {
+      const urlParams = new URLSearchParams(window.location.search);
+      if (urlParams.get('flipSpeed')) {
+        this.options.flipSpeed = parseAnimationSpeed(urlParams.get('flipSpeed')) || this.options.flipSpeed;
       }
-    }, this.flipDelay);
-  } else {
-    this.autoStop();
+      if (urlParams.get('flipDelay')) {
+        this.options.flipDelay = parseAnimationSpeed(urlParams.get('flipDelay')) || this.options.flipDelay;
+      }
+      if (urlParams.get('autoflip') === '1') {
+        this.autoToggle();
+      }
+    }
   }
-};
 
-/**
- * Stop autoplay mode, allowing animations to finish
- */
-BookReader.prototype.autoStop = function() {
-  if (!this.options.enableAutoPlayPlugin) return;
+  /** @override */
+  _bindNavigationHandlers() {
+    if (!this.options.enabled) return;
 
-  if (null != this.autoTimer) {
-    clearInterval(this.autoTimer);
-    this.flipSpeed = 'fast';
-    this.$('.pause').hide();
-    this.$('.play').show();
-    this.autoTimer = null;
+    const jIcons = this.br.$('.BRicon');
+
+    jIcons.filter('.play').on('click', () => {
+      this.autoToggle();
+      return false;
+    });
+
+    jIcons.filter('.pause').on('click', () => {
+      this.autoToggle();
+      return false;
+    });
   }
-};
+
+  /**
+   * Starts autoplay mode
+   * @param {object} overrides
+   * @param {number} overrides.flipSpeed
+   * @param {number} overrides.flipDelay
+   */
+  autoToggle(overrides = null) {
+    if (!this.options.enabled) return;
+
+    Object.assign(this.options, overrides);
+    this.br.trigger(EVENTS.stop);
+
+    let bComingFrom1up = false;
+    if (this.br.constMode2up != this.br.mode) {
+      bComingFrom1up = true;
+      this.br.switchMode(this.br.constMode2up);
+    }
+
+    if (null == this.autoTimer) {
+      // $$$ Draw events currently cause layout problems when they occur during animation.
+      //     There is a specific problem when changing from 1-up immediately to autoplay in RTL so
+      //     we workaround for now by not triggering immediate animation in that case.
+      //     See https://bugs.launchpad.net/gnubook/+bug/328327
+      if (('rl' == this.br.pageProgression) && bComingFrom1up) {
+        // don't flip immediately -- wait until timer fires
+      } else {
+        // flip immediately
+        this.br.next({ triggerStop: false, flipSpeed: this.options.flipSpeed });
+      }
+
+      this.br.$('.play').hide();
+      this.br.$('.pause').show();
+      this.autoTimer = setInterval(() => {
+        if (this.br.animating) return;
+
+        if (Math.max(this.br.twoPage.currentIndexL, this.br.twoPage.currentIndexR) >= this.br.book.getNumLeafs() - 1) {
+          this.br.prev({ triggerStop: false, flipSpeed: this.options.flipSpeed }); // $$$ really what we want?
+        } else {
+          this.br.next({ triggerStop: false, flipSpeed: this.options.flipSpeed });
+        }
+      }, parseAnimationSpeed(this.options.flipDelay));
+    } else {
+      this.autoStop();
+    }
+  }
+
+  /**
+   * Stop autoplay mode, allowing animations to finish
+   */
+  autoStop() {
+    if (!this.options.enabled) return;
+
+    if (null != this.autoTimer) {
+      clearInterval(this.autoTimer);
+      this.br.$('.pause').hide();
+      this.br.$('.play').show();
+      this.autoTimer = null;
+    }
+  }
+}
+
+const BookReader = /** @type {typeof import('../BookReader').default} */(window.BookReader);
+BookReader?.registerPlugin('autoplay', AutoplayPlugin);

--- a/src/plugins/tts/plugin.tts.js
+++ b/src/plugins/tts/plugin.tts.js
@@ -206,7 +206,7 @@ BookReader.prototype.initNavbar = (function (super_) {
 // ttsToggle()
 //______________________________________________________________________________
 BookReader.prototype.ttsToggle = function () {
-  if (this.autoStop) this.autoStop();
+  this._plugins.autoplay?.autoStop();
   if (this.ttsEngine.playing) {
     this.ttsStop();
   } else {

--- a/src/plugins/tts/plugin.tts.js
+++ b/src/plugins/tts/plugin.tts.js
@@ -206,7 +206,7 @@ BookReader.prototype.initNavbar = (function (super_) {
 // ttsToggle()
 //______________________________________________________________________________
 BookReader.prototype.ttsToggle = function () {
-  this._plugins.autoplay?.autoStop();
+  this._plugins.autoplay?.stop();
   if (this.ttsEngine.playing) {
     this.ttsStop();
   } else {

--- a/src/plugins/url/plugin.url.js
+++ b/src/plugins/url/plugin.url.js
@@ -106,7 +106,7 @@ BookReader.prototype.urlStartLocationPolling = function() {
     this.trigger(BookReader.eventNames.stop);
     if (this.animating) {
       // Queue change if animating
-      this._plugins.autoplay?.autoStop();
+      this._plugins.autoplay?.stop();
       this.animationFinishedCallback = updateParams;
     } else {
       // update immediately

--- a/src/plugins/url/plugin.url.js
+++ b/src/plugins/url/plugin.url.js
@@ -106,7 +106,7 @@ BookReader.prototype.urlStartLocationPolling = function() {
     this.trigger(BookReader.eventNames.stop);
     if (this.animating) {
       // Queue change if animating
-      if (this.autoStop) this.autoStop();
+      this._plugins.autoplay?.autoStop();
       this.animationFinishedCallback = updateParams;
     } else {
       // update immediately

--- a/tests/e2e/autoplay.test.js
+++ b/tests/e2e/autoplay.test.js
@@ -2,12 +2,15 @@ import { ClientFunction } from 'testcafe';
 import params from './helpers/params';
 
 const getLocationHref = ClientFunction(() => window.location.href.toString());
-const FLIP_SPEED = 2000;
-const FIRST_PAGE_DELAY = 6000;
+const FLIP_SPEED = 200;
+const FLIP_DELAY = 500;
 
-fixture `Autoplay plugin`.page `${params.baseUrl}/BookReaderDemo/demo-internetarchive.html?ocaid=goody&autoflip=1`;
+fixture `Autoplay plugin`.page `${params.baseUrl}/BookReaderDemo/demo-internetarchive.html?ocaid=goody&autoflip=1&flipSpeed=${FLIP_SPEED}&flipDelay=${FLIP_DELAY}`;
 
 test('page auto-advances after allotted flip speed and delay', async t => {
-  await t.wait(2 * FLIP_SPEED + FIRST_PAGE_DELAY);
-  await t.expect(getLocationHref()).match(/page\/n3/);
+  // Flips from cover, to #page/n1 to #page/n3, etc
+  await t.expect(getLocationHref()).notMatch(/page\/n\d+/);
+  await t.wait(2 * (FLIP_SPEED + FLIP_DELAY) + 500);
+  // Don't check for a specific page; initial load time can vary
+  await t.expect(getLocationHref()).match(/page\/n\d+/);
 });

--- a/tests/jest/BookReader/utils.test.js
+++ b/tests/jest/BookReader/utils.test.js
@@ -10,6 +10,7 @@ import {
   escapeRegExp,
   getActiveElement,
   isInputActive,
+  parseAnimationSpeed,
   poll,
   polyfillCustomEvent,
   PolyfilledCustomEvent,
@@ -225,5 +226,25 @@ describe('escapeRegex', () => {
     expect(escapeRegExp('{{{')).toBe('\\{\\{\\{');
     expect(escapeRegExp('')).toBe('');
     expect(escapeRegExp('https://example.com')).toBe('https://example\\.com');
+  });
+});
+
+describe('parseAnimationSpeed', () => {
+  test('Parses numbers', () => {
+    expect(parseAnimationSpeed(100)).toBe(100);
+    expect(parseAnimationSpeed(0)).toBe(0);
+    expect(parseAnimationSpeed(1000)).toBe(1000);
+  });
+
+  test('Parses strings', () => {
+    expect(parseAnimationSpeed('slow')).toBe(600);
+    expect(parseAnimationSpeed('fast')).toBe(200);
+    expect(parseAnimationSpeed('100')).toBe(100);
+  });
+
+  test('Handles invalid input', () => {
+    expect(parseAnimationSpeed('foo')).toBeFalsy();
+    expect(parseAnimationSpeed('')).toBeFalsy();
+    expect(parseAnimationSpeed(null)).toBeFalsy();
   });
 });

--- a/tests/jest/plugins/plugin.autoplay.test.js
+++ b/tests/jest/plugins/plugin.autoplay.test.js
@@ -2,12 +2,11 @@
 import BookReader from '@/src/BookReader.js';
 import '@/src/plugins/plugin.autoplay.js';
 
-
+/** @type {BookReader} */
 let br;
 beforeEach(() => {
   document.body.innerHTML = '<div id="BookReader">';
   br = new BookReader();
-  br.init();
 });
 
 afterEach(() => {
@@ -15,34 +14,22 @@ afterEach(() => {
 });
 
 describe('Plugin: Menu Toggle', () => {
-  test('has option flag', () => {
-    expect(BookReader.defaultOptions.enableAutoPlayPlugin).toEqual(true);
-  });
-  test('has added BR property: autoTimer', () => {
-    expect(br).toHaveProperty('autoTimer');
-    expect(br.autoTimer).toEqual(null);
-  });
-  test('has added BR property: flipDelay', () => {
-    expect(br).toHaveProperty('flipDelay');
-    expect(br.flipDelay).toBeTruthy();
-    expect(br.flipDelay).toBeGreaterThan(1);
-  });
   test('autoplay does not start when BookReaderInitializes', () => {
-    br.autoToggle = jest.fn();
+    br._plugins.autoplay.autoToggle = jest.fn();
     br.init();
-    expect(br.autoToggle).toHaveBeenCalledTimes(0);
+    expect(br._plugins.autoplay.autoToggle).toHaveBeenCalledTimes(0);
   });
   test('autoplay will run without `flipSpeed` parameters', () => {
-    const initialAutoTimer = br.autoTimer;
+    const initialAutoTimer = br._plugins.autoplay.autoTimer;
     br.next = jest.fn();
-    br.autoStop = jest.fn();
+    br._plugins.autoplay.autoStop = jest.fn();
     br.init();
-    br.autoToggle();
+    br._plugins.autoplay.autoToggle();
     // internally referenced functions that fire
     expect(br.next).toHaveBeenCalledTimes(1);
 
     expect(initialAutoTimer).toBeFalsy();
-    // br.autoTimer changes when autoToggle turns on
-    expect(br.autoTimer).toBeTruthy();
+    // autoTimer changes when autoToggle turns on
+    expect(br._plugins.autoplay.autoTimer).toBeTruthy();
   });
 });

--- a/tests/jest/plugins/plugin.autoplay.test.js
+++ b/tests/jest/plugins/plugin.autoplay.test.js
@@ -15,21 +15,21 @@ afterEach(() => {
 
 describe('Plugin: Menu Toggle', () => {
   test('autoplay does not start when BookReaderInitializes', () => {
-    br._plugins.autoplay.autoToggle = jest.fn();
+    br._plugins.autoplay.toggle = jest.fn();
     br.init();
-    expect(br._plugins.autoplay.autoToggle).toHaveBeenCalledTimes(0);
+    expect(br._plugins.autoplay.toggle).toHaveBeenCalledTimes(0);
   });
   test('autoplay will run without `flipSpeed` parameters', () => {
-    const initialAutoTimer = br._plugins.autoplay.autoTimer;
+    const initialTimer = br._plugins.autoplay.timer;
     br.next = jest.fn();
-    br._plugins.autoplay.autoStop = jest.fn();
+    br._plugins.autoplay.stop = jest.fn();
     br.init();
-    br._plugins.autoplay.autoToggle();
+    br._plugins.autoplay.toggle();
     // internally referenced functions that fire
     expect(br.next).toHaveBeenCalledTimes(1);
 
-    expect(initialAutoTimer).toBeFalsy();
-    // autoTimer changes when autoToggle turns on
-    expect(br._plugins.autoplay.autoTimer).toBeTruthy();
+    expect(initialTimer).toBeFalsy();
+    // timer changes when autoplay turns on
+    expect(br._plugins.autoplay.timer).toBeTruthy();
   });
 });


### PR DESCRIPTION
Testing:
* ✅ autoflip works https://deploy-preview-1374--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=theworksofplato01platiala&autoflip=1

Breaking changes:
* Moves the root autoplay bookreader methods/fields `autoToggle`, `autoTimer`, `autoStop` to `br._plugins.autoplay` as `toggle`, `timer`, `stop`
* Moves the root autoplay options `flipDelay`, `enableAutoPlayPlugin` out of the root options to `options.plugins.autoplay` as `flipDelay` and `enabled`.

New features:
* Adds new option for autoplay plugin, `urlParams`, defaulting to true. When true, `autoflip=1`, `flipSpeed=<number>` and `flipDelay=<number>` will be read from the url to configure the autoplay plugin.