### PR TITLE
Fix BookReader/ build dir missing from npm package!

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "5.0.0-95",
   "description": "The Internet Archive BookReader.",
   "type": "module",
+  "files": [
+    "BookReader/",
+    "src/",
+    "jsconfig.json"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/internetarchive/bookreader.git"


### PR DESCRIPTION
Confirmed with `npm pack --dry-run` that it is now indeed including BookReader/! Apparently otherwise it ignore .gitignore!