### PR TITLE
 Migrate TtsPlugin to BookReaderPlugin

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,7 @@ codecov:
     project:
       default:
         # Allow small drops in coverage
-        threshold: 0.005  # .5 %
+        threshold: 0.5  # 0.5%
         if_not_found: failure
 
 coverage:

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -593,7 +593,12 @@ BookReader.prototype.init = function() {
     this.initToolbar(this.mode, this.ui); // Build inside of toolbar div
   }
   if (this.options.showNavbar) { // default navigation
-    this.initNavbar();
+    const $navBar = this.initNavbar();
+
+    // extend navbar with plugins
+    for (const plugin of Object.values(this._plugins)) {
+      plugin.extendNavBar($navBar);
+    }
   }
 
   // Switch navbar controls on mobile/desktop

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -74,6 +74,8 @@ BookReader.PLUGINS = {
   resume: null,
   /** @type {typeof import('./plugins/plugin.text_selection.js').TextSelectionPlugin | null}*/
   textSelection: null,
+  /** @type {typeof import('./plugins/tts/plugin.tts.js').TtsPlugin | null}*/
+  tts: null,
 };
 
 /**
@@ -264,6 +266,7 @@ BookReader.prototype.setup = function(options) {
     autoplay: BookReader.PLUGINS.autoplay ? new BookReader.PLUGINS.autoplay(this) : null,
     resume: BookReader.PLUGINS.resume ? new BookReader.PLUGINS.resume(this) : null,
     textSelection: BookReader.PLUGINS.textSelection ? new BookReader.PLUGINS.textSelection(this) : null,
+    tts: BookReader.PLUGINS.tts ? new BookReader.PLUGINS.tts(this) : null,
   };
 
   // Delete anything that's null

--- a/src/BookReader/options.js
+++ b/src/BookReader/options.js
@@ -149,6 +149,8 @@ export const DEFAULT_OPTIONS = {
     resume: null,
     /** @type {import('../plugins/plugin.text_selection.js').TextSelectionPlugin['options']} */
     textSelection: null,
+    /** @type {import('../plugins/tts/plugin.tts.js').TtsPlugin['options']} */
+    tts: null,
   },
 
   /**

--- a/src/BookReaderPlugin.js
+++ b/src/BookReaderPlugin.js
@@ -36,4 +36,9 @@ export class BookReaderPlugin {
 
   /** @abstract @protected */
   _bindNavigationHandlers() {}
+
+  /**
+   * @param {JQuery<HTMLElement>} $navBar
+   */
+  extendNavBar($navBar) {}
 }

--- a/src/plugins/tts/AbstractTTSEngine.js
+++ b/src/plugins/tts/AbstractTTSEngine.js
@@ -6,8 +6,7 @@ import { hasLocalStorage } from './utils.js';
 /**
  * @export
  * @typedef {Object} TTSEngineOptions
- * @property {String} server
- * @property {String} bookPath
+ * @property {import('@/src/util/strings.js').StringWithVars} pageChunkUrl
  * @property {ISO6391} bookLanguage
  * @property {Function} onLoadingStart
  * @property {Function} onLoadingComplete
@@ -85,8 +84,7 @@ export default class AbstractTTSEngine {
     this.opts.onLoadingStart();
 
     this._chunkIterator = new PageChunkIterator(numLeafs, leafIndex, {
-      server: this.opts.server,
-      bookPath: this.opts.bookPath,
+      pageChunkUrl: this.opts.pageChunkUrl,
       pageBufferSize: 5,
     });
 

--- a/src/plugins/tts/PageChunk.js
+++ b/src/plugins/tts/PageChunk.js
@@ -1,3 +1,5 @@
+import { applyVariables } from "../../util/strings.js";
+
 /**
  * Class to manage a 'chunk' (approximately a paragraph) of text on a page.
  */
@@ -16,23 +18,17 @@ export default class PageChunk {
   }
 
   /**
-   * @param {string} server
-   * @param {string} bookPath
+   * @param {import('@/src/util/strings.js').StringWithVars} pageChunkUrl
    * @param {number} leafIndex
    * @return {Promise<PageChunk[]>}
    */
