### PR TITLE
Convert SearchPlugin to BookReaderPlugin

### DIFF
--- a/BookReaderDemo/IADemoBr.js
+++ b/BookReaderDemo/IADemoBr.js
@@ -70,9 +70,11 @@ const initializeBookReader = (brManifest) => {
     enableBookmarks: true, // turn this on
     enableFSLogoShortcut: true,
 
+    // TMP: To be replaced once BookReaderJSIA is updated to provide
+    // these in the right spot.
     plugins: {
       search: {
-        enableSearch: true,
+        enabled: true,
         initialSearchTerm: searchTerm ? searchTerm : '',
         searchInsideProtocol: brManifest.data.brOptions.searchInsideProtocol,
         searchInsideUrl: '/fulltext/inside.php',

--- a/BookReaderDemo/IADemoBr.js
+++ b/BookReaderDemo/IADemoBr.js
@@ -45,6 +45,23 @@ BookReader.optionOverrides.imagesBaseURL = '/BookReader/images/';
 const initializeBookReader = (brManifest) => {
   console.log('initializeBookReader', brManifest);
 
+  const {bookPath, subPrefix} = brManifest.data.brOptions;
+  let path = bookPath;
+  const subPrefixWithSlash = `/${subPrefix}`;
+  if (bookPath.length - bookPath.lastIndexOf(subPrefixWithSlash) == subPrefixWithSlash.length) {
+    path = bookPath.substr(0, bookPath.length - subPrefixWithSlash.length);
+  }
+
+  const searchInsideUrl = '//{{server}}/fulltext/inside.php?' + [
+    'item_id={{bookId|urlencode}}',
+    'doc={{subPrefix|urlencode}}',
+    'q={{query|urlencode}}',
+    // This endpoint doesn't expect the path to be url encoded
+    `path=${encodeURIComponent(path).replace(/%2F/g, '/')}`,
+    'pre_tag={{preTag|urlencode}}',
+    'post_tag={{postTag|urlencode}}',
+  ].join('&');
+
   const options = {
     el: '#BookReader',
     /* Url plugin - IA uses History mode for URL */
@@ -76,10 +93,9 @@ const initializeBookReader = (brManifest) => {
       search: {
         enabled: true,
         initialSearchTerm: searchTerm ? searchTerm : '',
-        searchInsideProtocol: brManifest.data.brOptions.searchInsideProtocol,
-        searchInsideUrl: '/fulltext/inside.php',
-        searchInsidePreTag: brManifest.data.brOptions.searchInsidePreTag,
-        searchInsidePostTag: brManifest.data.brOptions.searchInsidePostTag,
+        searchInsideUrl,
+        preTag: brManifest.data.brOptions.searchInsidePreTag,
+        postTag: brManifest.data.brOptions.searchInsidePostTag,
       },
     },
   };

--- a/BookReaderDemo/IADemoBr.js
+++ b/BookReaderDemo/IADemoBr.js
@@ -59,7 +59,6 @@ const initializeBookReader = (brManifest) => {
     enableBookTitleLink: false,
     bookUrlText: null,
     startFullscreen: openFullImmersionTheater,
-    initialSearchTerm: searchTerm ? searchTerm : '',
     // leaving this option commented out bc we change given user agent on archive.org
     // onePage: { autofit: <?=json_encode($this->ios ? 'width' : 'auto')?> },
     showToolbar: getFromUrl('options.showToolbar', 'false') === 'true',
@@ -70,6 +69,17 @@ const initializeBookReader = (brManifest) => {
     /* End multiple volumes */
     enableBookmarks: true, // turn this on
     enableFSLogoShortcut: true,
+
+    plugins: {
+      search: {
+        enableSearch: true,
+        initialSearchTerm: searchTerm ? searchTerm : '',
+        searchInsideProtocol: brManifest.data.brOptions.searchInsideProtocol,
+        searchInsideUrl: '/fulltext/inside.php',
+        searchInsidePreTag: brManifest.data.brOptions.searchInsidePreTag,
+        searchInsidePostTag: brManifest.data.brOptions.searchInsidePostTag,
+      },
+    },
   };
 
   // we want to show item as embedded when ?ui=embed is in URI

--- a/BookReaderDemo/ia-multiple-volumes-manifest.js
+++ b/BookReaderDemo/ia-multiple-volumes-manifest.js
@@ -5,7 +5,6 @@ const extraVolOptions = {
   "enableBookTitleLink": false,
   "bookUrlText": null,
   "startFullscreen": false,
-  "initialSearchTerm": null,
   "onePage": {
     "autofit": "auto"
   },

--- a/src/BookNavigator/book-navigator.js
+++ b/src/BookNavigator/book-navigator.js
@@ -186,7 +186,7 @@ export class BookNavigator extends LitElement {
 
     // Note plugins will never be null-ish in runtime, but some of the unit tests
     // stub BR with a nullish value there.
-    if (this.bookreader.options.plugins?.search?.enableSearch) {
+    if (this.bookreader.options.plugins?.search?.enabled) {
       providers.search = new SearchProvider({
         ...this.baseProviderConfig,
         /**

--- a/src/BookNavigator/book-navigator.js
+++ b/src/BookNavigator/book-navigator.js
@@ -10,6 +10,7 @@ import BookmarksProvider from './bookmarks/bookmarks-provider.js';
 import SharingProvider from './sharing.js';
 import ViewableFilesProvider from './viewable-files.js';
 import iaLogo from './assets/ia-logo.js';
+/** @typedef {import('@/src/BookReader.js').default} BookReader */
 
 const events = {
   menuUpdated: 'menuUpdated',
@@ -183,7 +184,9 @@ export class BookNavigator extends LitElement {
       providers.downloads = new DownloadProvider(this.baseProviderConfig);
     }
 
-    if (this.bookreader.options.enableSearch) {
+    // Note plugins will never be null-ish in runtime, but some of the unit tests
+    // stub BR with a nullish value there.
+    if (this.bookreader.options.plugins?.search?.enableSearch) {
       providers.search = new SearchProvider({
         ...this.baseProviderConfig,
         /**
@@ -193,7 +196,7 @@ export class BookNavigator extends LitElement {
          */
         onProviderChange: (brInstance = null, searchUpdates = {}) => {
           if (brInstance) {
-            /* refresh br instance reference */
+            /** @type {BookReader} refresh br instance reference */
             this.bookreader = brInstance;
           }
 

--- a/src/BookNavigator/search/search-provider.js
+++ b/src/BookNavigator/search/search-provider.js
@@ -204,6 +204,6 @@ export default class SearchProvider {
    * @param {{ detail: {match: SearchInsideMatch} }} param0
    */
   onSearchResultsClicked({ detail }) {
-    this.bookreader._plugins.search._searchPluginGoToResult(detail.match.matchIndex);
+    this.bookreader._plugins.search.jumpToMatch(detail.match.matchIndex);
   }
 }

--- a/src/BookNavigator/search/search-provider.js
+++ b/src/BookNavigator/search/search-provider.js
@@ -1,7 +1,10 @@
+// @ts-check
 import { html, nothing } from 'lit';
 import '@internetarchive/icon-search/icon-search';
 import './search-results';
 /** @typedef {import('@/src/plugins/search/plugin.search.js').SearchInsideMatch} SearchInsideMatch */
+/** @typedef {import('@/src/plugins/search/plugin.search.js').SearchInsideResults} SearchInsideResults */
+/** @typedef {import('@/src/BookReader.js').default} BookReader */
 
 let searchState = {
   query: '',
@@ -99,11 +102,14 @@ export default class SearchProvider {
     this.bookreader.search(searchState.query);
   }
 
+  /**
+   * @param {CustomEvent<{props: {instance: BookReader, results: SearchInsideResults}}>} event
+   */
   onSearchRequestError(event, errorType = 'default') {
-    const { detail: { props = {} } } = event;
-    const { instance = null } = props;
+    const { detail: { props } } = event;
+    const { instance, results } = props;
     if (instance) {
-      /* keep bookreader instance reference up-to-date */
+      /** @type {BookReader} keep bookreader instance reference up-to-date */
       this.bookreader = instance;
     }
     const errorMessages = {
@@ -114,7 +120,7 @@ export default class SearchProvider {
     };
 
     const messageToShow = errorMessages[errorType] ?? errorMessages.default;
-    searchState.query = instance?.searchResults?.q || '';
+    searchState.query = results?.q || '';
     searchState.results = [];
     searchState.resultsCount = 0;
     searchState.queryInProgress = false;
@@ -137,7 +143,7 @@ export default class SearchProvider {
   }
 
   searchCanceledInMenu() {
-    this.bookreader?.cancelSearchRequest();
+    this.bookreader._plugins.search.cancelSearchRequest();
   }
 
   onSearchResultsCleared() {
@@ -149,7 +155,7 @@ export default class SearchProvider {
       errorMessage: '',
     };
     this.updateMenu({ openMenu: false });
-    this.bookreader?.searchView?.clearSearchFieldAndResults(false);
+    this.bookreader._plugins.search.searchView.clearSearchFieldAndResults(false);
     if (this.bookreader.urlPlugin) {
       this.updateSearchInUrl();
     }
@@ -198,6 +204,6 @@ export default class SearchProvider {
    * @param {{ detail: {match: SearchInsideMatch} }} param0
    */
   onSearchResultsClicked({ detail }) {
-    this.bookreader._searchPluginGoToResult(detail.match.matchIndex);
+    this.bookreader._plugins.search._searchPluginGoToResult(detail.match.matchIndex);
   }
 }

--- a/src/BookNavigator/sharing.js
+++ b/src/BookNavigator/sharing.js
@@ -10,7 +10,7 @@ export default class SharingProvider {
   }) {
     const { identifier, creator, title } = item?.metadata;
     const creatorToUse = Array.isArray(creator) ? creator[0] : creator;
-    const subPrefix = bookreader.options.subPrefix || '';
+    const subPrefix = bookreader.subPrefix || '';
     const label = `Share this book`;
     this.icon = html`${iauxShareIcon}`;
     this.label = label;

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -74,6 +74,8 @@ BookReader.PLUGINS = {
   chapters: null,
   /** @type {typeof import('./plugins/plugin.resume.js').ResumePlugin | null}*/
   resume: null,
+  /** @type {typeof import('./plugins/search/plugin.search.js').SearchPlugin | null}*/
+  search: null,
   /** @type {typeof import('./plugins/plugin.text_selection.js').TextSelectionPlugin | null}*/
   textSelection: null,
   /** @type {typeof import('./plugins/tts/plugin.tts.js').TtsPlugin | null}*/
@@ -121,11 +123,22 @@ BookReader.prototype.setup = function(options) {
   /** @type {import('@/src/BookNavigator/book-navigator.js').BookNavigator} */
   this.shell;
 
+  // Base server used by some api calls
+  /** @deprecated */
+  this.bookId = options.bookId;
+  /** @deprecated */
+  this.server = options.server;
+  /** @deprecated */
+  this.subPrefix = options.subPrefix;
+  /** @deprecated */
+  this.bookPath = options.bookPath;
+
   // Construct the usual plugins first to get type hints
   this._plugins = {
     archiveAnalytics: BookReader.PLUGINS.archiveAnalytics ? new BookReader.PLUGINS.archiveAnalytics(this) : null,
     autoplay: BookReader.PLUGINS.autoplay ? new BookReader.PLUGINS.autoplay(this) : null,
     chapters: BookReader.PLUGINS.chapters ? new BookReader.PLUGINS.chapters(this) : null,
+    search: BookReader.PLUGINS.search ? new BookReader.PLUGINS.search(this) : null,
     resume: BookReader.PLUGINS.resume ? new BookReader.PLUGINS.resume(this) : null,
     textSelection: BookReader.PLUGINS.textSelection ? new BookReader.PLUGINS.textSelection(this) : null,
     tts: BookReader.PLUGINS.tts ? new BookReader.PLUGINS.tts(this) : null,
@@ -154,11 +167,13 @@ BookReader.prototype.setup = function(options) {
     }
   }
 
+  if (this._plugins.search?.options.enableSearch) {
+    // Expose the search method for convenience / backward compat
+    this.search = this._plugins.search.search.bind(this._plugins.search);
+  }
+
   /** @type {number} @deprecated some past iterations set this */
   this.numLeafs = undefined;
-
-  /** Overridden by plugin.search.js */
-  this.enableSearch = false;
 
   /**
    * Store viewModeOrder states
@@ -447,23 +462,24 @@ BookReader.prototype.initParams = function() {
   }
 
   // Check for Search plugin
-  if (this.options.enableSearch) {
+  if (this._plugins.search?.options.enableSearch) {
+    const sp = this._plugins.search;
     // Go to first result only if no default or URL page
-    this.options.goToFirstResult = !params.pageFound;
+    sp.options.goToFirstResult = !params.pageFound;
 
     // If initialSearchTerm not set
-    if (!this.options.initialSearchTerm) {
+    if (!sp.initialSearchTerm) {
       // Look for any term in URL
       if (params.search) {
         // Old style: /search/[term]
-        this.options.initialSearchTerm = params.search;
-        this.searchTerm = params.search;
+        sp.options.initialSearchTerm = params.search;
+        sp.searchTerm = params.search;
       } else {
         // If we have a query string: q=[term]
         const searchParams = new URLSearchParams(this.readQueryString());
         const searchTerm = searchParams.get('q');
         if (searchTerm) {
-          this.options.initialSearchTerm = utils.decodeURIComponentPlus(searchTerm);
+          sp.options.initialSearchTerm = utils.decodeURIComponentPlus(searchTerm);
         }
       }
     }
@@ -644,7 +660,7 @@ BookReader.prototype.init = function() {
   }
 
   // If not searching, set to allow on-going fragment changes
-  if (!this.options.initialSearchTerm) {
+  if (!this._plugins.search?.options.initialSearchTerm) {
     this.suppressFragmentChange = false;
   }
 
@@ -1308,7 +1324,7 @@ BookReader.prototype.updateFirstIndex = function(
   // If there's an initial search we stop suppressing global URL changes
   // when local suppression ends
   // This seems to correctly handle multiple calls during mode/1up
-  if (this.options.initialSearchTerm && !suppressFragmentChange) {
+  if (this._plugins.search.options.initialSearchTerm && !suppressFragmentChange) {
     this.suppressFragmentChange = false;
   }
 
@@ -1637,8 +1653,8 @@ BookReader.prototype.updateFromParams = function(params) {
   // process /search
   // @deprecated for urlMode 'history'
   // Continues to work for urlMode 'hash'
-  if (this.enableSearch && 'undefined' != typeof(params.search)) {
-    if (this.searchTerm !== params.search) {
+  if (this._plugins.search?.enableSearch && 'undefined' != typeof(params.search)) {
+    if (this._plugins.search.searchTerm !== params.search) {
       this.$('.BRsearchInput').val(params.search);
     }
   }
@@ -1842,8 +1858,8 @@ BookReader.prototype.paramsFromCurrent = function() {
     params.view = fullscreenView;
   }
   // Search
-  if (this.enableSearch) {
-    params.search = this.searchTerm;
+  if (this._plugins.search?.enableSearch) {
+    params.search = this._plugins.search.searchTerm;
   }
 
   return params;

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -167,7 +167,7 @@ BookReader.prototype.setup = function(options) {
     }
   }
 
-  if (this._plugins.search?.options.enableSearch) {
+  if (this._plugins.search?.options.enabled) {
     // Expose the search method for convenience / backward compat
     this.search = this._plugins.search.search.bind(this._plugins.search);
   }
@@ -462,7 +462,7 @@ BookReader.prototype.initParams = function() {
   }
 
   // Check for Search plugin
-  if (this._plugins.search?.options.enableSearch) {
+  if (this._plugins.search?.options.enabled) {
     const sp = this._plugins.search;
     // Go to first result only if no default or URL page
     sp.options.goToFirstResult = !params.pageFound;
@@ -1653,7 +1653,7 @@ BookReader.prototype.updateFromParams = function(params) {
   // process /search
   // @deprecated for urlMode 'history'
   // Continues to work for urlMode 'hash'
-  if (this._plugins.search?.enableSearch && 'undefined' != typeof(params.search)) {
+  if (this._plugins.search?.enabled && 'undefined' != typeof(params.search)) {
     if (this._plugins.search.searchTerm !== params.search) {
       this.$('.BRsearchInput').val(params.search);
     }
@@ -1858,7 +1858,7 @@ BookReader.prototype.paramsFromCurrent = function() {
     params.view = fullscreenView;
   }
   // Search
-  if (this._plugins.search?.enableSearch) {
+  if (this._plugins.search?.enabled) {
     params.search = this._plugins.search.searchTerm;
   }
 

--- a/src/BookReader/Toolbar/Toolbar.js
+++ b/src/BookReader/Toolbar/Toolbar.js
@@ -59,6 +59,11 @@ export class Toolbar {
       $titleSectionEl.append(br.bookUrlText || br.bookTitle);
     }
 
+    // Call _bindNavigationHandlers on the plugins
+    for (const plugin of Object.values(br._plugins)) {
+      plugin._configureToolbar(br.refs.$BRtoolbar);
+    }
+
     // const $hamburger = br.refs.$BRtoolbar.find('BRtoolbarHamburger');
     return br.refs.$BRtoolbar;
   }

--- a/src/BookReader/options.js
+++ b/src/BookReader/options.js
@@ -141,21 +141,21 @@ export const DEFAULT_OPTIONS = {
    * but going forward we'll keep them here.
    **/
   plugins: {
-    /** @type {import('../plugins/plugin.archive_analytics.js').ArchiveAnalyticsPlugin['options']}*/
+    /** @type {Partial<import('../plugins/plugin.archive_analytics.js').ArchiveAnalyticsPlugin['options'>]}*/
     archiveAnalytics: null,
-    /** @type {import('../plugins/plugin.autoplay.js').AutoplayPlugin['options']}*/
+    /** @type {Partial<import('../plugins/plugin.autoplay.js').AutoplayPlugin['options'>]}*/
     autoplay: null,
-    /** @type {import('../plugins/plugin.chapters.js').ChaptersPlugin['options']} */
+    /** @type {Partial<import('../plugins/plugin.chapters.js').ChaptersPlugin['options']>} */
     chapters: null,
-    /** @type {import('../plugins/plugin.iiif.js').IiifPlugin['options']} */
+    /** @type {Partial<import('../plugins/plugin.iiif.js').IiifPlugin['options']>} */
     iiif: null,
-    /** @type {import('../plugins/plugin.resume.js').ResumePlugin['options']} */
+    /** @type {Partial<import('../plugins/plugin.resume.js').ResumePlugin['options']>} */
     resume: null,
-    /** @type {import('../plugins/search/plugin.search.js').SearchPlugin['options']} */
+    /** @type {Partial<import('../plugins/search/plugin.search.js').SearchPlugin['options']>} */
     search: null,
-    /** @type {import('../plugins/plugin.text_selection.js').TextSelectionPlugin['options']} */
+    /** @type {Partial<import('../plugins/plugin.text_selection.js').TextSelectionPlugin['options']>} */
     textSelection: null,
-    /** @type {import('../plugins/tts/plugin.tts.js').TtsPlugin['options']} */
+    /** @type {Partial<import('../plugins/tts/plugin.tts.js').TtsPlugin['options']>} */
     tts: null,
   },
 

--- a/src/BookReader/options.js
+++ b/src/BookReader/options.js
@@ -151,6 +151,8 @@ export const DEFAULT_OPTIONS = {
     iiif: null,
     /** @type {import('../plugins/plugin.resume.js').ResumePlugin['options']} */
     resume: null,
+    /** @type {import('../plugins/search/plugin.search.js').SearchPlugin['options']} */
+    search: null,
     /** @type {import('../plugins/plugin.text_selection.js').TextSelectionPlugin['options']} */
     textSelection: null,
     /** @type {import('../plugins/tts/plugin.tts.js').TtsPlugin['options']} */

--- a/src/BookReaderPlugin.js
+++ b/src/BookReaderPlugin.js
@@ -34,6 +34,14 @@ export class BookReaderPlugin {
   _configurePageContainer(pageContainer) {
   }
 
+  /**
+   * @abstract
+   * @protected
+   * @param {JQuery<HTMLElement>} $toolbarElement
+   */
+  _configureToolbar($toolbarElement) {
+  }
+
   /** @abstract @protected */
   _bindNavigationHandlers() {}
 

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -43,11 +43,8 @@ export class SearchPlugin extends BookReaderPlugin {
      * @type {import('@/src/util/strings.js').StringWithVars}
      * Provides the variables: `query`, `preTag`, and `postTag` (from these options)
      */
-    searchInsideUrl: '//{{server}}/fulltext/inside.php?' + [
-      'item_id={{bookId|urlencode}}',
-      'doc={{subPrefix|urlencode}}',
+    searchInsideUrl: '/fulltext/inside.php?' + [
       'q={{query|urlencode}}',
-      'path={{bookPath|urlencode}}',
       'pre_tag={{preTag|urlencode}}',
       'post_tag={{postTag|urlencode}}',
     ].join('&'),

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -227,7 +227,7 @@ export class SearchPlugin extends BookReaderPlugin {
     this.searchTerm = '';
     this.searchXHR = null;
     this.searchCancelled = true;
-    this.searchResults = [];
+    this.searchResults = null;
   }
 
   /**
@@ -256,7 +256,7 @@ export class SearchPlugin extends BookReaderPlugin {
       this.options.searchInsidePreTag,
       this.options.searchInsidePostTag,
     );
-    this.searchResults = results || [];
+    this.searchResults = results || null;
 
     this.updateSearchHilites();
     this.br.removeProgressPopup();

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -1,5 +1,4 @@
 // @ts-check
-/* global BookReader */
 /**
  * Plugin for Archive.org book search
  * Events fired at various points throughout search processing are published
@@ -25,65 +24,61 @@ import { poll } from '../../BookReader/utils.js';
 import { renderBoxesInPageContainerLayer } from '../../BookReader/PageContainer.js';
 import SearchView from './view.js';
 import { marshallSearchResults } from './utils.js';
+import { BookReaderPlugin } from '../../BookReaderPlugin.js';
 /** @typedef {import('../../BookReader/PageContainer').PageContainer} PageContainer */
 /** @typedef {import('../../BookReader/BookModel').PageIndex} PageIndex */
 /** @typedef {import('../../BookReader/BookModel').LeafNum} LeafNum */
 /** @typedef {import('../../BookReader/BookModel').PageNumString} PageNumString */
 
-jQuery.extend(BookReader.defaultOptions, {
-  server: 'ia600609.us.archive.org',
-  bookId: '',
-  subPrefix: '',
-  bookPath: '',
-  enableSearch: true,
-  searchInsideProtocol: 'https',
-  searchInsideUrl: '/fulltext/inside.php',
-  searchInsidePreTag: '{{{',
-  searchInsidePostTag: '}}}',
-  initialSearchTerm: null,
-});
+// @ts-ignore
+const BookReader = /** @type {typeof import('@/src/BookReader.js').default} */(window.BookReader);
 
-/** @override */
-BookReader.prototype.setup = (function (super_) {
-  return function (options) {
-    super_.call(this, options);
+export class SearchPlugin extends BookReaderPlugin {
+  options = {
+    enableSearch: true,
+    searchInsideProtocol: 'https',
+    searchInsideUrl: '/fulltext/inside.php',
+    searchInsidePreTag: '{{{',
+    searchInsidePostTag: '}}}',
+    /** @type {string} */
+    initialSearchTerm: null,
+    goToFirstResult: false,
+  }
+
+  /**
+   * @override
+   * @param {Partial<SearchPlugin['options']>} options
+   **/
+  setup(options) {
+    super.setup(options);
 
     this.searchTerm = '';
+    /** @type {SearchInsideResults | null} */
     this.searchResults = null;
-    this.searchInsideUrl = options.searchInsideUrl;
-    this.enableSearch = options.enableSearch;
-
-    // Base server used by some api calls
-    this.bookId = options.bookId;
-    this.server = options.server;
-    this.subPrefix = options.subPrefix;
-    this.bookPath = options.bookPath;
-
+    this.searchInsideUrl = this.options.searchInsideUrl;
+    this.enableSearch = this.options.enableSearch;
     this.searchXHR = null;
-    this._cancelSearch.bind(this);
-    this.cancelSearchRequest.bind(this);
 
     /** @type { {[pageIndex: number]: SearchInsideMatchBox[]} } */
     this._searchBoxesByIndex = {};
 
     if (this.enableSearch) {
       this.searchView = new SearchView({
-        br: this,
+        br: this.br,
         searchCancelledCallback: () => {
           this._cancelSearch();
-          this.trigger('SearchCanceled', { term: this.searchTerm, instance: this });
+          this.br.trigger('SearchCanceled', { term: this.searchTerm, instance: this.br });
         },
       });
     } else {
       this.searchView = null;
     }
-  };
-})(BookReader.prototype.setup);
+  }
 
-/** @override */
-BookReader.prototype.init = (function (super_) {
-  return function () {
-    super_.call(this);
+  /** @override */
+  init() {
+    super.init();
+
     if (!this.enableSearch) return;
 
     this.searchView.init();
@@ -101,26 +96,27 @@ BookReader.prototype.init = (function (super_) {
         { goToFirstResult: this.options.goToFirstResult, suppressFragmentChange: false },
       );
     }
-  };
-})(BookReader.prototype.init);
+  }
 
-/** @override */
-BookReader.prototype.buildToolbarElement = (function (super_) {
-  return function () {
-    const $el = super_.call(this);
+  /**
+   * @override
+   * @protected
+   * @param {JQuery<HTMLElement>} $toolbarElement
+   */
+  _configureToolbar($toolbarElement) {
     if (!this.enableSearch) { return; }
     if (this.searchView.dom.toolbarSearch) {
-      $el.find('.BRtoolbarSectionInfo').after(this.searchView.dom.toolbarSearch);
+      $toolbarElement.find('.BRtoolbarSectionInfo').after(this.searchView.dom.toolbarSearch);
     }
-    return $el;
-  };
-})(BookReader.prototype.buildToolbarElement);
+    return $toolbarElement;
+  }
 
-/** @override */
-BookReader.prototype._createPageContainer = (function (super_) {
-  return function (index) {
-    const pageContainer = super_.call(this, index);
-    if (this.enableSearch && pageContainer.page && index in this._searchBoxesByIndex) {
+  /**
+   * @override
+   * @param {import ("@/src/BookReader/PageContainer.js").PageContainer} pageContainer
+   */
+  _configurePageContainer(pageContainer) {
+    if (this.enableSearch && pageContainer.page && pageContainer.page.index in this._searchBoxesByIndex) {
       const pageIndex = pageContainer.page.index;
       const boxes = this._searchBoxesByIndex[pageIndex];
       renderBoxesInPageContainerLayer(
@@ -132,140 +128,346 @@ BookReader.prototype._createPageContainer = (function (super_) {
       );
     }
     return pageContainer;
-  };
-})(BookReader.prototype._createPageContainer);
+  }
+
+  /**
+   * Submits search request
+   *
+   * @param {string} term
+   * @param {Partial<SearchOptions>} overrides
+   */
+  async search(term = '', overrides = {}) {
+    /** @type {SearchOptions} */
+    const defaultOptions = {
+      goToFirstResult: false, /* jump to the first result (default=false) */
+      disablePopup: false,    /* don't show the modal progress (default=false) */
+      suppressFragmentChange: false, /* don't change the URL on initial load */
+      error: null,            /* optional error handler (default=null) */
+      success: null,          /* optional success handler (default=null) */
+
+    };
+    const options = jQuery.extend({}, defaultOptions, overrides);
+    this.suppressFragmentChange = options.suppressFragmentChange;
+    this.searchCancelled = false;
+
+    // strip slashes, since this goes in the url
+    this.searchTerm = term.replace(/\//g, ' ');
+
+    if (!options.suppressFragmentChange) {
+      this.br.trigger(BookReader.eventNames.fragmentChange);
+    }
+
+    // Add quotes to the term. This is to compenstate for the backends default OR query
+    // term = term.replace(/['"]+/g, '');
+    // term = '"' + term + '"';
+
+    // Remove the port and userdir
+    const serverPath = this.br.server.replace(/:.+/, '');
+    const baseUrl = `${this.options.searchInsideProtocol}://${serverPath}${this.searchInsideUrl}?`;
+
+    // Remove subPrefix from end of path
+    let path = this.br.bookPath;
+    const subPrefixWithSlash = `/${this.br.subPrefix}`;
+    if (this.br.bookPath.length - this.br.bookPath.lastIndexOf(subPrefixWithSlash) == subPrefixWithSlash.length) {
+      path = this.br.bookPath.substr(0, this.br.bookPath.length - subPrefixWithSlash.length);
+    }
+
+    const urlParams = {
+      item_id: this.br.bookId,
+      doc: this.br.subPrefix,
+      path,
+      q: term,
+      pre_tag: this.options.searchInsidePreTag,
+      post_tag: this.options.searchInsidePostTag,
+    };
+
+    // NOTE that the API does not expect / (slashes) to be encoded. (%2F) won't work
+    const paramStr = $.param(urlParams).replace(/%2F/g, '/');
+
+    const url = `${baseUrl}${paramStr}`;
+
+    const callSearchResultsCallback = (searchInsideResults) => {
+      if (this.searchCancelled) {
+        return;
+      }
+      const responseHasError = searchInsideResults.error || !searchInsideResults.matches.length;
+      const hasCustomError = typeof options.error === 'function';
+      const hasCustomSuccess = typeof options.success === 'function';
+
+      if (responseHasError) {
+        console.error('Search Inside Response Error', searchInsideResults.error || 'matches.length == 0');
+        hasCustomError
+          ? options.error.call(this, searchInsideResults, options)
+          : this.BRSearchCallbackError(searchInsideResults);
+      } else {
+        hasCustomSuccess
+          ? options.success.call(this, searchInsideResults, options)
+          : this.BRSearchCallback(searchInsideResults, options);
+      }
+    };
+
+    this.br.trigger('SearchStarted', { term: this.searchTerm, instance: this.br });
+    callSearchResultsCallback(await $.ajax({
+      url: url,
+      cache: true,
+      xhrFields: {
+        withCredentials: this.br.protected,
+      },
+      beforeSend: xhr => { this.searchXHR = xhr; },
+    }));
+  }
+
+  /**
+   * cancels AJAX Call
+   * emits custom event
+   */
+  _cancelSearch() {
+    this.searchXHR?.abort();
+    this.searchView.clearSearchFieldAndResults(false);
+    this.searchTerm = '';
+    this.searchXHR = null;
+    this.searchCancelled = true;
+    this.searchResults = [];
+  }
+
+  /**
+   * External function to cancel search
+   * checks for term & xhr in flight before running
+   */
+  cancelSearchRequest() {
+    this.searchCancelled = true;
+    if (this.searchXHR !== null) {
+      this._cancelSearch();
+      this.searchView.toggleSearchPending();
+      this.br.trigger('SearchCanceled', { term: this.searchTerm, instance: this.br });
+    }
+  }
+
+  /**
+   * Search Results return handler
+   * @param {SearchInsideResults} results
+   * @param {object} options
+   * @param {boolean} options.goToFirstResult
+   */
+  BRSearchCallback(results, options) {
+    marshallSearchResults(
+      results,
+      pageNum => this.br.book.getPageNum(this.br.book.leafNumToIndex(pageNum)),
+      this.options.searchInsidePreTag,
+      this.options.searchInsidePostTag,
+    );
+    this.searchResults = results || [];
+
+    this.updateSearchHilites();
+    this.br.removeProgressPopup();
+    if (options.goToFirstResult) {
+      this._searchPluginGoToResult(0);
+    }
+    this.br.trigger('SearchCallback', { results, options, instance: this.br });
+  }
+
+  /**
+   * Main search results error handler
+   * @param {SearchInsideResults} results
+   */
+  BRSearchCallbackError(results) {
+    this._BRSearchCallbackError(results);
+  }
+
+  /**
+   * @private draws search results error
+   * @param {SearchInsideResults} results
+   */
+  _BRSearchCallbackError(results) {
+    this.searchResults = results;
+    const payload = {
+      term: this.searchTerm,
+      results,
+      instance: this.br,
+    };
+    if (results.error) {
+      this.br.trigger('SearchCallbackError', payload);
+    } else if (0 == results.matches.length) {
+      if (false === results.indexed) {
+        this.br.trigger('SearchCallbackBookNotIndexed', payload);
+        return;
+      }
+      this.br.trigger('SearchCallbackEmpty', payload);
+    }
+  }
+
+  /**
+   * updates search on-page highlights controller
+   */
+  updateSearchHilites() {
+    /** @type {SearchInsideMatch[]} */
+    const matches = this.searchResults?.matches || [];
+    /** @type { {[pageIndex: number]: SearchInsideMatchBox[]} } */
+    const boxesByIndex = {};
+
+    // Clear any existing svg layers
+    this.removeSearchHilites();
+
+    // Group by pageIndex
+    for (const match of matches) {
+      for (const box of match.par[0].boxes) {
+        const pageIndex = this.br.book.leafNumToIndex(box.page);
+        const pageBoxes = boxesByIndex[pageIndex] || (boxesByIndex[pageIndex] = []);
+        pageBoxes.push(box);
+      }
+    }
+
+    // update any already created pages
+    for (const [pageIndexString, boxes] of Object.entries(boxesByIndex)) {
+      const pageIndex = parseFloat(pageIndexString);
+      const page = this.br.book.getPage(pageIndex);
+      const pageContainers = this.br.getActivePageContainerElementsForIndex(pageIndex);
+      for (const container of pageContainers) {
+        renderBoxesInPageContainerLayer('searchHiliteLayer', boxes, page, container, boxes.map(b => `match-index-${b.matchIndex}`));
+      }
+    }
+
+    this._searchBoxesByIndex = boxesByIndex;
+  }
+
+  /**
+   * remove search highlights
+   */
+  removeSearchHilites() {
+    $(this.br.getActivePageContainerElements()).find('.searchHiliteLayer').remove();
+  }
+
+  /**
+   * Goes to the page specified. If the page is not viewable, tries to load the page
+   * FIXME Most of this logic is IA specific, and should be less integrated into here
+   * or at least more configurable.
+   * @param {number} matchIndex
+   */
+  async _searchPluginGoToResult(matchIndex) {
+    const match = this.searchResults?.matches[matchIndex];
+    const book = this.br.book;
+    const pageIndex = book.leafNumToIndex(match.par[0].page);
+    const page = book.getPage(pageIndex);
+    const onNearbyPage = Math.abs(this.br.currentIndex() - pageIndex) < 3;
+    let makeUnviewableAtEnd = false;
+    if (!page.isViewable) {
+      const resp = await fetch('/services/bookreader/request_page?' + new URLSearchParams({
+        id: this.options.bookId,
+        subprefix: this.options.subPrefix,
+        leafNum: page.leafNum,
+      })).then(r => r.json());
+
+      for (const leafNum of resp.value) {
+        book.getPage(book.leafNumToIndex(leafNum)).makeViewable();
+      }
+
+      // not able to show page; make the page viewable anyways so that it can
+      // actually open. On IA, it has a fallback to a special error page.
+      if (!resp.value.length) {
+        book.getPage(pageIndex).makeViewable();
+        makeUnviewableAtEnd = true;
+      }
+
+      // Trigger an update of book
+      this.br._modes.mode1Up.mode1UpLit.updatePages();
+      if (this.br.activeMode == this.br._modes.mode1Up) {
+        await this.br._modes.mode1Up.mode1UpLit.updateComplete;
+      }
+    }
+    /* this updates the URL */
+    if (!this.br._isIndexDisplayed(pageIndex)) {
+      this.suppressFragmentChange = false;
+      this.br.jumpToIndex(pageIndex);
+    }
+
+    // Reset it to unviewable if it wasn't resolved
+    if (makeUnviewableAtEnd) {
+      book.getPage(pageIndex).makeViewable(false);
+    }
+
+    // Scroll/flash in the ui
+    const $boxes = await poll(() => $(`rect.match-index-${match.matchIndex}`), { until: result => result.length > 0 });
+    if ($boxes.length) {
+      $boxes.css('animation', 'none');
+      $boxes[0].scrollIntoView({
+        // Only vertically center the highlight if we're in 1up or in full screen. In
+        // 2up, if we're not fullscreen, the whole body gets scrolled around to try to
+        // center the highlight 🙄 See:
+        // https://stackoverflow.com/questions/11039885/scrollintoview-causing-the-whole-page-to-move/11041376
+        // Note: nearest doesn't quite work great, because the ReadAloud toolbar is now
+        // full-width, and covers up the last line of the highlight.
+        block: this.br.constMode1up == this.br.mode || this.br.isFullscreenActive ? 'center' : 'nearest',
+        inline: 'center',
+        behavior: onNearbyPage ? 'smooth' : 'auto',
+      });
+      // wait for animation to start
+      await new Promise(resolve => setTimeout(resolve, 100));
+      $boxes.removeAttr("style");
+    }
+  }
+
+  /**
+   * Removes all search pins
+   */
+  removeSearchResults(suppressFragmentChange = false) {
+    this.removeSearchHilites(); //be sure to set all box.divs to null
+    this.searchTerm = null;
+    this.searchResults = null;
+    if (!suppressFragmentChange) {
+      this.br.trigger(BookReader.eventNames.fragmentChange);
+    }
+  }
+
+  /**
+   * Returns true if a search highlight is currently being displayed
+   * @returns {boolean}
+   */
+  searchHighlightVisible() {
+    const results = this.searchResults;
+    let visiblePages = [];
+    if (null == results) return false;
+
+    if (this.br.constMode2up == this.br.mode) {
+      visiblePages = [this.br.twoPage.currentIndexL, this.br.twoPage.currentIndexR];
+    } else if (this.br.constMode1up == this.br.mode) {
+      visiblePages = [this.br.currentIndex()];
+    } else {
+      return false;
+    }
+
+    results.matches.some(match => {
+      return match.par[0].boxes.some(box => {
+        const pageIndex = this.br.book.leafNumToIndex(box.page);
+        if (jQuery.inArray(pageIndex, visiblePages) >= 0) {
+          return true;
+        }
+      });
+    });
+
+    return false;
+  }
+}
+BookReader?.registerPlugin('search', SearchPlugin);
 
 /**
  * @typedef {object} SearchOptions
  * @property {boolean} goToFirstResult
  * @property {boolean} disablePopup
- * @property {(null|function)} error - @deprecated at v.5.0
- * @property {(null|function)} success - @deprecated at v.5.0
+ * @property {boolean} suppressFragmentChange
+ * @property {(null|function)} error (deprecated)
+ * @property {(null|function)} success (deprecated)
  */
 
 /**
- * Submits search request
- *
- * @param {string} term
- * @param {SearchOptions} overrides
+ * @typedef {object} SearchInsideMatchBox
+ * @property {number} page
+ * @property {number} r
+ * @property {number} l
+ * @property {number} b
+ * @property {number} t
+ * @property {HTMLDivElement} [div]
+ * @property {number} matchIndex This is a fake field! not part of the API response. The index of the match that contains this box in total search results matches.
  */
-BookReader.prototype.search = async function(term = '', overrides = {}) {
-  /** @type {SearchOptions} */
-  const defaultOptions = {
-    goToFirstResult: false, /* jump to the first result (default=false) */
-    disablePopup: false,    /* don't show the modal progress (default=false) */
-    suppressFragmentChange: false, /* don't change the URL on initial load */
-    error: null,            /* optional error handler (default=null) */
-    success: null,          /* optional success handler (default=null) */
-
-  };
-  const options = jQuery.extend({}, defaultOptions, overrides);
-  this.suppressFragmentChange = options.suppressFragmentChange;
-  this.searchCancelled = false;
-
-  // strip slashes, since this goes in the url
-  this.searchTerm = term.replace(/\//g, ' ');
-
-  if (!options.suppressFragmentChange) {
-    this.trigger(BookReader.eventNames.fragmentChange);
-  }
-
-  // Add quotes to the term. This is to compenstate for the backends default OR query
-  // term = term.replace(/['"]+/g, '');
-  // term = '"' + term + '"';
-
-  // Remove the port and userdir
-  const serverPath = this.server.replace(/:.+/, '');
-  const baseUrl = `${this.options.searchInsideProtocol}://${serverPath}${this.searchInsideUrl}?`;
-
-  // Remove subPrefix from end of path
-  let path = this.bookPath;
-  const subPrefixWithSlash = `/${this.subPrefix}`;
-  if (this.bookPath.length - this.bookPath.lastIndexOf(subPrefixWithSlash) == subPrefixWithSlash.length) {
-    path = this.bookPath.substr(0, this.bookPath.length - subPrefixWithSlash.length);
-  }
-
-  const urlParams = {
-    item_id: this.bookId,
-    doc: this.subPrefix,
-    path,
-    q: term,
-    pre_tag: this.options.searchInsidePreTag,
-    post_tag: this.options.searchInsidePostTag,
-  };
-
-  // NOTE that the API does not expect / (slashes) to be encoded. (%2F) won't work
-  const paramStr = $.param(urlParams).replace(/%2F/g, '/');
-
-  const url = `${baseUrl}${paramStr}`;
-
-  const callSearchResultsCallback = (searchInsideResults) => {
-    if (this.searchCancelled) {
-      return;
-    }
-    const responseHasError = searchInsideResults.error || !searchInsideResults.matches.length;
-    const hasCustomError = typeof options.error === 'function';
-    const hasCustomSuccess = typeof options.success === 'function';
-
-    if (responseHasError) {
-      console.error('Search Inside Response Error', searchInsideResults.error || 'matches.length == 0');
-      hasCustomError
-        ? options.error.call(this, searchInsideResults, options)
-        : this.BRSearchCallbackError(searchInsideResults, options);
-    } else {
-      hasCustomSuccess
-        ? options.success.call(this, searchInsideResults, options)
-        : this.BRSearchCallback(searchInsideResults, options);
-    }
-  };
-
-  this.trigger('SearchStarted', { term: this.searchTerm, instance: this });
-  callSearchResultsCallback(await $.ajax({
-    url: url,
-    cache: true,
-    xhrFields: {
-      withCredentials: this.protected,
-    },
-    beforeSend: xhr => { this.searchXHR = xhr; },
-  }));
-};
-
-/**
- * cancels AJAX Call
- * emits custom event
- */
-BookReader.prototype._cancelSearch = function () {
-  this.searchXHR?.abort();
-  this.searchView.clearSearchFieldAndResults(false);
-  this.searchTerm = '';
-  this.searchXHR = null;
-  this.searchCancelled = true;
-  this.searchResults = [];
-};
-
-/**
- * External function to cancel search
- * checks for term & xhr in flight before running
- */
-BookReader.prototype.cancelSearchRequest = function () {
-  this.searchCancelled = true;
-  if (this.searchXHR !== null) {
-    this._cancelSearch();
-    this.searchView.toggleSearchPending();
-    this.trigger('SearchCanceled', { term: this.searchTerm, instance: this });
-  }
-};
-
-/**
-  * @typedef {object} SearchInsideMatchBox
-  * @property {number} page
-  * @property {number} r
-  * @property {number} l
-  * @property {number} b
-  * @property {number} t
-  * @property {HTMLDivElement} [div]
-  * @property {number} matchIndex This is a fake field! not part of the API response. The index of the match that contains this box in total search results matches.
-  */
 
 /**
  * @typedef {object} SearchInsideMatch
@@ -278,216 +480,8 @@ BookReader.prototype.cancelSearchRequest = function () {
 
 /**
  * @typedef {object} SearchInsideResults
+ * @property {string} q
  * @property {string} error
  * @property {SearchInsideMatch[]} matches
  * @property {boolean} indexed
  */
-
-/**
- * Search Results return handler
- * @param {SearchInsideResults} results
- * @param {object} options
- * @param {boolean} options.goToFirstResult
- */
-BookReader.prototype.BRSearchCallback = function(results, options) {
-  marshallSearchResults(
-    results,
-    pageNum => this.book.getPageNum(this.book.leafNumToIndex(pageNum)),
-    this.options.searchInsidePreTag,
-    this.options.searchInsidePostTag,
-  );
-  this.searchResults = results || [];
-
-  this.updateSearchHilites();
-  this.removeProgressPopup();
-  if (options.goToFirstResult) {
-    this._searchPluginGoToResult(0);
-  }
-  this.trigger('SearchCallback', { results, options, instance: this });
-};
-
-/**
- * Main search results error handler
- * @callback
- * @param {SearchInsideResults} results
- */
-BookReader.prototype.BRSearchCallbackError = function(results) {
-  this._BRSearchCallbackError(results);
-};
-
-/**
- * @private draws search results error
- * @callback
- * @param {SearchInsideResults} results
- * @param {jQuery} $el
- * @param {boolean} fade
- */
-BookReader.prototype._BRSearchCallbackError = function(results) {
-  this.searchResults = results;
-  const basePayload = {
-    term: this.searchTerm,
-    instance: this,
-  };
-  if (results.error) {
-    const payload = Object.assign({}, basePayload, { results });
-    this.trigger('SearchCallbackError', payload);
-  } else if (0 == results.matches.length) {
-    if (false === results.indexed) {
-      this.trigger('SearchCallbackBookNotIndexed', basePayload);
-      return;
-    }
-    this.trigger('SearchCallbackEmpty', basePayload);
-  }
-};
-
-/**
- * updates search on-page highlights controller
- */
-BookReader.prototype.updateSearchHilites = function() {
-  /** @type {SearchInsideMatch[]} */
-  const matches = this.searchResults?.matches || [];
-  /** @type { {[pageIndex: number]: SearchInsideMatchBox[]} } */
-  const boxesByIndex = {};
-
-  // Clear any existing svg layers
-  this.removeSearchHilites();
-
-  // Group by pageIndex
-  for (const match of matches) {
-    for (const box of match.par[0].boxes) {
-      const pageIndex = this.book.leafNumToIndex(box.page);
-      const pageBoxes = boxesByIndex[pageIndex] || (boxesByIndex[pageIndex] = []);
-      pageBoxes.push(box);
-    }
-  }
-
-  // update any already created pages
-  for (const [pageIndexString, boxes] of Object.entries(boxesByIndex)) {
-    const pageIndex = parseFloat(pageIndexString);
-    const page = this.book.getPage(pageIndex);
-    const pageContainers = this.getActivePageContainerElementsForIndex(pageIndex);
-    for (const container of pageContainers) {
-      renderBoxesInPageContainerLayer('searchHiliteLayer', boxes, page, container, boxes.map(b => `match-index-${b.matchIndex}`));
-    }
-  }
-
-  this._searchBoxesByIndex = boxesByIndex;
-};
-
-/**
- * remove search highlights
- */
-BookReader.prototype.removeSearchHilites = function() {
-  $(this.getActivePageContainerElements()).find('.searchHiliteLayer').remove();
-};
-
-/**
- * @private
- * Goes to the page specified. If the page is not viewable, tries to load the page
- * FIXME Most of this logic is IA specific, and should be less integrated into here
- * or at least more configurable.
- * @param {number} matchIndex
- */
-BookReader.prototype._searchPluginGoToResult = async function (matchIndex) {
-  const match = this.searchResults?.matches[matchIndex];
-  const book = this.book;
-  const pageIndex = book.leafNumToIndex(match.par[0].page);
-  const page = book.getPage(pageIndex);
-  const onNearbyPage = Math.abs(this.currentIndex() - pageIndex) < 3;
-  let makeUnviewableAtEnd = false;
-  if (!page.isViewable) {
-    const resp = await fetch('/services/bookreader/request_page?' + new URLSearchParams({
-      id: this.options.bookId,
-      subprefix: this.options.subPrefix,
-      leafNum: page.leafNum,
-    })).then(r => r.json());
-
-    for (const leafNum of resp.value) {
-      book.getPage(book.leafNumToIndex(leafNum)).makeViewable();
-    }
-
-    // not able to show page; make the page viewable anyways so that it can
-    // actually open. On IA, it has a fallback to a special error page.
-    if (!resp.value.length) {
-      book.getPage(pageIndex).makeViewable();
-      makeUnviewableAtEnd = true;
-    }
-
-    // Trigger an update of book
-    this._modes.mode1Up.mode1UpLit.updatePages();
-    if (this.activeMode == this._modes.mode1Up) {
-      await this._modes.mode1Up.mode1UpLit.updateComplete;
-    }
-  }
-  /* this updates the URL */
-  if (!this._isIndexDisplayed(pageIndex)) {
-    this.suppressFragmentChange = false;
-    this.jumpToIndex(pageIndex);
-  }
-
-  // Reset it to unviewable if it wasn't resolved
-  if (makeUnviewableAtEnd) {
-    book.getPage(pageIndex).makeViewable(false);
-  }
-
-  // Scroll/flash in the ui
-  const $boxes = await poll(() => $(`rect.match-index-${match.matchIndex}`), { until: result => result.length > 0 });
-  if ($boxes.length) {
-    $boxes.css('animation', 'none');
-    $boxes[0].scrollIntoView({
-      // Only vertically center the highlight if we're in 1up or in full screen. In
-      // 2up, if we're not fullscreen, the whole body gets scrolled around to try to
-      // center the highlight 🙄 See:
-      // https://stackoverflow.com/questions/11039885/scrollintoview-causing-the-whole-page-to-move/11041376
-      // Note: nearest doesn't quite work great, because the ReadAloud toolbar is now
-      // full-width, and covers up the last line of the highlight.
-      block: this.constMode1up == this.mode || this.isFullscreenActive ? 'center' : 'nearest',
-      inline: 'center',
-      behavior: onNearbyPage ? 'smooth' : 'auto',
-    });
-    // wait for animation to start
-    await new Promise(resolve => setTimeout(resolve, 100));
-    $boxes.removeAttr("style");
-  }
-};
-
-/**
- * Removes all search pins
- */
-BookReader.prototype.removeSearchResults = function(suppressFragmentChange = false) {
-  this.removeSearchHilites(); //be sure to set all box.divs to null
-  this.searchTerm = null;
-  this.searchResults = null;
-  if (!suppressFragmentChange) {
-    this.trigger(BookReader.eventNames.fragmentChange);
-  }
-};
-
-/**
- * Returns true if a search highlight is currently being displayed
- * @returns {boolean}
- */
-BookReader.prototype.searchHighlightVisible = function() {
-  const results = this.searchResults;
-  let visiblePages = [];
-  if (null == results) return false;
-
-  if (this.constMode2up == this.mode) {
-    visiblePages = [this.twoPage.currentIndexL, this.twoPage.currentIndexR];
-  } else if (this.constMode1up == this.mode) {
-    visiblePages = [this.currentIndex()];
-  } else {
-    return false;
-  }
-
-  results.matches.some(match => {
-    return match.par[0].boxes.some(box => {
-      const pageIndex = this.book.leafNumToIndex(box.page);
-      if (jQuery.inArray(pageIndex, visiblePages) >= 0) {
-        return true;
-      }
-    });
-  });
-
-  return false;
-};

--- a/src/plugins/search/view.js
+++ b/src/plugins/search/view.js
@@ -273,7 +273,7 @@ class SearchView {
           $(event.target).addClass('front');
         })
         .on("mouseleave", (event) => $(event.target).removeClass('front'))
-        .on("click", () => { this.br._plugins.search._searchPluginGoToResult(match.matchIndex); });
+        .on("click", () => { this.br._plugins.search.jumpToMatch(match.matchIndex); });
     });
   }
 

--- a/src/plugins/search/view.js
+++ b/src/plugins/search/view.js
@@ -1,13 +1,17 @@
+// @ts-check
+/** @typedef {import('@/src/BookReader.js').default} BookReader */
+
 class SearchView {
   /**
    * @param {object} params
-   * @param {object} params.br The BookReader instance
-   * @param {function} params.cancelSearch callback when a user wants to cancel search
+   * @param {BookReader} params.br The BookReader instance
+   * @param {function} params.searchCancelledCallback callback when a user wants to cancel search
    *
    * @event BookReader:SearchResultsCleared - when the search results nav gets cleared
    * @event BookReader:ToggleSearchMenu - when search results menu should toggle
    */
   constructor({ br, searchCancelledCallback = () => {} }) {
+    /** @type {BookReader} */
     this.br = br;
     this.matches = [];
     this.cacheDOMElements();
@@ -40,7 +44,7 @@ class SearchView {
   }
 
   clearSearchFieldAndResults(dispatchEventWhenComplete = true) {
-    this.br.removeSearchResults();
+    this.br._plugins.search.removeSearchResults();
     this.removeResultPins();
     this.emptyMatches();
     this.setQuery('');
@@ -269,15 +273,15 @@ class SearchView {
           $(event.target).addClass('front');
         })
         .on("mouseleave", (event) => $(event.target).removeClass('front'))
-        .on("click", () => { this.br._searchPluginGoToResult(match.matchIndex); });
+        .on("click", () => { this.br._plugins.search._searchPluginGoToResult(match.matchIndex); });
     });
   }
 
   /**
-   * @param {boolean} bool
+   * @param {boolean} show
    */
-  toggleSearchPending(bool) {
-    if (bool) {
+  toggleSearchPending(show = false) {
+    if (show) {
       this.br.showProgressPopup("Search results will appear below...", () => this.progressPopupClosed());
     }
     else {
@@ -375,11 +379,11 @@ class SearchView {
 
   handleSearchStarted() {
     this.emptyMatches();
-    this.br.removeSearchHilites();
+    this.br._plugins.search.removeSearchHilites();
     this.removeResultPins();
     this.toggleSearchPending(true);
     this.teardownSearchNavigation();
-    this.setQuery(this.br.searchTerm);
+    this.setQuery(this.br._plugins.search.searchTerm);
   }
 
   /**

--- a/tests/e2e/helpers/mockSearch.js
+++ b/tests/e2e/helpers/mockSearch.js
@@ -2,7 +2,7 @@ export const TEST_TEXT_FOUND = 'theory';
 export const TEST_TEXT_NOT_FOUND = 'HopefullyNotFoundLongWord';
 export const PAGE_FIRST_RESULT = 30;
 
-export const SEARCH_INSIDE_URL_RE  = /https:\/\/ia[0-9]+\.us\.archive\.org\/fulltext\/inside\.php\?item_id=.*/;
+export const SEARCH_INSIDE_URL_RE  = /\/fulltext\/inside\.php/;
 
 /** Mock response for a matching search term. */
 export function mockResponseFound(req, res) {

--- a/tests/jest/BookNavigator/book-navigator.test.js
+++ b/tests/jest/BookNavigator/book-navigator.test.js
@@ -171,7 +171,13 @@ describe('<book-navigator>', () => {
             resize: sinon.fake(),
             currentIndex: sinon.fake(),
             jumpToIndex: sinon.fake(),
-            options: { enableSearch: true },
+            options: {
+              plugins: {
+                search: {
+                  enableSearch: true,
+                },
+              },
+            },
             refs: {
               $brContainer,
             },
@@ -346,7 +352,6 @@ describe('<book-navigator>', () => {
 
             let sidePanelConfig = {};
             el.addEventListener('updateSideMenu', (e) => {
-              console.log();
               sidePanelConfig = e.detail;
             });
             const toggleSearchMenuEvent = new Event('BookReader:ToggleSearchMenu');

--- a/tests/jest/BookNavigator/book-navigator.test.js
+++ b/tests/jest/BookNavigator/book-navigator.test.js
@@ -164,7 +164,7 @@ describe('<book-navigator>', () => {
         expect(el.menuProviders.visualAdjustments).toBeInstanceOf(VisualAdjustmentsProvider);
       });
       describe('Loading Sub Menus By Plugin Flags', () => {
-        test('Search: uses `enableSearch` flag', async() => {
+        test('Search: uses `enabled` flag', async() => {
           const el = fixtureSync(container());
           const $brContainer = document.createElement('div');
           const brStub = {
@@ -174,7 +174,7 @@ describe('<book-navigator>', () => {
             options: {
               plugins: {
                 search: {
-                  enableSearch: true,
+                  enabled: true,
                 },
               },
             },

--- a/tests/jest/BookNavigator/search/search-provider.test.js
+++ b/tests/jest/BookNavigator/search/search-provider.test.js
@@ -88,7 +88,11 @@ describe('Search Provider', () => {
         onProviderChange: sinon.fake(),
         bookreader: {
           leafNumToIndex: sinon.fake(),
-          _searchPluginGoToResult: sinon.fake(),
+          _plugins: {
+            search: {
+              _searchPluginGoToResult: sinon.fake(),
+            },
+          },
         },
       });
 
@@ -100,7 +104,7 @@ describe('Search Provider', () => {
           { detail: searchResultStub }),
       );
 
-      expect(provider.bookreader._searchPluginGoToResult.callCount).toEqual(1);
+      expect(provider.bookreader._plugins.search._searchPluginGoToResult.callCount).toEqual(1);
     });
     test('update url when search is cancelled or input cleared', async() => {
       const urlPluginMock = {
@@ -111,7 +115,11 @@ describe('Search Provider', () => {
         onProviderChange: sinon.fake(),
         bookreader: {
           leafNumToIndex: sinon.fake(),
-          _searchPluginGoToResult: sinon.fake(),
+          _plugins: {
+            search: {
+              _searchPluginGoToResult: sinon.fake(),
+            },
+          },
           urlPlugin: urlPluginMock,
         },
       });
@@ -145,7 +153,11 @@ describe('Search Provider', () => {
         onProviderChange: sinon.fake(),
         bookreader: {
           leafNumToIndex: sinon.fake(),
-          _searchPluginGoToResult: sinon.fake(),
+          _plugins: {
+            search: {
+              _searchPluginGoToResult: sinon.fake(),
+            },
+          },
           urlPlugin: urlPluginMock,
           search: sinon.fake(),
         },

--- a/tests/jest/BookNavigator/search/search-provider.test.js
+++ b/tests/jest/BookNavigator/search/search-provider.test.js
@@ -90,7 +90,7 @@ describe('Search Provider', () => {
           leafNumToIndex: sinon.fake(),
           _plugins: {
             search: {
-              _searchPluginGoToResult: sinon.fake(),
+              jumpToMatch: sinon.fake(),
             },
           },
         },
@@ -104,7 +104,7 @@ describe('Search Provider', () => {
           { detail: searchResultStub }),
       );
 
-      expect(provider.bookreader._plugins.search._searchPluginGoToResult.callCount).toEqual(1);
+      expect(provider.bookreader._plugins.search.jumpToMatch.callCount).toEqual(1);
     });
     test('update url when search is cancelled or input cleared', async() => {
       const urlPluginMock = {
@@ -117,7 +117,7 @@ describe('Search Provider', () => {
           leafNumToIndex: sinon.fake(),
           _plugins: {
             search: {
-              _searchPluginGoToResult: sinon.fake(),
+              jumpToMatch: sinon.fake(),
             },
           },
           urlPlugin: urlPluginMock,
@@ -155,7 +155,7 @@ describe('Search Provider', () => {
           leafNumToIndex: sinon.fake(),
           _plugins: {
             search: {
-              _searchPluginGoToResult: sinon.fake(),
+              jumpToMatch: sinon.fake(),
             },
           },
           urlPlugin: urlPluginMock,

--- a/tests/jest/BookNavigator/sharing/sharing-provider.test.js
+++ b/tests/jest/BookNavigator/sharing/sharing-provider.test.js
@@ -39,7 +39,7 @@ describe('Sharing Provider', () => {
         item,
         baseHost,
         bookreader: {
-          options: { subPrefix },
+          subPrefix,
         },
       });
 

--- a/tests/jest/BookReader.test.js
+++ b/tests/jest/BookReader.test.js
@@ -7,7 +7,12 @@ import '@/src/plugins/url/plugin.url.js';
 let br;
 beforeAll(() => {
   document.body.innerHTML = '<div id="BookReader">';
-  br = new BookReader();
+  br = new BookReader({
+    server: '',
+    bookId: '',
+    subPrefix: '',
+    bookPath: '',
+  });
 });
 
 afterEach(() => {
@@ -89,6 +94,26 @@ test('calls switchMode with init option when init called', () => {
   br.init();
   expect(br.switchMode.mock.calls[0][1])
     .toHaveProperty('init', true);
+});
+
+test('has added BR property: server', () => {
+  expect(br).toHaveProperty('server');
+  expect(br.server).toBeDefined();
+});
+
+test('has added BR property: bookId', () => {
+  expect(br).toHaveProperty('bookId');
+  expect(br.bookId).toBeDefined();
+});
+
+test('has added BR property: subPrefix', () => {
+  expect(br).toHaveProperty('subPrefix');
+  expect(br.subPrefix).toBeDefined();
+});
+
+test('has added BR property: bookPath', () => {
+  expect(br).toHaveProperty('bookPath');
+  expect(br.bookPath).toBeDefined();
 });
 
 test('has suppressFragmentChange true when init with no input', () => {

--- a/tests/jest/plugins/search/plugin.search.test.js
+++ b/tests/jest/plugins/search/plugin.search.test.js
@@ -5,6 +5,7 @@ import { DUMMY_RESULTS } from './utils.js';
 
 jest.mock('@/src/plugins/search/view.js');
 
+/** @type {BookReader} */
 let br;
 const namespace = 'BookReader:';
 const triggeredEvents = () => {
@@ -23,10 +24,14 @@ beforeEach(() => {
 
   $.fn.trigger = jest.fn();
   document.body.innerHTML = '<div id="BookReader">';
-  br = new BookReader();
+  br = new BookReader({
+    server: 'foo.bar.com',
+    bookPath: '/13/items/foo/foobar',
+    subPrefix: '/foobar',
+  });
   br.initToolbar = jest.fn();
   br.showProgressPopup = jest.fn();
-  br.searchXHR = jest.fn();
+  br._plugins.search.searchXHR = jest.fn();
 });
 
 afterEach(() => {
@@ -34,54 +39,24 @@ afterEach(() => {
 });
 
 describe('Plugin: Search', () => {
-  test('has option flag', () => {
-    expect(BookReader.defaultOptions.enableSearch).toEqual(true);
-  });
-
-  test('has added BR property: server', () => {
-    expect(br).toHaveProperty('server');
-    expect(br.server).toBeTruthy();
-  });
-
-  test('has added BR property: bookId', () => {
-    expect(br).toHaveProperty('bookId');
-    expect(br.bookId).toBeFalsy();
-  });
-
-  test('has added BR property: subPrefix', () => {
-    expect(br).toHaveProperty('subPrefix');
-    expect(br.subPrefix).toBeFalsy();
-  });
-
-  test('has added BR property: bookPath', () => {
-    expect(br).toHaveProperty('bookPath');
-    expect(br.bookPath).toBeFalsy();
-  });
-
-  test('has added BR property: searchInsideUrl', () => {
-    expect(br).toHaveProperty('searchInsideUrl');
-    expect(br.searchInsideUrl).toBeTruthy();
-  });
-
-  test('has added BR property: initialSearchTerm', () => {
-    expect(br.options).toHaveProperty('initialSearchTerm');
-    expect(br.options.initialSearchTerm).toBeFalsy();
-  });
-
   test('On init, it loads the toolbar', () => {
     br.init();
     expect(br.initToolbar).toHaveBeenCalled();
   });
 
+  test('Constructs SearchView', () => {
+    expect(br._plugins.search.searchView).toBeDefined();
+  });
+
   test('On init, it will run a search if given `options.initialSearchTerm`', () => {
-    br.search = jest.fn();
-    br.options.initialSearchTerm = 'foo';
+    br._plugins.search.search = jest.fn();
+    br.options.plugins.search.initialSearchTerm = 'foo';
     br.init();
 
-    expect(br.search).toHaveBeenCalled();
-    expect(br.search.mock.calls[0][1])
+    expect(br._plugins.search.search).toHaveBeenCalled();
+    expect(br._plugins.search.search.mock.calls[0][1])
       .toHaveProperty('goToFirstResult', true);
-    expect(br.search.mock.calls[0][1])
+    expect(br._plugins.search.search.mock.calls[0][1])
       .toHaveProperty('suppressFragmentChange', false);
   });
 
@@ -100,7 +75,7 @@ describe('Plugin: Search', () => {
   test('SearchStarted event fires and should go to first result', () => {
     br.init();
     br.search('foo', { goToFirstResult: true});
-    expect(br.options.goToFirstResult).toBeTruthy();
+    expect(br._plugins.search.options.goToFirstResult).toBeTruthy();
   });
 
   test('SearchCallback event fires when AJAX search returns results', async () => {

--- a/tests/jest/plugins/search/plugin.search.view.test.js
+++ b/tests/jest/plugins/search/plugin.search.view.test.js
@@ -1,9 +1,10 @@
-
+// @ts-check
 import BookReader from '@/src/BookReader.js';
 import '@/src/plugins/search/plugin.search.js';
 import { marshallSearchResults } from '@/src/plugins/search/utils.js';
 import '@/src/plugins/search/view.js';
 
+/** @type {BookReader} */
 let br;
 const namespace = 'BookReader:';
 const results = {
@@ -71,31 +72,22 @@ afterEach(() => {
 });
 
 describe('View: Plugin: Search', () => {
-  test('When search runs, the view gets created.', () => {
-    br.search = jest.fn();
-    br.options.initialSearchTerm = 'foo';
-    br.init();
-
-    expect(br.searchView).toBeDefined();
-    expect(br.searchView.handleSearchCallback).toBeDefined();
-  });
-
   describe("Search results navigation bar", () => {
     test('Search Results callback creates the results nav', () => {
       br.init();
       const event = new CustomEvent(`${namespace}SearchCallback`);
       const options = { goToFirstResult: false };
 
-      expect(br.searchView.dom.searchNavigation).toBeUndefined();
+      expect(br._plugins.search.searchView.dom.searchNavigation).toBeUndefined();
 
-      br.searchView.handleSearchCallback(event, { results, options});
-      expect(br.searchView.dom.searchNavigation).toBeDefined();
+      br._plugins.search.searchView.handleSearchCallback(event, { results, options});
+      expect(br._plugins.search.searchView.dom.searchNavigation).toBeDefined();
     });
     test('has controls', () => {
       br.init();
       const event = new CustomEvent(`${namespace}SearchCallback`);
       const options = { goToFirstResult: false };
-      br.searchView.handleSearchCallback(event, { results, options});
+      br._plugins.search.searchView.handleSearchCallback(event, { results, options});
 
       const searchResultsNav = document.querySelector('.BRsearch-navigation');
       expect(searchResultsNav).toBeDefined();
@@ -110,9 +102,9 @@ describe('View: Plugin: Search', () => {
       br.init();
       const event = new CustomEvent(`${namespace}SearchCallback`);
       const options = { goToFirstResult: false };
-      br.searchView.handleSearchCallback(event, { results: resultWithScript, options });
+      br._plugins.search.searchView.handleSearchCallback(event, { results: resultWithScript, options });
 
-      expect(br.searchView.dom.searchNavigation.parent().html()).not.toContain('<script>alert(1);</script>');
+      expect(br._plugins.search.searchView.dom.searchNavigation.parent().html()).not.toContain('<script>alert(1);</script>');
     });
 
     describe('Click events handlers', () => {
@@ -122,7 +114,7 @@ describe('View: Plugin: Search', () => {
         br.trigger = (eventName) => eventNameTriggered = eventName;
 
         expect(eventNameTriggered).toBeFalsy();
-        br.searchView.toggleSidebar();
+        br._plugins.search.searchView.toggleSidebar();
         expect(eventNameTriggered).toEqual('ToggleSearchMenu');
       });
       it('triggers custom event when closing navbar', () => {
@@ -131,7 +123,7 @@ describe('View: Plugin: Search', () => {
         br.trigger = (eventName) => eventNameTriggered = eventName;
 
         expect(eventNameTriggered).toBeFalsy();
-        br.searchView.clearSearchFieldAndResults();
+        br._plugins.search.searchView.clearSearchFieldAndResults();
         expect(eventNameTriggered).toEqual('SearchResultsCleared');
       });
     });

--- a/tests/jest/plugins/url/plugin.url.test.js
+++ b/tests/jest/plugins/url/plugin.url.test.js
@@ -145,7 +145,7 @@ describe('Plugin: URL controller', () => {
       search: 'foo',
     }));
     BookReader.prototype.search = jest.fn();
-    br.options.initialSearchTerm = 'foo';
+    br.options.plugins.search = { initialSearchTerm: 'foo' };
     br.options.urlMode = 'history';
     br.init();
     br.urlUpdateFragment();


### PR DESCRIPTION
Breaking changes:
* Search options are now nested under the plugin (eg `searchInsideUrl` → `options.plugins.search.searchInsideUrl`), and mostly longer include the `search` prefix; specifically:
    * `searchInsidePreTag`, `searchInsidePostTag` → `options.plugins.search.preTag` and `postTag`
    * `searchInsideUrl` is now a `StringWithVars` and supports including `vars` from the root options, e.g. `searchInsideUrl: "https://{{server}}/search_endpoint?q={{query|urlencode}}"` . It also has access to the `preTag` and `postTag` from the options. Note this allows the search inside URL to now be fully customizable from the options, and is no longer hard-coded internally to Internet Archive specific logic. 
    * `initialSearchTerm` → `options.plugins.search.initialSearchTerm`
    * `searchInsideProtocol` → deprecated in favour of variables in `searchInsideUrl`
* Internal search related methods/properties are now nested in the `SearchPlugin` and no longer accessible from the root bookreader object. Notable exception: `br.search` is still made available for convenience.
    * Moved: `searchResults`, `searchXHR`, `searchView`, `cancelSearchRequest`, `BRSearchCallback`, `updateSearchHilites`, `removeSearchResults`, `removeSearchHilites`, `searchHighlightVisible`
