### PR TITLE
 Migrate ResumePlugin to BookReaderPlugin

### DIFF
--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -70,6 +70,8 @@ BookReader.PLUGINS = {
   archiveAnalytics: null,
   /** @type {typeof import('./plugins/plugin.autoplay.js').AutoplayPlugin | null}*/
   autoplay: null,
+  /** @type {typeof import('./plugins/plugin.resume.js').ResumePlugin | null}*/
+  resume: null,
   /** @type {typeof import('./plugins/plugin.text_selection.js').TextSelectionPlugin | null}*/
   textSelection: null,
 };
@@ -260,6 +262,7 @@ BookReader.prototype.setup = function(options) {
   this._plugins = {
     archiveAnalytics: BookReader.PLUGINS.archiveAnalytics ? new BookReader.PLUGINS.archiveAnalytics(this) : null,
     autoplay: BookReader.PLUGINS.autoplay ? new BookReader.PLUGINS.autoplay(this) : null,
+    resume: BookReader.PLUGINS.resume ? new BookReader.PLUGINS.resume(this) : null,
     textSelection: BookReader.PLUGINS.textSelection ? new BookReader.PLUGINS.textSelection(this) : null,
   };
 
@@ -400,7 +403,7 @@ BookReader.prototype.initParams = function() {
   // Check for Resume plugin
   if (this.options.enablePageResume) {
     // Check cookies
-    const val = this.getResumeValue();
+    const val = this._plugins.resume.getResumeValue();
     if (val !== null) {
       // If page index different from default
       if (params.index !== val) {

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -401,7 +401,7 @@ BookReader.prototype.initParams = function() {
   }
 
   // Check for Resume plugin
-  if (this.options.enablePageResume) {
+  if (this._plugins.resume?.options.enabled) {
     // Check cookies
     const val = this._plugins.resume.getResumeValue();
     if (val !== null) {

--- a/src/BookReader/options.js
+++ b/src/BookReader/options.js
@@ -145,6 +145,8 @@ export const DEFAULT_OPTIONS = {
     archiveAnalytics: null,
     /** @type {import('../plugins/plugin.autoplay.js').AutoplayPlugin['options']}*/
     autoplay: null,
+    /** @type {import('../plugins/plugin.resume.js').ResumePlugin['options']} */
+    resume: null,
     /** @type {import('../plugins/plugin.text_selection.js').TextSelectionPlugin['options']} */
     textSelection: null,
   },

--- a/src/plugins/plugin.resume.js
+++ b/src/plugins/plugin.resume.js
@@ -12,14 +12,14 @@ BookReader.docCookies = docCookies;
  */
 export class ResumePlugin extends BookReaderPlugin {
   options = {
-    enablePageResume: true,
+    enabled: true,
     /** @type {string|null} eg '/', '/details/id' */
-    resumeCookiePath: null,
+    cookiePath: null,
   }
 
   /** @override */
   init() {
-    if (this.options.enablePageResume) {
+    if (this.options.enabled) {
       this.br.bind(EVENTS.fragmentChange, () => {
         const params = this.br.paramsFromCurrent();
         this.updateResumeValue(params.index);
@@ -60,9 +60,9 @@ export class ResumePlugin extends BookReaderPlugin {
    */
   updateResumeValue(index, cookieName) {
     const ttl = new Date(+new Date + 12096e5); // 2 weeks
-    // For multiple files in item, leave resumeCookiePath blank
-    // It's likely we can remove resumeCookiePath using getCookiePath()
-    const path = this.options.resumeCookiePath
+    // For multiple files in item, leave cookiePath blank
+    // It's likely we can remove cookiePath using getCookiePath()
+    const path = this.options.cookiePath
       || this.getCookiePath(window.location.pathname);
     BookReader.docCookies.setItem(cookieName || 'br-resume', index, ttl, path, null, false);
   }

--- a/src/plugins/plugin.resume.js
+++ b/src/plugins/plugin.resume.js
@@ -1,3 +1,5 @@
+import { EVENTS } from '../BookReader/events.js';
+import { BookReaderPlugin } from '../BookReaderPlugin.js';
 import * as docCookies from '../util/docCookies.js';
 
 /* global BookReader */
@@ -8,61 +10,62 @@ BookReader.docCookies = docCookies;
 /**
  * Plugin to remember the current page number in a cookie
  */
-jQuery.extend(BookReader.defaultOptions, {
-  enablePageResume: true,
-  /** @type {string|null} eg '/', '/details/id' */
-  resumeCookiePath: null,
-});
+export class ResumePlugin extends BookReaderPlugin {
+  options = {
+    enablePageResume: true,
+    /** @type {string|null} eg '/', '/details/id' */
+    resumeCookiePath: null,
+  }
 
-/** @override */
-BookReader.prototype.init = (function(super_) {
-  return function() {
-    super_.call(this);
+  /** @override */
+  init() {
     if (this.options.enablePageResume) {
-      this.bind(BookReader.eventNames.fragmentChange, () => {
-        const params = this.paramsFromCurrent();
+      this.br.bind(EVENTS.fragmentChange, () => {
+        const params = this.br.paramsFromCurrent();
         this.updateResumeValue(params.index);
       });
     }
-  };
-})(BookReader.prototype.init);
+  }
 
-/**
- * Gets page resume value, for remembering reader's page
- * Can be overridden for different implementation
- *
- * @return {number|null}
- */
-BookReader.prototype.getResumeValue = function() {
-  const val = BookReader.docCookies.getItem('br-resume');
-  if (val !== null) return parseInt(val);
-  else return null;
-};
+  /**
+   * Gets page resume value, for remembering reader's page
+   * Can be overridden for different implementation
+   *
+   * @return {number|null}
+   */
+  getResumeValue() {
+    const val = BookReader.docCookies.getItem('br-resume');
+    if (val !== null) return parseInt(val);
+    else return null;
+  }
 
-/**
- * Return cookie path using pathname up to /page/... or /mode/...
- * using window.location.pathname for urlPathPart:
- * - matches encoding
- * - ignores querystring part
- * - ignores fragment part (after #)
- * @param {string} urlPathPart - window.location.pathname
- */
-BookReader.prototype.getCookiePath = function(urlPathPart) {
-  return urlPathPart.match('.+?(?=/page/|/mode/|$)')[0];
-};
+  /**
+   * Return cookie path using pathname up to /page/... or /mode/...
+   * using window.location.pathname for urlPathPart:
+   * - matches encoding
+   * - ignores querystring part
+   * - ignores fragment part (after #)
+   * @param {string} urlPathPart - window.location.pathname
+   */
+  getCookiePath(urlPathPart) {
+    return urlPathPart.match('.+?(?=/page/|/mode/|$)')[0];
+  }
 
-/**
- * Sets page resume value, for remembering reader's page
- * Can be overridden for different implementation
- *
- * @param {Number} index leaf index
- * @param {string} [cookieName]
- */
-BookReader.prototype.updateResumeValue = function(index, cookieName) {
-  const ttl = new Date(+new Date + 12096e5); // 2 weeks
-  // For multiple files in item, leave resumeCookiePath blank
-  // It's likely we can remove resumeCookiePath using getCookiePath()
-  const path = this.options.resumeCookiePath
-    || this.getCookiePath(window.location.pathname);
-  BookReader.docCookies.setItem(cookieName || 'br-resume', index, ttl, path, null, false);
-};
+  /**
+   * Sets page resume value, for remembering reader's page
+   * Can be overridden for different implementation
+   *
+   * @param {Number} index leaf index
+   * @param {string} [cookieName]
+   */
+  updateResumeValue(index, cookieName) {
+    const ttl = new Date(+new Date + 12096e5); // 2 weeks
+    // For multiple files in item, leave resumeCookiePath blank
+    // It's likely we can remove resumeCookiePath using getCookiePath()
+    const path = this.options.resumeCookiePath
+      || this.getCookiePath(window.location.pathname);
+    BookReader.docCookies.setItem(cookieName || 'br-resume', index, ttl, path, null, false);
+  }
+}
+
+BookReader?.registerPlugin('resume', ResumePlugin);

--- a/tests/e2e/helpers/base.js
+++ b/tests/e2e/helpers/base.js
@@ -78,8 +78,8 @@ export function runBaseTests (br) {
 
     // Check if uses plugin.resume.js
     const usesResume = ClientFunction(() => {
-      const hasResumePlugin = typeof(br.getResumeValue) !== "undefined";
-      const hasResumeValue = hasResumePlugin ? br.getResumeValue() : false;
+      const hasResumePlugin = typeof(br._plugins.resume) !== "undefined";
+      const hasResumeValue = hasResumePlugin ? br._plugins.resume.getResumeValue() : false;
       return hasResumeValue;
     });
 

--- a/tests/jest/BookReader.test.js
+++ b/tests/jest/BookReader.test.js
@@ -47,7 +47,7 @@ test('checks cookie when initParams called', () => {
 test('does not check cookie when initParams called', () => {
   br._plugins.resume.getResumeValue = jest.fn(() => null);
   br.urlReadFragment = jest.fn(() => '');
-  br.options.enablePageResume = false;
+  br.options.plugins.resume.enabled = false;
 
   const params = br.initParams();
   expect(br._plugins.resume.getResumeValue).toHaveBeenCalledTimes(0);
@@ -59,7 +59,7 @@ test('does not check cookie when initParams called', () => {
 test('gets index from fragment when both fragment and cookie when InitParams called', () => {
   br._plugins.resume.getResumeValue = jest.fn(() => 15);
   br.urlReadFragment = jest.fn(() => 'page/n4');
-  br.options.enablePageResume = true;
+  br.options.plugins.resume.enabled = true;
 
   const params = br.initParams();
   expect(br._plugins.resume.getResumeValue).toHaveBeenCalledTimes(1);

--- a/tests/jest/BookReader.test.js
+++ b/tests/jest/BookReader.test.js
@@ -3,6 +3,7 @@ import BookReader, {_modeStringToNumber} from '@/src/BookReader.js';
 import '@/src/plugins/plugin.resume.js';
 import '@/src/plugins/url/plugin.url.js';
 
+/** @type {import('@/src/BookReader.js').default} */
 let br;
 beforeAll(() => {
   document.body.innerHTML = '<div id="BookReader">';
@@ -33,35 +34,35 @@ test('has registered fullscreen toggle event', () => {
 });
 
 test('checks cookie when initParams called', () => {
-  br.getResumeValue = jest.fn(() => 15);
+  br._plugins.resume.getResumeValue = jest.fn(() => 15);
   br.urlReadFragment = jest.fn(() => '');
 
   const params = br.initParams();
-  expect(br.getResumeValue).toHaveBeenCalledTimes(1);
+  expect(br._plugins.resume.getResumeValue).toHaveBeenCalledTimes(1);
   expect(params.init).toBe(true);
   expect(params.index).toBe(15);
   expect(params.fragmentChange).toBe(true);
 });
 
 test('does not check cookie when initParams called', () => {
-  br.getResumeValue = jest.fn(() => null);
+  br._plugins.resume.getResumeValue = jest.fn(() => null);
   br.urlReadFragment = jest.fn(() => '');
   br.options.enablePageResume = false;
 
   const params = br.initParams();
-  expect(br.getResumeValue).toHaveBeenCalledTimes(0);
+  expect(br._plugins.resume.getResumeValue).toHaveBeenCalledTimes(0);
   expect(params.init).toBe(true);
   expect(params.index).toBe(0);
   expect(params.fragmentChange).toBe(false);
 });
 
 test('gets index from fragment when both fragment and cookie when InitParams called', () => {
-  br.getResumeValue = jest.fn(() => 15);
+  br._plugins.resume.getResumeValue = jest.fn(() => 15);
   br.urlReadFragment = jest.fn(() => 'page/n4');
   br.options.enablePageResume = true;
 
   const params = br.initParams();
-  expect(br.getResumeValue).toHaveBeenCalledTimes(1);
+  expect(br._plugins.resume.getResumeValue).toHaveBeenCalledTimes(1);
   expect(params.init).toBe(true);
   expect(params.index).toBe(4);
   expect(params.fragmentChange).toBe(true);
@@ -91,7 +92,7 @@ test('calls switchMode with init option when init called', () => {
 });
 
 test('has suppressFragmentChange true when init with no input', () => {
-  br.getResumeValue = jest.fn(() => null);
+  br._plugins.resume.getResumeValue = jest.fn(() => null);
   br.urlReadFragment = jest.fn(() => '');
   br.urlReadHashFragment = jest.fn(() => '');
   br.switchMode = jest.fn();
@@ -102,7 +103,7 @@ test('has suppressFragmentChange true when init with no input', () => {
 });
 
 test('has suppressFragmentChange false when init with cookie', () => {
-  br.getResumeValue = jest.fn(() => 5);
+  br._plugins.resume.getResumeValue = jest.fn(() => 5);
   br.urlReadFragment = jest.fn(() => '');
   br.switchMode = jest.fn();
 
@@ -112,7 +113,7 @@ test('has suppressFragmentChange false when init with cookie', () => {
 });
 
 test('has suppressFragmentChange false when init with fragment', () => {
-  br.getResumeValue = jest.fn(() => null);
+  br._plugins.resume.getResumeValue = jest.fn(() => null);
   br.urlReadFragment = jest.fn(() => 'mode/1up');
   br.switchMode = jest.fn();
 
@@ -122,7 +123,7 @@ test('has suppressFragmentChange false when init with fragment', () => {
 });
 
 test('has suppressFragmentChange false when init with hash fragment', () => {
-  br.getResumeValue = jest.fn(() => null);
+  br._plugins.resume.getResumeValue = jest.fn(() => null);
   br.urlReadFragment = jest.fn(() => '');
   br.urlReadHashFragment = jest.fn(() => 'mode/1up');
   br.switchMode = jest.fn();

--- a/tests/jest/plugins/plugin.resume.test.js
+++ b/tests/jest/plugins/plugin.resume.test.js
@@ -3,7 +3,9 @@ import '@/src/plugins/plugin.resume.js';
 
 import sinon from 'sinon';
 import * as docCookies from '@/src/util/docCookies.js';
+import { ResumePlugin } from '@/src/plugins/plugin.resume.js';
 
+/** @type {import('@/src/BookReader.js').default} */
 let br;
 beforeAll(() => {
   document.body.innerHTML = '<div id="BookReader">';
@@ -14,21 +16,6 @@ beforeAll(() => {
 afterEach(() => {
   jest.clearAllMocks();
   sinon.restore();
-});
-
-describe('Plugin: Remember Current Page in Cookies', () => {
-  test('has default option flag', () => {
-    expect(BookReader.defaultOptions.enablePageResume).toEqual(true);
-    expect(BookReader.defaultOptions.resumeCookiePath).toEqual(null);
-  });
-
-  test('has added BR property: getResumeValue', () => {
-    expect(br).toHaveProperty('getResumeValue');
-  });
-
-  test('has added BR property: updateResumeValue', () => {
-    expect(br).toHaveProperty('updateResumeValue');
-  });
 });
 
 describe('updateResumeValue', () => {
@@ -42,17 +29,17 @@ describe('updateResumeValue', () => {
     In this branch .toHaveBeenCalledTimes() === 1
   */
   test.skip('starts when BookReaderInit is called', () => {
-    br.updateResumeValue = jest.fn();
+    br._plugins.resume.updateResumeValue = jest.fn();
     br.init();
-    expect(br.updateResumeValue).toHaveBeenCalledTimes(2);
+    expect(br._plugins.resume.updateResumeValue).toHaveBeenCalledTimes(2);
   });
 
   test('handles cookieName=null', () => {
-    const { updateResumeValue } = BookReader.prototype;
+    const p = new ResumePlugin(null);
+    p.setup({ resumeCookiePath: '/details/goody' });
     const setItemSpy = sinon.spy(docCookies, 'setItem');
-    const fakeBr = { options: { resumeCookiePath: '/details/goody' } };
 
-    updateResumeValue.call(fakeBr, 16);
+    p.updateResumeValue(16);
     expect(setItemSpy.callCount).toBe(1);
     expect(setItemSpy.args[0].slice(0, 2)).toEqual(['br-resume', 16]);
     expect(setItemSpy.args[0][3]).toEqual('/details/goody');
@@ -61,38 +48,38 @@ describe('updateResumeValue', () => {
   test('handles resumeCookiePath not set', () => {
     const setItemSpy = sinon.spy(docCookies, 'setItem');
     // Save function
-    const saveFn = br.getCookiePath;
-    br.getCookiePath = jest.fn(() => '/details/foo');
-    br.updateResumeValue(16);
+    const saveFn = br._plugins.resume.getCookiePath;
+    br._plugins.resume.getCookiePath = jest.fn(() => '/details/foo');
+    br._plugins.resume.updateResumeValue(16);
     expect(setItemSpy.args[0][3]).toEqual('/details/foo');
     // Restore function
-    br.getCookiePath = saveFn;
+    br._plugins.resume.getCookiePath = saveFn;
   });
 
   test('handles cookie path from URL with decoration', () => {
     const complexPathWithPage = '/details/2008ELMValidityStudyFinalReportRevised/Executive%20Summary%20for%20the%20EPT%26ELM%20Validity%20Studie_20100603%20-%20Copy/page/n1/mode/2up';
     const complexPath = '/details/2008ELMValidityStudyFinalReportRevised/Executive%20Summary%20for%20the%20EPT%26ELM%20Validity%20Studie_20100603%20-%20Copy';
-    expect(br.getCookiePath(complexPathWithPage))
+    expect(br._plugins.resume.getCookiePath(complexPathWithPage))
       .toEqual(complexPath);
 
-    expect(br.getCookiePath('/details/item/mode/1up'))
+    expect(br._plugins.resume.getCookiePath('/details/item/mode/1up'))
       .toEqual('/details/item');
 
-    expect(br.getCookiePath('/details/item/inside/a/long/path/model/is/used'))
+    expect(br._plugins.resume.getCookiePath('/details/item/inside/a/long/path/model/is/used'))
       .toEqual('/details/item/inside/a/long/path/model/is/used');
 
-    expect(br.getCookiePath('/details/item/inside/a/long/path/mode/is/used'))
+    expect(br._plugins.resume.getCookiePath('/details/item/inside/a/long/path/mode/is/used'))
       .toEqual('/details/item/inside/a/long/path');
   });
 
   test('handles cookie path from URL with no decoration', () => {
-    expect(br.getCookiePath('/details/item'))
+    expect(br._plugins.resume.getCookiePath('/details/item'))
       .toEqual('/details/item');
 
-    expect(br.getCookiePath('/details/item/'))
+    expect(br._plugins.resume.getCookiePath('/details/item/'))
       .toEqual('/details/item/');
 
-    expect(br.getCookiePath('/details/item/almost/any/kind/of/long/path'))
+    expect(br._plugins.resume.getCookiePath('/details/item/almost/any/kind/of/long/path'))
       .toEqual('/details/item/almost/any/kind/of/long/path');
   });
 });

--- a/tests/jest/plugins/plugin.resume.test.js
+++ b/tests/jest/plugins/plugin.resume.test.js
@@ -36,7 +36,7 @@ describe('updateResumeValue', () => {
 
   test('handles cookieName=null', () => {
     const p = new ResumePlugin(null);
-    p.setup({ resumeCookiePath: '/details/goody' });
+    p.setup({ cookiePath: '/details/goody' });
     const setItemSpy = sinon.spy(docCookies, 'setItem');
 
     p.updateResumeValue(16);
@@ -45,7 +45,7 @@ describe('updateResumeValue', () => {
     expect(setItemSpy.args[0][3]).toEqual('/details/goody');
   });
 
-  test('handles resumeCookiePath not set', () => {
+  test('handles cookiePath not set', () => {
     const setItemSpy = sinon.spy(docCookies, 'setItem');
     // Save function
     const saveFn = br._plugins.resume.getCookiePath;


### PR DESCRIPTION
Blocked by #1374 , so ignore the autoplay files in this diff.

Testing:
1. Go to the netlify review app https://deploy-preview-1375--lucid-poitras-9a1249.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=theworksofplato01platiala
2. Go to a page
3. Remove the `#...` fragment from the url and reload the page
4. ✅ Should be sent back to the same page

Breaking changes:

- `BookReader#getResumeValue()` moved to `BookReader._plugins.resume.getResumeValue()`. Similarly for `getCookiePath`, and `updateResumeValue` .
- The option `enablePageResume: bool` has been renamed to `plugins.resume.enabled: bool`
- The option `resumeCookiePath: string` has been renamed to `plugins.resume.cookiePath: string`