-  static async fetch(server, bookPath, leafIndex) {
+  static async fetch(pageChunkUrl, leafIndex) {
     const chunks = await $.ajax({
       type: 'GET',
-      url: `https://${server}/BookReader/BookReaderGetTextWrapper.php`,
+      url: applyVariables(pageChunkUrl, { pageIndex: leafIndex }),
       cache: true,
       xhrFields: {
         withCredentials: window.br.protected,
-      },
-      data: {
-        path: `${bookPath}_djvu.xml`,
-        page: leafIndex,
-        callback: 'false',
       },
     });
     return PageChunk._fromTextWrapperResponse(leafIndex, chunks);

--- a/src/plugins/tts/PageChunkIterator.js
+++ b/src/plugins/tts/PageChunkIterator.js
@@ -138,7 +138,7 @@ export default class PageChunkIterator {
    * @param {number} index
    */
   _fetchPageChunksDirect(index) {
-    return PageChunk.fetch(this.opts.server, this.opts.bookPath, index);
+    return PageChunk.fetch(this.opts.pageChunkUrl, index);
   }
 }
 
@@ -146,14 +146,12 @@ PageChunkIterator.AT_END = "__PageChunkIterator.AT_END__";
 
 /** @type {PageChunkIteratorOptions} */
 const DEFAULT_OPTS = {
-  server: null,
-  bookPath: null,
+  pageChunkUrl: null,
   pageBufferSize: 2,
 };
 
 /**
  * @typedef {Object} PageChunkIteratorOptions
- * @property {string} server
- * @property {string} bookPath
+ * @property {import('@/src/util/strings.js').StringWithVars} pageChunkUrl
  * @property {number} [pageBufferSize] number of pages to buffer before/after the current page
  */

--- a/src/plugins/tts/plugin.tts.js
+++ b/src/plugins/tts/plugin.tts.js
@@ -6,6 +6,7 @@ import { toISO6391, approximateWordCount } from './utils.js';
 import { en as tooltips } from './tooltip_dict.js';
 import { renderBoxesInPageContainerLayer } from '../../BookReader/PageContainer.js';
 import { BookReaderPlugin } from '../../BookReaderPlugin.js';
+import { applyVariables } from '../../util/strings.js';
 /** @typedef {import('./PageChunk.js').default} PageChunk */
 /** @typedef {import("./AbstractTTSEngine.js").default} AbstractTTSEngine */
 
@@ -17,8 +18,11 @@ const BookReader = /** @type {typeof import('../../BookReader').default} */(wind
 export class TtsPlugin extends BookReaderPlugin {
   options = {
     enabled: true,
-    server: 'ia600609.us.archive.org',
-    bookPath: '',
+    /**
+     * @type {import('@/src/util/strings.js').StringWithVars}
+     * The URL where to get PageChunk objects for a given page. Expects a var `pageIndex`
+     **/
+    pageChunkUrl: 'https://{{server}}/BookReader/BookReaderGetTextWrapper.php?path={{bookPath|urlencode}}_djvu.xml&page={{pageIndex}}&callback=false',
   }
 
   /**
@@ -49,8 +53,7 @@ export class TtsPlugin extends BookReaderPlugin {
     if (TTSEngine) {
       /** @type {AbstractTTSEngine} */
       this.ttsEngine = new TTSEngine({
-        server: this.options.server,
-        bookPath: this.options.bookPath,
+        pageChunkUrl: applyVariables(this.options.pageChunkUrl, this.br.options.vars),
         bookLanguage: toISO6391(this.br.options.bookLanguage),
         onLoadingStart: this.br.showProgressPopup.bind(this.br, 'Loading audio...'),
         onLoadingComplete: this.br.removeProgressPopup.bind(this.br),

--- a/src/plugins/tts/plugin.tts.js
+++ b/src/plugins/tts/plugin.tts.js
@@ -1,124 +1,261 @@
-/* global BookReader */
-/**
- * Plugin for Text to Speech in BookReader
- */
+// @ts-check
+
 import FestivalTTSEngine from './FestivalTTSEngine.js';
 import WebTTSEngine from './WebTTSEngine.js';
 import { toISO6391, approximateWordCount } from './utils.js';
 import { en as tooltips } from './tooltip_dict.js';
 import { renderBoxesInPageContainerLayer } from '../../BookReader/PageContainer.js';
+import { BookReaderPlugin } from '../../BookReaderPlugin.js';
 /** @typedef {import('./PageChunk.js').default} PageChunk */
 /** @typedef {import("./AbstractTTSEngine.js").default} AbstractTTSEngine */
 
-// Default options for TTS
-jQuery.extend(BookReader.defaultOptions, {
-  server: 'ia600609.us.archive.org',
-  bookPath: '',
-  enableTtsPlugin: true,
-});
+const BookReader = /** @type {typeof import('../../BookReader').default} */(window.BookReader);
 
-// Extend the constructor to add TTS properties
-BookReader.prototype.setup = (function (super_) {
-  return function (options) {
-    super_.call(this, options);
+/**
+ * Plugin for Text to Speech in BookReader
+ */
+export class TtsPlugin extends BookReaderPlugin {
+  options = {
+    server: 'ia600609.us.archive.org',
+    bookPath: '',
+    enableTtsPlugin: true,
+  }
 
-    if (this.options.enableTtsPlugin) {
-      /** @type { {[pageIndex: number]: Array<{ l: number, r: number, t: number, b: number }>} } */
-      this._ttsBoxesByIndex = {};
+  /**
+   * @override
+   * @param {Partial<TtsPlugin['options']>} options
+   **/
+  setup(options) {
+    super.setup(Object.assign({
+      // @deprecated support options specified in global options
+      server: this.br.options.server,
+      bookPath: this.br.options.bookPath,
+    }, options));
 
-      let TTSEngine = WebTTSEngine.isSupported() ? WebTTSEngine :
-        FestivalTTSEngine.isSupported() ? FestivalTTSEngine :
-          null;
+    if (!this.options.enableTtsPlugin) return;
 
-      if (/_forceTTSEngine=(festival|web)/.test(location.toString())) {
-        const engineName = location.toString().match(/_forceTTSEngine=(festival|web)/)[1];
-        TTSEngine = { festival: FestivalTTSEngine, web: WebTTSEngine }[engineName];
-      }
+    /** @type { {[pageIndex: number]: Array<{ l: number, r: number, t: number, b: number }>} } */
+    this._ttsBoxesByIndex = {};
 
-      if (TTSEngine) {
-        /** @type {AbstractTTSEngine} */
-        this.ttsEngine = new TTSEngine({
-          server: options.server,
-          bookPath: options.bookPath,
-          bookLanguage: toISO6391(options.bookLanguage),
-          onLoadingStart: this.showProgressPopup.bind(this, 'Loading audio...'),
-          onLoadingComplete: this.removeProgressPopup.bind(this),
-          onDone: this.ttsStop.bind(this),
-          beforeChunkPlay: this.ttsBeforeChunkPlay.bind(this),
-          afterChunkPlay: this.ttsSendChunkFinishedAnalyticsEvent.bind(this),
-        });
-      }
+    let TTSEngine = WebTTSEngine.isSupported() ? WebTTSEngine :
+      FestivalTTSEngine.isSupported() ? FestivalTTSEngine :
+        null;
+
+    if (/_forceTTSEngine=(festival|web)/.test(location.toString())) {
+      const engineName = location.toString().match(/_forceTTSEngine=(festival|web)/)[1];
+      TTSEngine = { festival: FestivalTTSEngine, web: WebTTSEngine }[engineName];
     }
-  };
-})(BookReader.prototype.setup);
 
-BookReader.prototype.init = (function(super_) {
-  return function() {
-    if (this.options.enableTtsPlugin) {
-      // Bind to events
-
-      this.bind(BookReader.eventNames.PostInit, () => {
-        this.$('.BRicon.read').click(() => {
-          this.ttsToggle();
-          return false;
-        });
-        if (this.ttsEngine) {
-          this.ttsEngine.init();
-          if (/[?&]_autoReadAloud=show/.test(location.toString())) {
-            this.ttsStart(false); // false flag is to initiate read aloud controls
-          }
-        }
+    if (TTSEngine) {
+      /** @type {AbstractTTSEngine} */
+      this.ttsEngine = new TTSEngine({
+        server: this.options.server,
+        bookPath: this.options.bookPath,
+        bookLanguage: toISO6391(this.br.options.bookLanguage),
+        onLoadingStart: this.br.showProgressPopup.bind(this.br, 'Loading audio...'),
+        onLoadingComplete: this.br.removeProgressPopup.bind(this.br),
+        onDone: this.ttsStop.bind(this),
+        beforeChunkPlay: this.ttsBeforeChunkPlay.bind(this),
+        afterChunkPlay: this.ttsSendChunkFinishedAnalyticsEvent.bind(this),
       });
-
-      // This is fired when the hash changes by one of the other plugins!
-      // i.e. it will fire every time the page changes -_-
-      // this.bind(BookReader.eventNames.stop, function(e, br) {
-      //     this.ttsStop();
-      // }.bind(this));
     }
-    super_.call(this);
-  };
-})(BookReader.prototype.init);
+  }
 
-/** @override */
-BookReader.prototype._createPageContainer = (function (super_) {
-  return function (index) {
-    const pageContainer = super_.call(this, index);
-    if (this.options.enableTtsPlugin && pageContainer.page && index in this._ttsBoxesByIndex) {
+  /** @override */
+  init() {
+    if (!this.options.enableTtsPlugin) return;
+
+    this.br.bind(BookReader.eventNames.PostInit, () => {
+      this.br.$('.BRicon.read').click(() => {
+        this.ttsToggle();
+        return false;
+      });
+      if (this.ttsEngine) {
+        this.ttsEngine.init();
+        if (/[?&]_autoReadAloud=show/.test(location.toString())) {
+          this.ttsStart(false); // false flag is to initiate read aloud controls
+        }
+      }
+    });
+
+    // This is fired when the hash changes by one of the other plugins!
+    // i.e. it will fire every time the page changes -_-
+    // this.br.bind(BookReader.eventNames.stop, function(e, br) {
+    //     this.ttsStop();
+    // }.bind(this));
+  }
+
+  /**
+   * @override
+   * @param {import ("@/src/BookReader/PageContainer.js").PageContainer} pageContainer
+   */
+  _configurePageContainer(pageContainer) {
+    if (this.options.enableTtsPlugin && pageContainer.page && pageContainer.page.index in this._ttsBoxesByIndex) {
       const pageIndex = pageContainer.page.index;
       renderBoxesInPageContainerLayer('ttsHiliteLayer', this._ttsBoxesByIndex[pageIndex], pageContainer.page, pageContainer.$container[0]);
     }
-    return pageContainer;
-  };
-})(BookReader.prototype._createPageContainer);
+  }
 
-// Extend buildMobileDrawerElement
-BookReader.prototype.buildMobileDrawerElement = (function (super_) {
-  return function () {
-    const $el = super_.call(this);
-    if (this.options.enableTtsPlugin && this.ttsEngine) {
-      $el.find('.BRmobileMenu__moreInfoRow').after($(`
-        <li>
-            <span>
-                <span class="DrawerIconWrapper"><img class="DrawerIcon" src="${this.imagesBaseURL}icon_speaker_open.svg" alt="info-speaker"/></span>
-                Read Aloud
-            </span>
-            <div>
-                <span class="larger">Press to toggle read aloud</span>
-                <br/>
-                <button class="BRicon read"></button>
-            </div>
-        </li>`));
+  ttsToggle() {
+    this.br._plugins.autoplay?.stop();
+    if (this.ttsEngine.playing) {
+      this.ttsStop();
+    } else {
+      this.ttsStart();
     }
-    return $el;
-  };
-})(BookReader.prototype.buildMobileDrawerElement);
+  }
+
+  ttsStart(startTTSEngine = true) {
+    if (this.br.constModeThumb == this.br.mode)
+      this.br.switchMode(this.br.constMode1up);
+
+    this.br.refs.$BRReadAloudToolbar.addClass('visible');
+    this.br.$('.BRicon.read').addClass('unread active');
+    this.ttsSendAnalyticsEvent('Start');
+    if (startTTSEngine)
+      this.ttsEngine.start(this.br.currentIndex(), this.br.book.getNumLeafs());
+  }
+
+  ttsJumpForward() {
+    if (this.ttsEngine.paused) {
+      this.ttsEngine.resume();
+    }
+    this.ttsEngine.jumpForward();
+  }
+
+  ttsJumpBackward() {
+    if (this.ttsEngine.paused) {
+      this.ttsEngine.resume();
+    }
+    this.ttsEngine.jumpBackward();
+  }
+
+  ttsUpdateState() {
+    const isPlaying = !(this.ttsEngine.paused || !this.ttsEngine.playing);
+    this.br.$('.read-aloud [name=play]').toggleClass('playing', isPlaying);
+  }
+
+  ttsPlayPause() {
+    if (!this.ttsEngine.playing) {
+      this.ttsToggle();
+    } else {
+      this.ttsEngine.togglePlayPause();
+      this.ttsUpdateState();
+    }
+  }
+
+
+  ttsStop() {
+    this.br.refs.$BRReadAloudToolbar.removeClass('visible');
+    this.br.$('.BRicon.read').removeClass('unread active');
+    this.ttsSendAnalyticsEvent('Stop');
+    this.ttsEngine.stop();
+    this.ttsRemoveHilites();
+    this.br.removeProgressPopup();
+  }
+
+  /**
+   * @param {PageChunk} chunk
+   * Returns once the flip is done
+   */
+  async ttsBeforeChunkPlay(chunk) {
+    await this.ttsMaybeFlipToIndex(chunk.leafIndex);
+    this.ttsHighlightChunk(chunk);
+    this.ttsScrollToChunk(chunk);
+  }
+
+  /**
+   * @param {PageChunk} chunk
+   */
+  ttsSendChunkFinishedAnalyticsEvent(chunk) {
+    this.ttsSendAnalyticsEvent('ChunkFinished-Words', approximateWordCount(chunk.text));
+  }
+
+  /**
+   * Flip the page if the provided leaf index is not visible
+   * @param {Number} leafIndex
+   */
+  async ttsMaybeFlipToIndex(leafIndex) {
+    if (this.br.constMode2up != this.br.mode) {
+      this.br.jumpToIndex(leafIndex);
+    } else {
+      await this.br._modes.mode2Up.mode2UpLit.jumpToIndex(leafIndex);
+    }
+  }
+
+  /**
+   * @param {PageChunk} chunk
+   */
+  ttsHighlightChunk(chunk) {
+    // The poorly-named variable leafIndex
+    const pageIndex = chunk.leafIndex;
+
+    this.ttsRemoveHilites();
+
+    // group by index; currently only possible to have chunks on one page :/
+    this._ttsBoxesByIndex = {
+      [pageIndex]: chunk.lineRects.map(([l, b, r, t]) => ({l, r, b, t})),
+    };
+
+    // update any already created pages
+    for (const [pageIndexString, boxes] of Object.entries(this._ttsBoxesByIndex)) {
+      const pageIndex = parseFloat(pageIndexString);
+      const page = this.br.book.getPage(pageIndex);
+      const pageContainers = this.br.getActivePageContainerElementsForIndex(pageIndex);
+      pageContainers.forEach(container => renderBoxesInPageContainerLayer('ttsHiliteLayer', boxes, page, container));
+    }
+  }
+
+  /**
+   * @param {PageChunk} chunk
+   */
+  ttsScrollToChunk(chunk) {
+    // It behaves weird if used in thumb mode
+    if (this.br.constModeThumb == this.br.mode) return;
+
+    $(`.pagediv${chunk.leafIndex} .ttsHiliteLayer rect`).last()?.[0]?.scrollIntoView({
+      // Only vertically center the highlight if we're in 1up or in full screen. In
+      // 2up, if we're not fullscreen, the whole body gets scrolled around to try to
+      // center the highlight 🙄 See:
+      // https://stackoverflow.com/questions/11039885/scrollintoview-causing-the-whole-page-to-move/11041376
+      // Note: nearest doesn't quite work great, because the ReadAloud toolbar is now
+      // full-width, and covers up the last line of the highlight.
+      block: this.br.constMode1up == this.br.mode || this.br.isFullscreenActive ? 'center' : 'nearest',
+      inline: 'center',
+      behavior: 'smooth',
+    });
+  }
+
+  ttsRemoveHilites() {
+    $(this.br.getActivePageContainerElements()).find('.ttsHiliteLayer').remove();
+    this._ttsBoxesByIndex = {};
+  }
+
+  /**
+   * @private
+   * Send an analytics event with an optional value. Also attaches the book's language.
+   * @param {string} action
+   * @param {number} [value]
+   */
+  ttsSendAnalyticsEvent(action, value) {
+    if (this.br._plugins.archiveAnalytics) {
+      const extraValues = {};
+      const mediaLanguage = this.ttsEngine.opts.bookLanguage;
+      if (mediaLanguage) extraValues.mediaLanguage = mediaLanguage;
+      this.br._plugins.archiveAnalytics.sendEvent('BRReadAloud', action, value, extraValues);
+    }
+  }
+}
 
 // Extend initNavbar
 BookReader.prototype.initNavbar = (function (super_) {
+  /**
+   * @this {import('@/src/BookReader.js').default}
+   */
   return function () {
     const $el = super_.call(this);
-    if (this.options.enableTtsPlugin && this.ttsEngine) {
+    if (this._plugins.tts?.options.enableTtsPlugin && this._plugins.tts?.ttsEngine) {
+      const ttsPlugin = this._plugins.tts;
       this.refs.$BRReadAloudToolbar = $(`
         <ul class="read-aloud">
           <li>
@@ -167,15 +304,15 @@ BookReader.prototype.initNavbar = (function (super_) {
 
       const renderVoicesMenu = (voicesMenu) => {
         voicesMenu.empty();
-        const bookLanguage = this.ttsEngine.opts.bookLanguage;
-        const bookLanguages = this.ttsEngine.getVoices().filter(v => v.lang.startsWith(bookLanguage)).sort(voiceSortOrder);
-        const otherLanguages = this.ttsEngine.getVoices().filter(v => !v.lang.startsWith(bookLanguage)).sort(voiceSortOrder);
+        const bookLanguage = ttsPlugin.ttsEngine.opts.bookLanguage;
+        const bookLanguages = ttsPlugin.ttsEngine.getVoices().filter(v => v.lang.startsWith(bookLanguage)).sort(voiceSortOrder);
+        const otherLanguages = ttsPlugin.ttsEngine.getVoices().filter(v => !v.lang.startsWith(bookLanguage)).sort(voiceSortOrder);
 
-        if (this.ttsEngine.getVoices().length > 1) {
+        if (ttsPlugin.ttsEngine.getVoices().length > 1) {
           voicesMenu.append($(`<optgroup label="Book Language (${bookLanguage})"> ${renderVoiceOption(bookLanguages)} </optgroup>`));
           voicesMenu.append($(`<optgroup label="Other Languages"> ${renderVoiceOption(otherLanguages)} </optgroup>`));
 
-          voicesMenu.val(this.ttsEngine.voice.voiceURI);
+          voicesMenu.val(ttsPlugin.ttsEngine.voice.voiceURI);
           voicesMenu.show();
         } else {
           voicesMenu.hide();
@@ -184,14 +321,14 @@ BookReader.prototype.initNavbar = (function (super_) {
 
       const voicesMenu = this.refs.$BRReadAloudToolbar.find('[name=playback-voice]');
       renderVoicesMenu(voicesMenu);
-      voicesMenu.on("change", ev => this.ttsEngine.setVoice(voicesMenu.val()));
-      this.ttsEngine.events.on('pause resume start', () => this.ttsUpdateState());
-      this.ttsEngine.events.on('voiceschanged', () => renderVoicesMenu(voicesMenu));
-      this.refs.$BRReadAloudToolbar.find('[name=play]').on("click", this.ttsPlayPause.bind(this));
-      this.refs.$BRReadAloudToolbar.find('[name=advance]').on("click", this.ttsJumpForward.bind(this));
-      this.refs.$BRReadAloudToolbar.find('[name=review]').on("click", this.ttsJumpBackward.bind(this));
+      voicesMenu.on("change", ev => ttsPlugin.ttsEngine.setVoice(voicesMenu.val()));
+      ttsPlugin.ttsEngine.events.on('pause resume start', () => ttsPlugin.ttsUpdateState());
+      ttsPlugin.ttsEngine.events.on('voiceschanged', () => renderVoicesMenu(voicesMenu));
+      this.refs.$BRReadAloudToolbar.find('[name=play]').on("click", ttsPlugin.ttsPlayPause.bind(ttsPlugin));
+      this.refs.$BRReadAloudToolbar.find('[name=advance]').on("click", ttsPlugin.ttsJumpForward.bind(ttsPlugin));
+      this.refs.$BRReadAloudToolbar.find('[name=review]').on("click", ttsPlugin.ttsJumpBackward.bind(ttsPlugin));
       const $rateSelector = this.refs.$BRReadAloudToolbar.find('select[name="playback-speed"]');
-      $rateSelector.on("change", ev => this.ttsEngine.setPlaybackRate(parseFloat($rateSelector.val())));
+      $rateSelector.on("change", ev => ttsPlugin.ttsEngine.setPlaybackRate(parseFloat($rateSelector.val())));
       $(`<li>
           <button class="BRicon read js-tooltip" title="${tooltips.readAloud}">
             <div class="icon icon-read-aloud"></div>
@@ -203,159 +340,4 @@ BookReader.prototype.initNavbar = (function (super_) {
   };
 })(BookReader.prototype.initNavbar);
 
-// ttsToggle()
-//______________________________________________________________________________
-BookReader.prototype.ttsToggle = function () {
-  this._plugins.autoplay?.stop();
-  if (this.ttsEngine.playing) {
-    this.ttsStop();
-  } else {
-    this.ttsStart();
-  }
-};
-
-// ttsStart(
-//______________________________________________________________________________
-BookReader.prototype.ttsStart = function (startTTSEngine = true) {
-  if (this.constModeThumb == this.mode)
-    this.switchMode(this.constMode1up);
-
-  this.refs.$BRReadAloudToolbar.addClass('visible');
-  this.$('.BRicon.read').addClass('unread active');
-  this.ttsSendAnalyticsEvent('Start');
-  if (startTTSEngine)
-    this.ttsEngine.start(this.currentIndex(), this.book.getNumLeafs());
-};
-
-BookReader.prototype.ttsJumpForward = function () {
-  if (this.ttsEngine.paused) {
-    this.ttsEngine.resume();
-  }
-  this.ttsEngine.jumpForward();
-};
-
-BookReader.prototype.ttsJumpBackward = function () {
-  if (this.ttsEngine.paused) {
-    this.ttsEngine.resume();
-  }
-  this.ttsEngine.jumpBackward();
-};
-
-BookReader.prototype.ttsUpdateState = function() {
-  const isPlaying = !(this.ttsEngine.paused || !this.ttsEngine.playing);
-  this.$('.read-aloud [name=play]').toggleClass('playing', isPlaying);
-};
-
-BookReader.prototype.ttsPlayPause = function() {
-  if (!this.ttsEngine.playing) {
-    this.ttsToggle();
-  } else {
-    this.ttsEngine.togglePlayPause();
-    this.ttsUpdateState();
-  }
-};
-
-// ttsStop()
-//______________________________________________________________________________
-BookReader.prototype.ttsStop = function () {
-  this.refs.$BRReadAloudToolbar.removeClass('visible');
-  this.$('.BRicon.read').removeClass('unread active');
-  this.ttsSendAnalyticsEvent('Stop');
-  this.ttsEngine.stop();
-  this.ttsRemoveHilites();
-  this.removeProgressPopup();
-};
-
-/**
- * @param {PageChunk} chunk
- * @return {PromiseLike<void>} returns once the flip is done
- */
-BookReader.prototype.ttsBeforeChunkPlay = async function(chunk) {
-  await this.ttsMaybeFlipToIndex(chunk.leafIndex);
-  this.ttsHighlightChunk(chunk);
-  this.ttsScrollToChunk(chunk);
-};
-
-/**
- * @param {PageChunk} chunk
- */
-BookReader.prototype.ttsSendChunkFinishedAnalyticsEvent = function(chunk) {
-  this.ttsSendAnalyticsEvent('ChunkFinished-Words', approximateWordCount(chunk.text));
-};
-
-/**
- * Flip the page if the provided leaf index is not visible
- * @param {Number} leafIndex
- */
-BookReader.prototype.ttsMaybeFlipToIndex = async function (leafIndex) {
-  if (this.constMode2up != this.mode) {
-    this.jumpToIndex(leafIndex);
-  } else {
-    await this._modes.mode2Up.mode2UpLit.jumpToIndex(leafIndex);
-  }
-};
-
-/**
- * @param {PageChunk} chunk
- */
-BookReader.prototype.ttsHighlightChunk = function(chunk) {
-  // The poorly-named variable leafIndex
-  const pageIndex = chunk.leafIndex;
-
-  this.ttsRemoveHilites();
-
-  // group by index; currently only possible to have chunks on one page :/
-  this._ttsBoxesByIndex = {
-    [pageIndex]: chunk.lineRects.map(([l, b, r, t]) => ({l, r, b, t})),
-  };
-
-  // update any already created pages
-  for (const [pageIndexString, boxes] of Object.entries(this._ttsBoxesByIndex)) {
-    const pageIndex = parseFloat(pageIndexString);
-    const page = this.book.getPage(pageIndex);
-    const pageContainers = this.getActivePageContainerElementsForIndex(pageIndex);
-    pageContainers.forEach(container => renderBoxesInPageContainerLayer('ttsHiliteLayer', boxes, page, container));
-  }
-};
-
-/**
- * @param {PageChunk} chunk
- */
-BookReader.prototype.ttsScrollToChunk = function(chunk) {
-  // It behaves weird if used in thumb mode
-  if (this.constModeThumb == this.mode) return;
-
-  $(`.pagediv${chunk.leafIndex} .ttsHiliteLayer rect`).last()?.[0]?.scrollIntoView({
-    // Only vertically center the highlight if we're in 1up or in full screen. In
-    // 2up, if we're not fullscreen, the whole body gets scrolled around to try to
-    // center the highlight 🙄 See:
-    // https://stackoverflow.com/questions/11039885/scrollintoview-causing-the-whole-page-to-move/11041376
-    // Note: nearest doesn't quite work great, because the ReadAloud toolbar is now
-    // full-width, and covers up the last line of the highlight.
-    block: this.constMode1up == this.mode || this.isFullscreenActive ? 'center' : 'nearest',
-    inline: 'center',
-    behavior: 'smooth',
-  });
-};
-
-// ttsRemoveHilites()
-//______________________________________________________________________________
-BookReader.prototype.ttsRemoveHilites = function () {
-  $(this.getActivePageContainerElements()).find('.ttsHiliteLayer').remove();
-  this._ttsBoxesByIndex = {};
-};
-
-/**
- * @private
- * Send an analytics event with an optional value. Also attaches the book's language.
- * @param {string} action
- * @param {number} [value]
- */
-BookReader.prototype.ttsSendAnalyticsEvent = function(action, value) {
-  if (this._plugins.archiveAnalytics) {
-    const extraValues = {};
-    const mediaLanguage = this.ttsEngine.opts.bookLanguage;
-    if (mediaLanguage) extraValues.mediaLanguage = mediaLanguage;
-    this._plugins.archiveAnalytics.sendEvent('BRReadAloud', action, value, extraValues);
-  }
-};
+BookReader?.registerPlugin('tts', TtsPlugin);

--- a/src/util/strings.js
+++ b/src/util/strings.js
@@ -9,6 +9,7 @@
  * @param {StringWithVars|String} template
  * @param { {[varName: string]: { toString: () => string} } } vars
  * @param { {[varName: string]: { toString: () => string} } } [overrides]
+ * @returns {StringWithVars|string}
  */
 export function applyVariables(template, vars, overrides = {}, possibleFilters = APPLY_FILTERS) {
   return template?.replace(/\{\{([^}]*?)\}\}/g, ($0, $1) => {


### PR DESCRIPTION
Blocked by #1374 , so ignore the autoplay files in this diff

Breaking Changes:
* All root-level BookReader tts methods/fields, eg `BookReader#ttsToggle`, `BookReader#ttsScrollToChunk`, `BookReader#ttsStart`, etc, have all been moved to e.g. `br._plugins.tts.toggle`. That is they are now on the `TtsPlugin` class, and no longer have the `tts` as in `ttsStart`.
* The option `enableTtsPlugin` has been renamed to `plugins.tts.enabled`
* The options `server` and `bookPath` have been replaced with `pageChunkUrl` StringWithVars. This makes the page chunk URL configurable for other clients.