### PR TITLE
Fix TTS chrome pausing workaround bugs

### DIFF
--- a/src/plugins/tts/WebTTSEngine.js
+++ b/src/plugins/tts/WebTTSEngine.js
@@ -282,7 +282,7 @@ export class WebTTSSound {
       await this.reload();
     }
 
-    if (!this.started) {
+    if (!this.started || this.stopped) {
       this.play();
       return;
     }

--- a/src/plugins/tts/WebTTSEngine.js
+++ b/src/plugins/tts/WebTTSEngine.js
@@ -152,7 +152,7 @@ export class WebTTSSound {
       this.utterance.addEventListener('resume', () => console.log('resume'));
       this.utterance.addEventListener('start', () => console.log('start'));
       this.utterance.addEventListener('end', () => console.log('end'));
-      this.utterance.addEventListener('error', () => console.log('error'));
+      this.utterance.addEventListener('error', ev => console.log('error', ev));
       this.utterance.addEventListener('boundary', () => console.log('boundary'));
       this.utterance.addEventListener('mark', () => console.log('mark'));
       this.utterance.addEventListener('finish', () => console.log('finish'));

--- a/src/plugins/tts/WebTTSEngine.js
+++ b/src/plugins/tts/WebTTSEngine.js
@@ -13,7 +13,7 @@ import AbstractTTSEngine from './AbstractTTSEngine.js';
  **/
 export default class WebTTSEngine extends AbstractTTSEngine {
   static isSupported() {
-    return typeof(window.speechSynthesis) !== 'undefined' && !/samsungbrowser/i.test(navigator.userAgent);
+    return typeof(window.speechSynthesis) !== 'undefined';
   }
 
   /** @param {TTSEngineOptions} options */

--- a/src/plugins/tts/WebTTSEngine.js
+++ b/src/plugins/tts/WebTTSEngine.js
@@ -48,6 +48,10 @@ export default class WebTTSEngine extends AbstractTTSEngine {
           ],
         });
 
+        navigator.mediaSession.setPositionState({
+          duration: Infinity,
+        });
+
         navigator.mediaSession.setActionHandler('play', () => {
           audio.play();
           this.resume();

--- a/src/plugins/tts/WebTTSEngine.js
+++ b/src/plugins/tts/WebTTSEngine.js
@@ -278,10 +278,6 @@ export class WebTTSSound {
   }
 
   async resume() {
-    if (this._chromeTimedOutWhilePaused) {
-      await this.reload();
-    }
-
     if (!this.started || this.stopped) {
       this.play();
       return;
@@ -337,7 +333,6 @@ export class WebTTSSound {
       console.log('CHROME-PAUSE-HACK: starting');
     }
 
-    this._chromeTimedOutWhilePaused = false;
     const result = await Promise.race([
       sleep(14000).then(() => 'timeout'),
       promisifyEvent(this.utterance, 'pause').then(() => 'pause'),
@@ -368,9 +363,9 @@ export class WebTTSSound {
         if (DEBUG_READ_ALOUD) {
           console.log('CHROME-PAUSE-HACK: stopped (timed out while paused)');
         }
-        // We hit Chrome's secret cut off time while paused, note as such
-        // so we can reload when the user tries to resume.
-        this._chromeTimedOutWhilePaused = true;
+        // We hit Chrome's secret cut off time while paused, and
+        // won't be able to resume normally, so trigger a stop.
+        this.stop();
       } else {
         // The user resumed before the cut off! Continue as normal
         this._chromePausingBugFix();

--- a/src/plugins/tts/utils.js
+++ b/src/plugins/tts/utils.js
@@ -79,3 +79,5 @@ export function hasLocalStorage() {
     return false;
   }
 }
+
+export const DEBUG_READ_ALOUD = location.toString().indexOf('_debugReadAloud=true') != -1;

--- a/src/plugins/tts/utils.js
+++ b/src/plugins/tts/utils.js
@@ -81,3 +81,14 @@ export function hasLocalStorage() {
 }
 
 export const DEBUG_READ_ALOUD = location.toString().indexOf('_debugReadAloud=true') != -1;
+
+export async function checkIfFiresPause() {
+  // Pick some random text so that if it accidentally speaks, it's not too annoying
+  const u = new SpeechSynthesisUtterance("Loading");
+  let calledPause = false;
+  u.addEventListener('pause', () => calledPause = true);
+  speechSynthesis.speak(u);
+  await new Promise(res => setTimeout(res, 10));
+  speechSynthesis.pause();
+  return calledPause;
+}

--- a/src/util/browserSniffing.js
+++ b/src/util/browserSniffing.js
@@ -7,7 +7,17 @@
  * @return {boolean}
  */
 export function isChrome(userAgent = navigator.userAgent, vendor = navigator.vendor) {
-  return /chrome/i.test(userAgent) && /google inc/i.test(vendor) && !/\bedg\b/i.test(userAgent);
+  return /chrome/i.test(userAgent) && /google inc/i.test(vendor) && !isEdge(userAgent);
+}
+
+/**
+ * Checks whether the current browser is a Edge browser
+ * See https://learn.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-guidance
+ * @param {string} [userAgent]
+ * @return {boolean}
+ */
+export function isEdge(userAgent = navigator.userAgent) {
+  return /chrome/i.test(userAgent) && /\bEdg(e|A|iOS)?\b/i.test(userAgent);
 }
 
 /**

--- a/src/util/browserSniffing.js
+++ b/src/util/browserSniffing.js
@@ -7,7 +7,7 @@
  * @return {boolean}
  */
 export function isChrome(userAgent = navigator.userAgent, vendor = navigator.vendor) {
-  return /chrome/i.test(userAgent) && /google inc/i.test(vendor);
+  return /chrome/i.test(userAgent) && /google inc/i.test(vendor) && !/\bedg\b/i.test(userAgent);
 }
 
 /**

--- a/tests/jest/plugins/tts/WebTTSEngine.test.js
+++ b/tests/jest/plugins/tts/WebTTSEngine.test.js
@@ -93,44 +93,51 @@ describe('WebTTSSound', () => {
   });
 
   describe('_chromePausingBugFix', () => {
+    /** @type {sinon.SinonFakeTimers} */
+    let clock = null;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
     test('if speech less than 15s, nothing special', async () => {
-      const clock = sinon.useFakeTimers();
       const sound = new WebTTSSound('hello world foo bar');
       sound.load();
       sound.play();
       sound._chromePausingBugFix();
       clock.tick(10000);
       sound.utterance.dispatchEvent('end', {});
-      clock.restore();
       await afterEventLoop();
       expect(speechSynthesis.pause.callCount).toBe(0);
     });
 
     test('if speech greater than 15s, pause called', async () => {
-      const clock = sinon.useFakeTimers();
       const sound = new WebTTSSound('foo bah');
       sound.load();
       sound.play();
       sound._chromePausingBugFix();
       clock.tick(20000);
-      clock.restore();
 
       await afterEventLoop();
       expect(speechSynthesis.pause.callCount).toBe(1);
     });
 
     test('on pause reloads if timed out', async () => {
-      const clock = sinon.useFakeTimers();
       const sound = new WebTTSSound('foo bah');
       sound.load();
       sound.play();
       sound._chromePausingBugFix();
-      sound.pause();
-      clock.tick(2000);
-      clock.restore();
+      clock.tick(5000);
+      sound.utterance.dispatchEvent('pause', {});
+      await afterEventLoop();
+      clock.tick(15000);
 
       await afterEventLoop();
-      expect(speechSynthesis.cancel.callCount).toBe(1);
+      expect(sound._chromeTimedOutWhilePaused).toBe(true);
     });
   });
 

--- a/tests/jest/plugins/tts/WebTTSEngine.test.js
+++ b/tests/jest/plugins/tts/WebTTSEngine.test.js
@@ -143,8 +143,6 @@ describe('WebTTSSound', () => {
 
   test('fire pause if browser does not do it', async () => {
     const clock = sinon.useFakeTimers();
-    const languageGetter = jest.spyOn(window.navigator, 'userAgent', 'get');
-    languageGetter.mockReturnValue('firefox android');
     const sound = new WebTTSSound('foo bah');
     sound.load();
     sound.play();

--- a/tests/jest/plugins/tts/WebTTSEngine.test.js
+++ b/tests/jest/plugins/tts/WebTTSEngine.test.js
@@ -126,10 +126,11 @@ describe('WebTTSSound', () => {
       expect(speechSynthesis.pause.callCount).toBe(1);
     });
 
-    test('on pause reloads if timed out', async () => {
+    test('on pause, stops sound if timed out', async () => {
       const sound = new WebTTSSound('foo bah');
       sound.load();
       sound.play();
+      sound.stop = sinon.stub();
       sound._chromePausingBugFix();
       clock.tick(5000);
       sound.utterance.dispatchEvent('pause', {});
@@ -137,7 +138,7 @@ describe('WebTTSSound', () => {
       clock.tick(15000);
 
       await afterEventLoop();
-      expect(sound._chromeTimedOutWhilePaused).toBe(true);
+      expect(sound.stop.callCount).toBe(1);
     });
   });
 

--- a/tests/jest/util/browserSniffing.test.js
+++ b/tests/jest/util/browserSniffing.test.js
@@ -1,5 +1,5 @@
 import {
-  isChrome, isFirefox, isSafari,
+  isChrome, isEdge, isFirefox, isSafari,
 } from '@/src/util/browserSniffing.js';
 
 const TESTS = [
@@ -19,13 +19,13 @@ const TESTS = [
     name: 'Edge on Windows 10',
     userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; ServiceUI 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.18362',
     vendor: '',
-    machingFn: null,
+    machingFn: isEdge,
   },
   {
     name: 'Edge on Windows 11',
     userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36 Edg/134.0.0.0',
     vendor: 'Google Inc.',
-    machingFn: null,
+    machingFn: isEdge,
   },
   {
     name: 'IE11 on Windows 10',
@@ -53,7 +53,7 @@ const TESTS = [
   },
 ];
 
-for (const fn of [isChrome, isFirefox, isSafari]) {
+for (const fn of [isChrome, isEdge, isFirefox, isSafari]) {
   describe(fn.name, () => {
     for (const { name, userAgent, vendor, machingFn } of TESTS) {
       test(name, () => expect(fn(userAgent, vendor)).toBe(machingFn == fn));

--- a/tests/jest/util/browserSniffing.test.js
+++ b/tests/jest/util/browserSniffing.test.js
@@ -22,6 +22,12 @@ const TESTS = [
     machingFn: null,
   },
   {
+    name: 'Edge on Windows 11',
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36 Edg/134.0.0.0',
+    vendor: 'Google Inc.',
+    machingFn: null,
+  },
+  {
     name: 'IE11 on Windows 10',
     userAgent: 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; Touch; .NET4.0C; .NET4.0E; Tablet PC 2.0; Zoom 3.6.0; rv:11.0) like Gecko',
     vendor: '',

--- a/tests/jest/utils.js
+++ b/tests/jest/utils.js
@@ -1,3 +1,6 @@
+// Keep a copy of this, since it can be overridden by sinon timers.
+const _realTimeout = setTimeout;
+
 /**
  * Resolves after all enqueued callbacks in the event loop have resolved.
  * @return {Promise}
@@ -5,7 +8,7 @@
 export function afterEventLoop() {
   // Waiting 0 seconds essentially lets us run at the end of the event
   // loop (i.e. after any promises which aren't _actually_ async have finished)
-  return new Promise(res => setTimeout(res, 0));
+  return new Promise(res => _realTimeout(res, 0));
 }
 
 /**


### PR DESCRIPTION
Closes #184

The chrome auto-pause work around wasn't working correctly, and causing the audio to pause/resume at random moments. Fix the state machine to make sure only one state machine is ever running.

Also fix a bug where Edge was being incorrectly identified as Chrome. It doesn't not have the TTS bug for which we have this workaround.

Tested, no new bugs!

Firefox 136.0 / Windows 10

✔️ Runs
✔️ Can advance and review
✔️ Can change voice
✔️ Can change speed
✔️ Can pause
✔️ Can resume
❌ Shows media session
✔️ Can play while screen off

Microsoft Edge 134.0.0.0 / Windows 10

✔️ Runs
✔️ Can advance and review
✔️ Can change voice
🔵 Runs 15+ seconds non-local voice (skipped)
✔️ Can change speed
✔️ Can pause
✔️ Can resume
✔️ Shows media session
✔️ Can play while screen off

Chrome 134.0.0.0 / Windows 10

✔️ Runs
✔️ Can advance and review
✔️ Can change voice
🔵 Runs 15+ seconds non-local voice (skipped)
✔️ Can change speed
✔️ Can pause
✔️ Can resume
✔️ Shows media session
✔️ Can play while screen off

Chrome 134.0.0.0 / Android 10

✔️ Runs
✔️ Can advance and review
✔️ Can change voice
🔵 Runs 15+ seconds non-local voice (skipped)
✔️ Can change speed
✔️ Can pause
✔️ Can resume
✔️ Shows media session
❌ Can play while screen off

Samsung Internet for Android 27.0 / Android 10

✔️ Runs
✔️ Can advance and review
✔️ Can change voice
🔵 Runs 15+ seconds non-local voice (skipped)
✔️ Can change speed
✔️ Can pause
✔️ Can resume
✔️ Shows media session
❌ Can play while screen offn

Microsoft Edge 134.0.0.0 / Android 10

✔️ Runs
✔️ Can advance and review
🔵 Can change voice (skipped)
🔵 Runs 15+ seconds non-local voice (skipped)
✔️ Can change speed
✔️ Can pause
✔️ Can resume
✔️ Shows media session
✔️ Can play while screen off

Opera 89.0.2254.76420 / Android 15

✔️ Runs
✔️ Can advance and review
🔵 Can change voice (skipped)
🔵 Runs 15+ seconds non-local voice (skipped)
✔️ Can change speed
✔️ Can pause
✔️ Can resume
❌ Shows media session
✔️ Can play while screen off

Safari 17.4.1 / macOS 10.15.7

✔️ Runs
✔️ Can advance and review
✔️ Can change voice
🔵 Runs 15+ seconds non-local voice (skipped)
✔️ Can change speed
✔️ Can pause
✔️ Can resume
✔️ Shows media session
✔️ Can play while screen off

Chrome 116.0.5845.90 / iOS 17.4

✔️ Runs
✔️ Can advance and review
✔️ Can change voice
🔵 Runs 15+ seconds non-local voice (skipped)
✔️ Can change speed
✔️ Can pause
✔️ Can resume
❌ Shows media session
✔️ Can play while screen off