### PR TITLE
 Convert ChaptersPlugin to BookReaderPlugin 

### DIFF
--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -70,6 +70,8 @@ BookReader.PLUGINS = {
   archiveAnalytics: null,
   /** @type {typeof import('./plugins/plugin.autoplay.js').AutoplayPlugin | null}*/
   autoplay: null,
+  /** @type {typeof import('./plugins/plugin.chapters.js').ChaptersPlugin | null}*/
+  chapters: null,
   /** @type {typeof import('./plugins/plugin.resume.js').ResumePlugin | null}*/
   resume: null,
   /** @type {typeof import('./plugins/plugin.text_selection.js').TextSelectionPlugin | null}*/
@@ -80,7 +82,7 @@ BookReader.PLUGINS = {
 
 /**
  * @param {string} pluginName
- * @param {typeof import('./BookReaderPlugin.js').BookReaderPlugin} plugin
+ * @param {new (...args: any[]) => import('./BookReaderPlugin.js').BookReaderPlugin} plugin
  */
 BookReader.registerPlugin = function(pluginName, plugin) {
   if (BookReader.PLUGINS[pluginName]) {
@@ -116,10 +118,14 @@ BookReader.prototype.setup = function(options) {
   // Store the options used to setup bookreader
   this.options = options;
 
+  /** @type {import('@/src/BookNavigator/book-navigator.js').BookNavigator} */
+  this.shell;
+
   // Construct the usual plugins first to get type hints
   this._plugins = {
     archiveAnalytics: BookReader.PLUGINS.archiveAnalytics ? new BookReader.PLUGINS.archiveAnalytics(this) : null,
     autoplay: BookReader.PLUGINS.autoplay ? new BookReader.PLUGINS.autoplay(this) : null,
+    chapters: BookReader.PLUGINS.chapters ? new BookReader.PLUGINS.chapters(this) : null,
     resume: BookReader.PLUGINS.resume ? new BookReader.PLUGINS.resume(this) : null,
     textSelection: BookReader.PLUGINS.textSelection ? new BookReader.PLUGINS.textSelection(this) : null,
     tts: BookReader.PLUGINS.tts ? new BookReader.PLUGINS.tts(this) : null,

--- a/src/BookReader/options.js
+++ b/src/BookReader/options.js
@@ -145,6 +145,8 @@ export const DEFAULT_OPTIONS = {
     archiveAnalytics: null,
     /** @type {import('../plugins/plugin.autoplay.js').AutoplayPlugin['options']}*/
     autoplay: null,
+    /** @type {import('../plugins/plugin.chapters.js').ChaptersPlugin['options']} */
+    chapters: null,
     /** @type {import('../plugins/plugin.iiif.js').IiifPlugin['options']} */
     iiif: null,
     /** @type {import('../plugins/plugin.resume.js').ResumePlugin['options']} */

--- a/tests/jest/plugins/plugin.chapters.test.js
+++ b/tests/jest/plugins/plugin.chapters.test.js
@@ -75,21 +75,21 @@ describe("ChaptersPlugin", () => {
     );
   });
 
-  describe("_chapterInit", () => {
+  describe("init", () => {
     test("does not render when open library has no record", async () => {
       const p = new ChaptersPlugin({ options: { vars: {} } });
       sinon.stub(p, "getOpenLibraryRecord").resolves(null);
-      sinon.spy(p, "_chaptersRender");
-      await p._chapterInit();
-      expect(p._chaptersRender.callCount).toBe(0);
+      sinon.spy(p, "_render");
+      await p.init();
+      expect(p._render.callCount).toBe(0);
     });
 
     test("does not render when open library record has no TOC", async () => {
       const p = new ChaptersPlugin({ options: { vars: {} } });
       sinon.stub(p, "getOpenLibraryRecord").resolves({ key: "/books/OL1M" });
-      sinon.spy(p, "_chaptersRender");
-      await p._chapterInit();
-      expect(p._chaptersRender.callCount).toBe(0);
+      sinon.spy(p, "_render");
+      await p.init();
+      expect(p._render.callCount).toBe(0);
     });
 
     test("renders if valid TOC on open library", async () => {
@@ -103,9 +103,9 @@ describe("ChaptersPlugin", () => {
         "table_of_contents": deepCopy(SAMPLE_TOC_OPTION),
         "ocaid": "adventureofsherl0000unse",
       });
-      sinon.stub(p, "_chaptersRender");
-      await p._chapterInit();
-      expect(p._chaptersRender.callCount).toBe(1);
+      sinon.stub(p, "_render");
+      await p.init();
+      expect(p._render.callCount).toBe(1);
     });
 
     test("does not fetch open library record if table of contents in options", async () => {
@@ -117,10 +117,10 @@ describe("ChaptersPlugin", () => {
       };
       const p = new ChaptersPlugin(fakeBR);
       sinon.stub(p, "getOpenLibraryRecord");
-      sinon.stub(p, "_chaptersRender");
-      await p._chapterInit();
+      sinon.stub(p, "_render");
+      await p.init();
       expect(p.getOpenLibraryRecord.callCount).toBe(0);
-      expect(p._chaptersRender.callCount).toBe(1);
+      expect(p._render.callCount).toBe(1);
     });
 
     test("converts leafs and pagenums to page index", async () => {
@@ -138,15 +138,15 @@ describe("ChaptersPlugin", () => {
         },
       };
       const p = new ChaptersPlugin(fakeBR);
-      sinon.stub(p, "_chaptersRender");
-      await p._chapterInit();
-      expect(p._chaptersRender.callCount).toBe(1);
+      sinon.stub(p, "_render");
+      await p.init();
+      expect(p._render.callCount).toBe(1);
       expect(p._tocEntries[0].pageIndex).toBe(1);
       expect(p._tocEntries[1].pageIndex).toBe(17);
     });
   });
 
-  describe('_chaptersRender', () => {
+  describe('_render', () => {
     test('renders markers and panel', () => {
       const fakeBR = {
         shell: {
@@ -156,17 +156,17 @@ describe("ChaptersPlugin", () => {
         },
       };
       const p = new ChaptersPlugin(fakeBR);
-      sinon.stub(p, '_chaptersRenderMarker');
+      sinon.stub(p, '_renderMarker');
       p._tocEntries = deepCopy(SAMPLE_TOC);
-      p._chaptersRender();
+      p._render();
       expect(fakeBR.shell.menuProviders['chapters']).toBeTruthy();
       expect(fakeBR.shell.addMenuShortcut.callCount).toBe(1);
       expect(fakeBR.shell.updateMenuContents.callCount).toBe(1);
-      expect(p._chaptersRenderMarker.callCount).toBeGreaterThan(1);
+      expect(p._renderMarker.callCount).toBeGreaterThan(1);
     });
   });
 
-  describe('_chaptersUpdateCurrent', () => {
+  describe('_updateCurrent', () => {
     test('highlights the current chapter', () => {
       const fakeBR = {
         mode: 2,
@@ -178,15 +178,15 @@ describe("ChaptersPlugin", () => {
       p._chaptersPanel = {
         currentChapter: null,
       };
-      p._chaptersUpdateCurrent();
+      p._updateCurrent();
       expect(p._chaptersPanel.currentChapter).toEqual(SAMPLE_TOC[1]);
 
       fakeBR.mode = 1;
-      p._chaptersUpdateCurrent();
+      p._updateCurrent();
       expect(p._chaptersPanel.currentChapter).toEqual(SAMPLE_TOC[0]);
 
       fakeBR.firstIndex = 0;
-      p._chaptersUpdateCurrent();
+      p._updateCurrent();
       expect(p._chaptersPanel.currentChapter).toBeUndefined();
     });
   });

--- a/tests/jest/plugins/plugin.chapters.test.js
+++ b/tests/jest/plugins/plugin.chapters.test.js
@@ -1,7 +1,7 @@
 import sinon from "sinon";
 
-import BookReader from "@/src/BookReader.js";
-import "@/src/plugins/plugin.chapters.js";
+import "@/src/BookReader.js";
+import {ChaptersPlugin} from "@/src/plugins/plugin.chapters.js";
 import { BookModel } from "@/src/BookReader/BookModel";
 import { deepCopy } from "../utils";
 /** @typedef {import('@/src/plugins/plugin.chapters').TocEntry} TocEntry  */
@@ -68,50 +68,44 @@ afterEach(() => {
   sinon.restore();
 });
 
-describe("BRChaptersPlugin", () => {
+describe("ChaptersPlugin", () => {
   beforeEach(() => {
     sinon.stub(BookModel.prototype, "getPageIndex").callsFake((str) =>
       parseFloat(str),
     );
   });
 
-  describe("_chaptersInit", () => {
-    test("does not render when no open library record", async () => {
-      const fakeBR = {
-        options: {},
-        getOpenLibraryRecord: async () => null,
-        _chaptersRender: sinon.stub(),
-      };
-      await BookReader.prototype._chapterInit.call(fakeBR);
-      expect(fakeBR._chaptersRender.callCount).toBe(0);
+  describe("_chapterInit", () => {
+    test("does not render when open library has no record", async () => {
+      const p = new ChaptersPlugin({ options: { vars: {} } });
+      sinon.stub(p, "getOpenLibraryRecord").resolves(null);
+      sinon.spy(p, "_chaptersRender");
+      await p._chapterInit();
+      expect(p._chaptersRender.callCount).toBe(0);
     });
 
-    test("does not render when open library record with no TOC", async () => {
-      const fakeBR = {
-        options: {},
-        getOpenLibraryRecord: async () => ({ key: "/books/OL1M" }),
-        _chaptersRender: sinon.stub(),
-      };
-      await BookReader.prototype._chapterInit.call(fakeBR);
-      expect(fakeBR._chaptersRender.callCount).toBe(0);
+    test("does not render when open library record has no TOC", async () => {
+      const p = new ChaptersPlugin({ options: { vars: {} } });
+      sinon.stub(p, "getOpenLibraryRecord").resolves({ key: "/books/OL1M" });
+      sinon.spy(p, "_chaptersRender");
+      await p._chapterInit();
+      expect(p._chaptersRender.callCount).toBe(0);
     });
 
     test("renders if valid TOC on open library", async () => {
       const fakeBR = {
-        options: {},
+        options: { vars: {} },
         bind: sinon.stub(),
-        book: {
-          getPageIndex: (str) => parseFloat(str),
-        },
-        getOpenLibraryRecord: async () => ({
-          "title": "The Adventures of Sherlock Holmes",
-          "table_of_contents": deepCopy(SAMPLE_TOC_OPTION),
-          "ocaid": "adventureofsherl0000unse",
-        }),
-        _chaptersRender: sinon.stub(),
       };
-      await BookReader.prototype._chapterInit.call(fakeBR);
-      expect(fakeBR._chaptersRender.callCount).toBe(1);
+      const p = new ChaptersPlugin(fakeBR);
+      sinon.stub(p, "getOpenLibraryRecord").resolves({
+        "title": "The Adventures of Sherlock Holmes",
+        "table_of_contents": deepCopy(SAMPLE_TOC_OPTION),
+        "ocaid": "adventureofsherl0000unse",
+      });
+      sinon.stub(p, "_chaptersRender");
+      await p._chapterInit();
+      expect(p._chaptersRender.callCount).toBe(1);
     });
 
     test("does not fetch open library record if table of contents in options", async () => {
@@ -120,12 +114,13 @@ describe("BRChaptersPlugin", () => {
           table_of_contents: deepCopy(SAMPLE_TOC_UNDEF),
         },
         bind: sinon.stub(),
-        getOpenLibraryRecord: sinon.stub(),
-        _chaptersRender: sinon.stub(),
       };
-      await BookReader.prototype._chapterInit.call(fakeBR);
-      expect(fakeBR.getOpenLibraryRecord.callCount).toBe(0);
-      expect(fakeBR._chaptersRender.callCount).toBe(1);
+      const p = new ChaptersPlugin(fakeBR);
+      sinon.stub(p, "getOpenLibraryRecord");
+      sinon.stub(p, "_chaptersRender");
+      await p._chapterInit();
+      expect(p.getOpenLibraryRecord.callCount).toBe(0);
+      expect(p._chaptersRender.callCount).toBe(1);
     });
 
     test("converts leafs and pagenums to page index", async () => {
@@ -141,31 +136,33 @@ describe("BRChaptersPlugin", () => {
           leafNumToIndex: (leaf) => leaf + 1,
           getPageIndex: (str) => parseFloat(str),
         },
-        _chaptersRender: sinon.stub(),
       };
-      await BookReader.prototype._chapterInit.call(fakeBR);
-      expect(fakeBR._chaptersRender.callCount).toBe(1);
-      expect(fakeBR._tocEntries[0].pageIndex).toBe(1);
-      expect(fakeBR._tocEntries[1].pageIndex).toBe(17);
+      const p = new ChaptersPlugin(fakeBR);
+      sinon.stub(p, "_chaptersRender");
+      await p._chapterInit();
+      expect(p._chaptersRender.callCount).toBe(1);
+      expect(p._tocEntries[0].pageIndex).toBe(1);
+      expect(p._tocEntries[1].pageIndex).toBe(17);
     });
   });
 
   describe('_chaptersRender', () => {
     test('renders markers and panel', () => {
       const fakeBR = {
-        _tocEntries: SAMPLE_TOC,
-        _chaptersRenderMarker: sinon.stub(),
         shell: {
           menuProviders: {},
           addMenuShortcut: sinon.stub(),
           updateMenuContents: sinon.stub(),
         },
       };
-      BookReader.prototype._chaptersRender.call(fakeBR);
+      const p = new ChaptersPlugin(fakeBR);
+      sinon.stub(p, '_chaptersRenderMarker');
+      p._tocEntries = deepCopy(SAMPLE_TOC);
+      p._chaptersRender();
       expect(fakeBR.shell.menuProviders['chapters']).toBeTruthy();
       expect(fakeBR.shell.addMenuShortcut.callCount).toBe(1);
       expect(fakeBR.shell.updateMenuContents.callCount).toBe(1);
-      expect(fakeBR._chaptersRenderMarker.callCount).toBeGreaterThan(1);
+      expect(p._chaptersRenderMarker.callCount).toBeGreaterThan(1);
     });
   });
 
@@ -175,21 +172,22 @@ describe("BRChaptersPlugin", () => {
         mode: 2,
         firstIndex: 16,
         displayedIndices: [16, 17],
-        _tocEntries: SAMPLE_TOC,
-        _chaptersPanel: {
-          currentChapter: null,
-        },
       };
-      BookReader.prototype._chaptersUpdateCurrent.call(fakeBR);
-      expect(fakeBR._chaptersPanel.currentChapter).toEqual(SAMPLE_TOC[1]);
+      const p = new ChaptersPlugin(fakeBR);
+      p._tocEntries = deepCopy(SAMPLE_TOC);
+      p._chaptersPanel = {
+        currentChapter: null,
+      };
+      p._chaptersUpdateCurrent();
+      expect(p._chaptersPanel.currentChapter).toEqual(SAMPLE_TOC[1]);
 
       fakeBR.mode = 1;
-      BookReader.prototype._chaptersUpdateCurrent.call(fakeBR);
-      expect(fakeBR._chaptersPanel.currentChapter).toEqual(SAMPLE_TOC[0]);
+      p._chaptersUpdateCurrent();
+      expect(p._chaptersPanel.currentChapter).toEqual(SAMPLE_TOC[0]);
 
       fakeBR.firstIndex = 0;
-      BookReader.prototype._chaptersUpdateCurrent.call(fakeBR);
-      expect(fakeBR._chaptersPanel.currentChapter).toBeUndefined();
+      p._chaptersUpdateCurrent();
+      expect(p._chaptersPanel.currentChapter).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
~Blocked by #1380~

Breaking changes:
* Options moved:
    * `options.olHost` → `options.plugins.chapters.olHost`
    * `options.enableChaptersPlugin` → `options.plugins.chapters.enabled`
    * Note `table_of_contents` _did not_ move; that is still root-level
* All chapters state/methods moved from `BookReader` to `BookReader.plugins.chapters`. Full list:
    * `BookReader._chapterInit` has been dissolved
    * `BookReader._chaptersRender` → `ChaptersPlugin._render`
    * `BookReader._chaptersRenderMarker` → `ChaptersPlugin._renderMarker`
    * `BookReader.getOpenLibraryRecord` → `ChaptersPlugin.getOpenLibraryRecord`
    * `BookReader._chaptersUpdateCurrent` → `ChaptersPlugin._updateCurrent`
    * `BookReader._tocEntries` → `ChaptersPlugin._tocEntries`
    * `BookReader._chaptersPanel` → `ChaptersPlugin._chaptersPanel`