### PR TITLE
Fix: thumbnail navigation bug when zoomed in (#1401)

### DIFF
--- a/src/BookReader/ModeThumb.js
+++ b/src/BookReader/ModeThumb.js
@@ -2,7 +2,7 @@
 import { notInArray, clamp } from './utils.js';
 import { EVENTS } from './events.js';
 import { DragScrollable } from './DragScrollable.js';
-/** @typedef {import('../BookREader.js').default} BookReader */
+/** @typedef {import('../BookReader.js').default} BookReader */
 /** @typedef {import('./BookModel.js').PageIndex} PageIndex */
 /** @typedef {import('./BookModel.js').BookModel} BookModel */
 
@@ -201,10 +201,14 @@ export class ModeThumb {
 
     // Update which page is considered current to make sure a visible page is the current one
     const currentIndex = this.br.currentIndex();
-    if (currentIndex < leastVisible) {
-      this.br.updateFirstIndex(leastVisible);
-    } else if (currentIndex > mostVisible) {
-      this.br.updateFirstIndex(mostVisible);
+
+    // prevent the page from jumping when animating
+    if (!this.br.animating) {
+      if (currentIndex < leastVisible) {
+        this.br.updateFirstIndex(leastVisible);
+      } else if (currentIndex > mostVisible) {
+        this.br.updateFirstIndex(mostVisible);
+      }
     }
 
     // remember what rows are displayed
@@ -332,11 +336,14 @@ export class ModeThumb {
     }
     this.br.updateFirstIndex(index);
     if (this.br.refs.$brContainer.prop('scrollTop') == leafTop) {
-      this.br.drawLeafs();
+      this.drawLeafs(index);
     } else {
       this.br.animating = true;
       this.br.refs.$brContainer.stop(true)
-        .animate({ scrollTop: leafTop }, 'fast', () => { this.br.animating = false; });
+        .animate({ scrollTop: leafTop }, 'fast', () => {
+          this.br.animating = false;
+          this.drawLeafs(index);
+      });
     }
   }
 }


### PR DESCRIPTION
**Fix for Thumbnail Mode Navigation Bug**

This PR fixes the issue where page flipping in thumbnail mode becomes stuck, with visual display showing the new page but page index incorrectly reverting to the previous page. A typo in `ModeThumb.js` is also fixed.

**Problem Analysis:**
✅ The root cause of this issue has been identified:
* When `jumpToIndex` method calls `this.br.drawLeafs()` instead of `this.drawLeafs(index)`, no parameter is passed
* This leads to the thumbnail mode's `drawLeafs` method running without a proper seek index
* During animation, when the current index is not within the visible range (`leastVisible` to `mostVisible`)
* The method incorrectly resets the `firstIndex` to the last visible page

**Fix Implementation:**
✅ Two key changes were made to resolve this issue:

1. **Prevent index modification during animation:**
   * Added a check to avoid modifying the `firstIndex` when animation is in progress
   ```javascript
   if (!this.br.animating) {
     if (currentIndex < leastVisible) {
       this.br.updateFirstIndex(leastVisible);
     } else if (currentIndex > mostVisible) {
       this.br.updateFirstIndex(mostVisible);
     }
   }
   ```

2. **Ensure proper redraw after animation completes:**
   * Changed `this.br.drawLeafs()` to `this.drawLeafs(index)`
   * Added explicit call to `this.drawLeafs(index)` after animation completes
   ```javascript
    if (this.br.refs.$brContainer.prop('scrollTop') == leafTop) {
      this.drawLeafs(index);
    } else {
      this.br.animating = true;
      this.br.refs.$brContainer.stop(true)
        .animate({ scrollTop: leafTop }, 'fast', () => {
          this.br.animating = false;
          this.drawLeafs(index);
      });
    }
   ```

**🛠 Testing Done:**
* ✅ Verified page flipping in thumbnail mode now correctly maintains page index
* ✅ Confirmed no regression in other viewing modes

**✅ Expected Outcome:**
* Page flipping in thumbnail mode now correctly updates both visual display and page index
* Smooth navigation experience with no unexpected index resets

**Observation**
* When I was testing, I found that `this.br.refs.$brContainer.prop('scrollTop') == leafTop` never returns true. There is always a difference between them. I didn't figure out the reason.

I hope this helps!
