### PR TITLE
Fix search icon being fetched from wrong path

### DIFF
--- a/src/plugins/search/view.js
+++ b/src/plugins/search/view.js
@@ -218,7 +218,7 @@ class SearchView {
       <form class="BRbooksearch desktop">
         <input type="search" name="query" class="BRsearchInput" value="" placeholder="Search inside"/>
         <button type="submit" class="BRsearchSubmit">
-          <img src="${this.br.imagesBaseURL}icon_search_button.svg" />
+          <img src="${this.br.options.imagesBaseURL}icon_search_button.svg" />
         </button>
       </form>
     `;


### PR DESCRIPTION
Was seeing some warnings in the dev server logs. Since plugins are setup before these fields are saved on the BR object, this needs to be fetched directly from options.