### PR TITLE
[GSoC] Auto-Translate: Add Properties, Show Translations as Lines

### DIFF
--- a/BookReaderDemo/css/index.css
+++ b/BookReaderDemo/css/index.css
@@ -90,17 +90,3 @@
     box-shadow: 0 0 50px 50px #f8edc0ff;
     overflow-y: scroll;
   }
-
-  .translation .trParagraph {
-    pointer-events: all;
-    overflow-y: auto;
-    font-family: "Helvetica Neue", Arial, Verdana, sans-serif;
-    margin-bottom: 0;
-  }
-
-  .translation .trParagraph .trSentence {
-    white-space: preserve-spaces;
-    display: inline-block;
-    background: #f8edc0;
-    line-height: normal;
-  }

--- a/BookReaderDemo/css/index.css
+++ b/BookReaderDemo/css/index.css
@@ -85,11 +85,22 @@
     color: black;
     z-index: 9999;
     font-size: 2.85em;
-    height: 95%;
-    margin: 50px;
-    padding: 25px;
-    background-color: #f8edc0;
+    height: 100%;
     border-radius: 8px;
     box-shadow: 0 0 50px 50px #f8edc0ff;
     overflow-y: scroll;
+  }
+
+  .translation .trParagraph {
+    pointer-events: all;
+    overflow-y: auto;
+    font-family: "Helvetica Neue", Arial, Verdana, sans-serif;
+    margin-bottom: 0;
+  }
+
+  .translation .trParagraph .trSentence {
+    white-space: preserve-spaces;
+    display: inline-block;
+    background: #f8edc0;
+    line-height: normal;
   }

--- a/src/assets/translate/worker.js
+++ b/src/assets/translate/worker.js
@@ -64,7 +64,7 @@ onmessage = async function(e) {
       const from = e.data[1];
       const to = e.data[2];
       const inputParagraphs = e.data[3];
-      const selector = e.data[4];
+      const cacheKey = e.data[4];
       let inputWordCount = 0;
       inputParagraphs.forEach(sentence => {
         inputWordCount += sentence.trim().split(" ").filter(word => word.trim() !== "").length;
@@ -78,7 +78,7 @@ onmessage = async function(e) {
         log(`Error: ${error.message}`);
       }
       log(`'${command}' command done, Posting message back to main script`);
-      postMessage([`${command}_reply`, result, selector]);
+      postMessage([`${command}_reply`, result, cacheKey]);
   }
 }
 

--- a/src/assets/translate/worker.js
+++ b/src/assets/translate/worker.js
@@ -59,7 +59,7 @@ onmessage = async function(e) {
         result = "Model loading failed";
       }
       log(`'${command}' command done, Posting message back to main script`);
-      postMessage([`${command}_reply`, result]);
+      postMessage([`${command}_reply`, result, from, to]);
   } else if (command === 'translate') {
       const from = e.data[1];
       const to = e.data[2];

--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -1,4 +1,4 @@
-.BRtextLayer {
+.BRtextLayer, .BRtranslateLayer {
     z-index: 2;
     position: absolute;
     top: 0;
@@ -8,7 +8,7 @@
     // Make it so right-clicking on "blank" part of text layer sends events to the image (for saving)
     pointer-events: none;
     cursor: text;
-    mix-blend-mode: multiply;
+    // mix-blend-mode: multiply;
 }
 
 .BRparagraphElement {
@@ -107,4 +107,21 @@
 .BRlineElement[_msttexthash] {
     background: #ccbfa7;
     word-spacing: unset !important;
+}
+
+.BRtranslateLayer .BRparagraphElement {
+    pointer-events: all;
+    overflow-y: auto;
+    font-family: "Helvetica Neue", Arial, Verdana, sans-serif;
+    margin-bottom: 0;
+    background: #f8edc0;
+    color:black;
+}
+
+.BRtranslateLayer .BRparagraphElement .BRlineElement {
+    white-space: preserve-spaces;
+    display: inline-block;
+    background: #f8edc0;
+    line-height: normal;
+    pointer-events: all;
 }

--- a/src/plugins/plugin.text_selection.js
+++ b/src/plugins/plugin.text_selection.js
@@ -3,31 +3,12 @@ import { createDIVPageLayer } from '../BookReader/PageContainer.js';
 import { SelectionObserver } from '../BookReader/utils/SelectionObserver.js';
 import { BookReaderPlugin } from '../BookReaderPlugin.js';
 import { applyVariables } from '../util/strings.js';
+import { Cache } from '../util/cache.js';
 /** @typedef {import('../util/strings.js').StringWithVars} StringWithVars */
 /** @typedef {import('../BookReader/PageContainer.js').PageContainer} PageContainer */
 
 const BookReader = /** @type {typeof import('../BookReader').default} */(window.BookReader);
 
-/**
- * @template T
- */
-export class Cache {
-  constructor(maxSize = 10) {
-    this.maxSize = maxSize;
-    /** @type {T[]} */
-    this.entries = [];
-  }
-
-  /**
-   * @param {T} entry
-   */
-  add(entry) {
-    if (this.entries.length >= this.maxSize) {
-      this.entries.shift();
-    }
-    this.entries.push(entry);
-  }
-}
 
 export class TextSelectionPlugin extends BookReaderPlugin {
   options = {
@@ -356,6 +337,10 @@ export class TextSelectionPlugin extends BookReaderPlugin {
     }
     $container.append(textLayer);
     this.stopPageFlip($container);
+    this.br.trigger('textLayerRendered', {
+      pageIndex,
+      pageContainer,
+    });
   }
 
   /**

--- a/src/plugins/translate/TranslationManager.js
+++ b/src/plugins/translate/TranslationManager.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { Cache } from './cache.js';
+import { Cache } from '../../util/cache.js';
 
 export const langs = /** @type {{[lang: string]: string}} */ {
   "bg": "Bulgarian",

--- a/src/plugins/translate/plugin.translate.js
+++ b/src/plugins/translate/plugin.translate.js
@@ -28,7 +28,7 @@ const langs = /** @type {{[lang: string]: string}} */ {
   "pt": "Portuguese",
   "ru": "Russian",
   "es": "Spanish",
-  "uk": "Ukrainian"
+  "uk": "Ukrainian",
 };
 
 export class TranslatePlugin extends BookReaderPlugin {
@@ -94,11 +94,21 @@ export class TranslatePlugin extends BookReaderPlugin {
       const [cmd, ...rest] = e.data;
       if (cmd === "translate_reply" && rest[0]) {
         const [translation, selector] = rest;
+        // Use '.' as delimiter and keep within translated text
+        const translationChunks = translation[0].split('(.)');
         console.log(translation.join("\n\n"));
         console.log(selector);
         const el = document.querySelector(selector);
         if (el) {
-          document.querySelector(selector).innerHTML = translation.join("<br><br>");
+          for (const sentence of translationChunks) {
+            if (!sentence.length) { // skip empty strings
+              continue;
+            }
+            const translationSpan = document.createElement('span');
+            translationSpan.className = 'trSentence';
+            translationSpan.textContent = sentence;
+            document.querySelector(selector).appendChild(translationSpan);
+          }
         }
       } else if (cmd === "load_model_reply" && e.data[1]) {
         status(e.data[1]);
@@ -142,6 +152,7 @@ export class TranslatePlugin extends BookReaderPlugin {
 
   translateVisiblePages = () => {
     this.clearTranslations();
+    /** @type {number} - Tracks the current paragraph for html tag*/
     let gidx = 0;
     for (const page of this.getVisiblePages()) {
       const paragraphs = this.getParagraphsOnPage(page);
@@ -151,13 +162,29 @@ export class TranslatePlugin extends BookReaderPlugin {
       pageTranslationLayer.className = 'translation';
       page.insertBefore(pageTranslationLayer, page.firstChild);
 
-      paragraphs.forEach((paragraph) => {
+      paragraphs.forEach((paragraph, pidx) => {
         // set data-index on the paragraph
         paragraph.setAttribute('data-index', gidx.toString());
 
         const translationPlaceholder = document.createElement('p');
         // set data-translate-index on the placeholder
         translationPlaceholder.setAttribute('data-translate-index', gidx.toString());
+        translationPlaceholder.className = 'trParagraph';
+        const originalParagraphStyle = paragraphs[pidx];
+
+        const marginLeft = $(originalParagraphStyle).css("margin-left");
+        const marginTop = $(originalParagraphStyle).css("margin-top");
+        const fontSize = $(originalParagraphStyle).css("font-size");
+        const height = $(originalParagraphStyle).css("height");
+        const top = $(originalParagraphStyle).css("top");
+
+        translationPlaceholder.style.marginTop = marginTop;
+        translationPlaceholder.style.marginLeft = marginLeft;
+        // normal font size from transparent layer sometimes too big
+        translationPlaceholder.style.fontSize = `${parseInt(fontSize) - 5}px`;
+        translationPlaceholder.style.top = top;
+        translationPlaceholder.style.height = height;
+
         pageTranslationLayer.appendChild(translationPlaceholder);
 
         const selector = `.${page.className.split(' ').join('.')} .translation p[data-translate-index="${gidx}"]`;
@@ -168,7 +195,7 @@ export class TranslatePlugin extends BookReaderPlugin {
             this.langFromCode,
             this.langToCode,
             [paragraph.textContent],
-            selector
+            selector,
           ]);
         }
         gidx++;
@@ -181,7 +208,7 @@ export class TranslatePlugin extends BookReaderPlugin {
   };
 
 
-    /**
+  /**
    * @protected
    * @param {import ("../../BookReader/PageContainer.js").PageContainer} pageContainer
    */
@@ -260,7 +287,7 @@ export class TranslatePlugin extends BookReaderPlugin {
 
   isSupported = (lngFrom, lngTo) => {
     return (`${lngFrom}${lngTo}` in this.modelRegistry) || lngFrom === lngTo ||
-      ((`${lngFrom}en` in this.modelRegistry) && (`en${lngTo}` in this.modelRegistry))
+      ((`${lngFrom}en` in this.modelRegistry) && (`en${lngTo}` in this.modelRegistry));
   }
 
   switchLanguage() {
@@ -275,11 +302,11 @@ export class TranslatePlugin extends BookReaderPlugin {
     }
 
     this.loadModel();
-  };
+  }
 
   findFirstSupportedTo = () => {
     return Object.keys(this.supportedToCodes)[0];
-}
+  }
 
   loadModel = () => {
     const fromCode = this.langFromCode;
@@ -296,6 +323,7 @@ export class TranslatePlugin extends BookReaderPlugin {
     }
   };
 
+  // From an older version of the code? no more #output element
   translateCall = (paragraphs) => {
     this.worker.postMessage(["translate", this.langFromCode, this.langToCode, paragraphs, '#output']);
   };
@@ -323,10 +351,10 @@ export class TranslatePlugin extends BookReaderPlugin {
       label: 'Translate',
       component: html`<br-translate-panel
         @connected="${e => {
-          this._panel = e.target;
-          this._panel.fromLanguages = this.fromLanguages;
-          this._panel.toLanguages = this.toLanguages;
-        }
+        this._panel = e.target;
+        this._panel.fromLanguages = this.fromLanguages;
+        this._panel.toLanguages = this.toLanguages;
+      }
       }"
         @langFromChanged="${this.handleFromLangChange}"
         @langToChanged="${this.handleToLangChange}"
@@ -371,7 +399,7 @@ export class BrTranslatePanel extends LitElement {
           From
           <select id="lang-from" name="from" class="lang-select" @change="${this._onLangFromChange}">
             ${this.fromLanguages.map(
-              lang => html`<option value="${lang.code}">${lang.name}</option>`
+              lang => html`<option value="${lang.code}">${lang.name}</option>`,
             )}
           </select>
         </label>
@@ -381,7 +409,7 @@ export class BrTranslatePanel extends LitElement {
           To
           <select id="lang-to" name="to" class="lang-select" @change="${this._onLangToChange}">
             ${this.toLanguages.map(
-              lang => html`<option value="${lang.code}">${lang.name}</option>`
+              lang => html`<option value="${lang.code}">${lang.name}</option>`,
             )}
           </select>
         </label>

--- a/src/plugins/translate/plugin.translate.js
+++ b/src/plugins/translate/plugin.translate.js
@@ -2,7 +2,7 @@
 import { html, LitElement } from 'lit';
 import { BookReaderPlugin } from '../../BookReaderPlugin.js';
 import { customElement, property } from 'lit/decorators.js';
-import { langs, TranslationManager } from "../../util/translationmanager.js";
+import { langs, TranslationManager } from "./TranslationManager.js";
 
 // @ts-ignore
 const BookReader = /** @type {typeof import('@/src/BookReader.js').default} */(window.BookReader);

--- a/src/plugins/translate/plugin.translate.js
+++ b/src/plugins/translate/plugin.translate.js
@@ -10,7 +10,7 @@ const BookReader = /** @type {typeof import('@/src/BookReader.js').default} */(w
 const qs = selector => document.querySelector(selector);
 const status = message => (console.log(message));
 
-const langs = {
+const langs = /** @type {{[lang: string]: string}} */ {
   "bg": "Bulgarian",
   "ca": "Catalan",
   "cs": "Czech",
@@ -36,20 +36,41 @@ export class TranslatePlugin extends BookReaderPlugin {
   options = {
     enabled: true,
   }
+  /**
+   * @typedef {Object} genericModelInfo
+   * @property {string} name
+   * @property {number} size
+   * @property {number} estimatedCompressedSize
+   * @property {qualityModelInfo} [qualityModel]
+   * @property {string} [expectedSha256Hash]
+   * @property {string} [modelType]
+   */
 
+  /** @type {Worker}*/
   worker;
+  /**
+   * @type { {[langPair: string] : {model: genericModelInfo, lex: genericModelInfo, vocab: genericModelInfo, quality?: genericModelInfo}} }
+   */
   modelRegistry;
+
+  /** @type {?number}*/
   version;
 
+  /** @type {{[lang: string]: string}} */
   supportedFromCodes = {};
+  /** @type {{[lang:string]: string}} */
   supportedToCodes = {};
 
+  /** @type {string[]} */
   fromLanguages = [];
+  /** @type {string[]} */
   toLanguages = [];
+  /** @type {!string} */
   langFromCode;
+  /** @type {!string} */
   langToCode;
   /**
-   * @type {BrTranslatePanel} _panel - Represents a panel used in the plugin. 
+   * @type {BrTranslatePanel} _panel - Represents a panel used in the plugin.
    * The specific type and purpose of this panel should be defined based on its usage.
    */
   _panel;
@@ -90,7 +111,7 @@ export class TranslatePlugin extends BookReaderPlugin {
         this.initWorker();
       }
     };
-    
+
     // Any time an action occurs, get the text
     const next = BookReader.prototype.next;
     BookReader.prototype.next = function (...args) {
@@ -105,7 +126,7 @@ export class TranslatePlugin extends BookReaderPlugin {
       return r;
     };
   }
- 
+
   *getVisiblePages() {
     for (const el of document.querySelectorAll('.BRpage-visible')) {
       if ([...el.classList].some(cls => /^pagediv\d+$/.test(cls))) {
@@ -114,15 +135,15 @@ export class TranslatePlugin extends BookReaderPlugin {
       }
     }
   }
-  
+  /** @param {JQuery<HTMLElement>} page*/
   getParagraphsOnPage = (page) => {
     return page ? Array.from(page.querySelectorAll(".BRparagraphElement")) : [];
   }
-  
+
   translateVisiblePages = () => {
     this.clearTranslations();
     let gidx = 0;
-    for (const page of this.getVisiblePages()) {      
+    for (const page of this.getVisiblePages()) {
       const paragraphs = this.getParagraphsOnPage(page);
 
       // Create the translation layer for all paragraphs on the page
@@ -158,7 +179,7 @@ export class TranslatePlugin extends BookReaderPlugin {
   clearTranslations = () => {
     document.querySelectorAll('.translation').forEach(el => el.remove());
   };
- 
+
 
     /**
    * @protected
@@ -167,7 +188,7 @@ export class TranslatePlugin extends BookReaderPlugin {
   _configurePageContainer(pageContainer) {
     // fetch each page
     // break each page into paragraphs
-    // call translate and give ... 
+    // call translate and give ...
     return pageContainer;
   }
 
@@ -211,7 +232,7 @@ export class TranslatePlugin extends BookReaderPlugin {
   handleFromLangChange = (e) => {
     this.clearTranslations();
     const selectedLangFrom = e.detail.value;
-    
+
     // Update the from language
     this.langFromCode = selectedLangFrom;
 

--- a/src/plugins/translate/plugin.translate.js
+++ b/src/plugins/translate/plugin.translate.js
@@ -3,11 +3,11 @@ import { html, LitElement } from 'lit';
 import { BookReaderPlugin } from '../../BookReaderPlugin.js';
 import { customElement, property } from 'lit/decorators.js';
 import { toISO6391 } from '../tts/utils.js';
+import { TranslationManager } from "../../util/translationmanager.js";
 
 // @ts-ignore
 const BookReader = /** @type {typeof import('@/src/BookReader.js').default} */(window.BookReader);
 
-const qs = selector => document.querySelector(selector);
 const status = message => (console.log(message));
 
 const langs = /** @type {{[lang: string]: string}} */ {
@@ -41,10 +41,13 @@ export class TranslatePlugin extends BookReaderPlugin {
    * @property {string} name
    * @property {number} size
    * @property {number} estimatedCompressedSize
-   * @property {qualityModelInfo} [qualityModel]
+   * @property {any} [qualityModel]
    * @property {string} [expectedSha256Hash]
    * @property {string} [modelType]
    */
+
+  /** @type {TranslationManager} */
+  translationManager = new TranslationManager();
 
   /** @type {Worker}*/
   worker;
@@ -53,18 +56,22 @@ export class TranslatePlugin extends BookReaderPlugin {
    */
   modelRegistry;
 
-  /** @type {{[lang: string]: string}} */
-  supportedFromCodes = {};
-  /** @type {{[lang:string]: string}} */
-  supportedToCodes = {};
-
-  /** @type {string[]} */
-  fromLanguages = [];
-  /** @type {string[]} */
+  /** 
+   * Contains the list of languages availabile to translate to
+   * @type {string[]} 
+   */
   toLanguages = [];
-  /** @type {!string} */
-  langFromCode;
-  /** @type {!string} */
+
+  /** 
+   * Current language code that is being translated From
+   * @type {!string} 
+   */
+  langFromCode = "en";
+
+  /** 
+   * Current language code that is being translated To 
+   * @type {!string} 
+   */
   langToCode;
   /**
    * @type {BrTranslatePanel} _panel - Represents a panel used in the plugin.
@@ -78,45 +85,19 @@ export class TranslatePlugin extends BookReaderPlugin {
     if (!this.options.enabled) {
       return;
     }
+    const initTranslationManager = await this.translationManager.initWorker();
     await Promise.resolve();
     this._render();
+    this.worker = this.translationManager.worker;
 
-    if (window.Worker) {
-      this.worker = new Worker("/BookReader/translate/worker.js");
-      this.worker.postMessage(["import"]);
+    [this.modelRegistry] = initTranslationManager;
+    
+    let readersLanguage = navigator.language;
+    if (readersLanguage) {
+      readersLanguage = readersLanguage.split("-")[0];
+      console.log("guessing input language is", readersLanguage);
+      this.langToCode = this.findFirstSupportedTo();
     }
-
-    // This needs to be updates to change #output
-    this.worker.onmessage = (e) => {
-      const [cmd, ...rest] = e.data;
-      if (cmd === "translate_reply" && rest[0]) {
-        const [translation, selector] = rest;
-        // Use '.' as delimiter and keep within translated text
-        const translationChunks = translation[0].split('(.)');
-        console.log(translation.join("\n\n"));
-        console.log(selector);
-        const el = document.querySelector(selector);
-        if (el) {
-          for (const sentence of translationChunks) {
-            if (!sentence.length) { // skip empty strings
-              continue;
-            }
-            const translationSpan = document.createElement('span');
-            translationSpan.className = 'BRlineElement';
-            translationSpan.textContent = sentence;
-            document.querySelector(selector).appendChild(translationSpan);
-          }
-        }
-      } else if (cmd === "load_model_reply" && e.data[1]) {
-        status(e.data[1]);
-        if (this.langFromCode !== this.langToCode) {
-          this.translateVisiblePages();
-        }
-      } else if (cmd === "import_reply" && e.data[1]) {
-        this.modelRegistry = e.data[1];
-        this.initWorker();
-      }
-    };
 
     // Any time an action occurs, get the text
     const next = BookReader.prototype.next;
@@ -124,14 +105,27 @@ export class TranslatePlugin extends BookReaderPlugin {
       let r = next.apply(this, args);
       console.log("BookReader.prototype.next triggered", args);
       setTimeout(() => {
-        self.clearTranslations();
         if (self.langFromCode !== self.langToCode) {
           self.translateVisiblePages();
         }
       }, 0);
       return r;
     };
+
+    const prev = BookReader.prototype.prev;
+    BookReader.prototype.prev = function(...args) {
+      let r = prev.apply(this, args);
+      console.log("BookReader.prototype.prev triggered", args);
+      setTimeout(() => {
+        if (self.langFromCode !== self.langToCode) {
+          self.translateVisiblePages();
+        }
+      }, 0);
+      return r;
+    };
+
   }
+
 
   *getVisiblePages() {
     for (const el of document.querySelectorAll('.BRpage-visible')) {
@@ -146,11 +140,15 @@ export class TranslatePlugin extends BookReaderPlugin {
     return page ? Array.from(page.querySelectorAll(".BRparagraphElement")) : [];
   }
 
-  translateVisiblePages = () => {
+  translateVisiblePages = async () => {
+    if (this.br.mode == this.br.constModeThumb) {
+      console.log("translateVisiblePages: will not translate in thumbnail mode");
+      return;
+    }
+    // don't do clearTranslations() within the loop because it'll remove the element we want to target in the translator
     this.clearTranslations();
-    /** @type {number} - Tracks the current paragraph for html tag*/
-    let gidx = 0;
     for (const page of this.getVisiblePages()) {
+      const pageIndex = page.parentElement.className.match(/\d+/)[0];
       const paragraphs = this.getParagraphsOnPage(page);
 
       // Create the translation layer for all paragraphs on the page
@@ -166,13 +164,12 @@ export class TranslatePlugin extends BookReaderPlugin {
       });
       page.insertAdjacentElement('beforebegin', pageTranslationLayer);
 
-      paragraphs.forEach((paragraph, pidx) => {
+      paragraphs.forEach(async (paragraph, pidx) => {
         // set data-index on the paragraph
-        paragraph.setAttribute('data-index', gidx.toString());
-
+        paragraph.setAttribute('data-index', pidx.toString());
         const translationPlaceholder = document.createElement('p');
         // set data-translate-index on the placeholder
-        translationPlaceholder.setAttribute('data-translate-index', gidx.toString());
+        translationPlaceholder.setAttribute('data-translate-index', `${pageIndex}-${pidx}`);
         translationPlaceholder.className = 'BRparagraphElement';
         const originalParagraphStyle = paragraphs[pidx];
 
@@ -187,18 +184,18 @@ export class TranslatePlugin extends BookReaderPlugin {
 
         pageTranslationLayer.appendChild(translationPlaceholder);
 
-        const selector = `.${pageTranslationLayer.className.split(' ').join('.')} p[data-translate-index="${gidx}"]`;
+        const selector = `.${pageTranslationLayer.className.split(' ').join('.')} p[data-translate-index='${pageIndex}-${pidx}']`;
 
         if (paragraph.textContent) {
-          this.worker.postMessage([
-            "translate",
-            this.langFromCode,
-            this.langToCode,
-            [paragraph.textContent],
-            selector,
-          ]);
+          const translatedText = await this.translationManager.getTranslation(this.langFromCode, this.langToCode, pageIndex, pidx, paragraph.textContent); 
+          const createSpan = document.createElement('span');
+          createSpan.className = 'BRlineElement';
+          createSpan.textContent = translatedText;
+          const selectorElement = document.querySelector(selector);
+          if (selectorElement) {
+            selectorElement.appendChild(createSpan);
+          }
         }
-        gidx++;
       });
     }
   }
@@ -209,7 +206,7 @@ export class TranslatePlugin extends BookReaderPlugin {
 
 
   /**
-   * @protected
+   * @override
    * @param {import ("../../BookReader/PageContainer.js").PageContainer} pageContainer
    */
   _configurePageContainer(pageContainer) {
@@ -219,70 +216,32 @@ export class TranslatePlugin extends BookReaderPlugin {
     return pageContainer;
   }
 
-  initWorker = () => {
-    // parse supported languages and model types (prod or dev)
-    this.supportedFromCodes["en"] = "prod";
-    this.supportedToCodes["en"] = "prod";
-    for (const [langPair, value] of Object.entries(this.modelRegistry)) {
-      const firstLang = langPair.substring(0, 2);
-      const secondLang = langPair.substring(2, 4);
-      if (firstLang !== "en") this.supportedFromCodes[firstLang] = value.model.modelType;
-      if (secondLang !== "en") this.supportedToCodes[secondLang] = value.model.modelType;
-    }
 
-    // try to guess input language from user agent
-    let bookLanguage = "en"; //toISO6391(this.br.options.bookLanguage);
-    let readersLanguage = navigator.language;
-
-    // initialize everything as book language
-    this.langFromCode = this.langToCode = bookLanguage;
-
-    // use reader's language, if we know it and it's available
-    if (readersLanguage) {
-      readersLanguage = readersLanguage.split("-")[0];
-      if (readersLanguage in this.supportedToCodes) {
-        console.log("guessing input language is", readersLanguage);
-        this.langToCode = readersLanguage;
-      }
-    }
-
-    this.fromLanguages = this.formatLangs(this.supportedFromCodes);
-    // find first output lang that *isn't* input language
-
-    this.toLanguages = this.formatLangs(this.supportedToCodes);
-    this.langToCode = this.findFirstSupportedTo();
-
-    // load this model
-    this.loadModel();
-  }
-
-  handleFromLangChange = (e) => {
+  handleFromLangChange = async (e) => {
     this.clearTranslations();
     const selectedLangFrom = e.detail.value;
 
     // Update the from language
     this.langFromCode = selectedLangFrom;
 
-    let setToCode = this.langToCode !== selectedLangFrom ? this.langToCode : this.findFirstSupportedTo();
-
     // Add 'From' language to 'To' list if not already present
-    if (!this.toLanguages.some(lang => lang.code === selectedLangFrom)) {
-      this.toLanguages.push({ code: selectedLangFrom, name: langs[selectedLangFrom] });
+    if (!this.translationManager.toLanguages.some(lang => lang.code === selectedLangFrom)) {
+      this.translationManager.toLanguages.push({ code: selectedLangFrom, name: langs[selectedLangFrom] });
     }
 
     // Update the 'To' languages list and set the correct 'To' language
-    this._panel.toLanguages = this.formatLangs(this.supportedToCodes, setToCode, selectedLangFrom);
+    this._panel.toLanguages = this.translationManager.toLanguages;
 
     console.log(this.langFromCode, this.langToCode);
     if (this.langFromCode !== this.langToCode) {
-      this.loadModel();
+      await this.translateVisiblePages();
     }
   }
 
-  handleToLangChange = (e) => {
+  handleToLangChange = async (e) => {
     this.clearTranslations();
     this.langToCode = e.detail.value;
-    this.loadModel();
+    await this.translateVisiblePages();
   }
 
   isSupported = (lngFrom, lngTo) => {
@@ -290,22 +249,8 @@ export class TranslatePlugin extends BookReaderPlugin {
       ((`${lngFrom}en` in this.modelRegistry) && (`en${lngTo}` in this.modelRegistry));
   }
 
-  switchLanguage() {
-    const prevLangFromCode = this.langFromCode;
-    this.langFromCode = this.langToCode;
-
-    if (prevLangFromCode in this.supportedToCodes) {
-      this._panel.toLanguages = this.formatLangs(this.supportedToCodes, prevLangFromCode, this.langFromCode);
-    }
-    else {
-      this.langToCode = null;
-    }
-
-    this.loadModel();
-  }
-
   findFirstSupportedTo = () => {
-    return Object.keys(this.supportedToCodes)[0];
+    return this.translationManager.toLanguages[0].code;
   }
 
   loadModel = () => {
@@ -323,22 +268,6 @@ export class TranslatePlugin extends BookReaderPlugin {
     }
   };
 
-  // From an older version of the code? no more #output element
-  translateCall = (paragraphs) => {
-    this.worker.postMessage(["translate", this.langFromCode, this.langToCode, paragraphs, '#output']);
-  };
-
-  formatLangs = (langsToSet, value, exclude) => {
-    const prop = [];
-    for (const [code, type] of Object.entries(langsToSet)) {
-      //if (code === exclude) continue;
-      let name = langs[code];
-      if (type === "dev") name += " (βeta)";
-      prop.push({code, name});
-    }
-    return prop;
-  }
-
   /**
   * Update the table of contents based on array of TOC entries.
   */
@@ -352,14 +281,14 @@ export class TranslatePlugin extends BookReaderPlugin {
       component: html`<br-translate-panel
         @connected="${e => {
         this._panel = e.target;
-        this._panel.fromLanguages = this.fromLanguages;
-        this._panel.toLanguages = this.toLanguages;
+        this._panel.fromLanguages = this.translationManager.fromLanguages;
+        this._panel.toLanguages = this.translationManager.toLanguages;
       }
       }"
         @langFromChanged="${this.handleFromLangChange}"
         @langToChanged="${this.handleToLangChange}"
-        .fromLanguages="${this.fromLanguages}"
-        .toLanguages="${this.toLanguages}"
+        .fromLanguages="${this.translationManager.fromLanguages}"
+        .toLanguages="${this.translationManager.toLanguages}"
         class="translate-panel"
       />`,
     };
@@ -451,6 +380,10 @@ export class BrTranslatePanel extends LitElement {
 
   _onPrevLangClick() {
     const prevLang = this.prevSelectedLang;
+    if (prevLang == this._getSelectedLang('from')) {
+      console.log("_onPrevLangClick: will not change since prevLang is the same as the current 'To' language code");
+      return;
+    }
     this.prevSelectedLang = this._getSelectedLang('to'); // Update prevSelectedLang to current "To" value
     const langToChangedEvent = new CustomEvent('langToChanged', {
       detail: { value: prevLang },

--- a/src/util/cache.js
+++ b/src/util/cache.js
@@ -1,0 +1,20 @@
+/**
+ * @template T
+ */
+export class Cache {
+  constructor(maxSize = 10) {
+    this.maxSize = maxSize;
+    /** @type {T[]} */
+    this.entries = [];
+  }
+
+  /**
+   * @param {T} entry
+   */
+  add(entry) {
+    if (this.entries.length >= this.maxSize) {
+      this.entries.shift();
+    }
+    this.entries.push(entry);
+  }
+}

--- a/src/util/translationmanager.js
+++ b/src/util/translationmanager.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { Cache } from './cache.js';
 
-const langs = /** @type {{[lang: string]: string}} */ {
+export const langs = /** @type {{[lang: string]: string}} */ {
   "bg": "Bulgarian",
   "ca": "Catalan",
   "cs": "Czech",
@@ -24,14 +24,32 @@ const langs = /** @type {{[lang: string]: string}} */ {
 const status = message => (console.log(message));
 
 export class TranslationManager {
-  /** @type {Cache<{index: string, response: any}>} */
-  alreadyTranslated = new Cache();
+  /** @type {Cache<{index: string, response: string}>} */
+  alreadyTranslated = new Cache(100);
+  
+  /**
+  * @typedef {Object} genericModelInfo
+  * @property {string} name
+  * @property {number} size
+  * @property {number} estimatedCompressedSize
+  * @property {any} [qualityModel]
+  * @property {string} [expectedSha256Hash]
+  * @property {string} [modelType]
+  */
+  /**
+  * @type { {[langPair: string] : {model: genericModelInfo, lex: genericModelInfo, vocab: genericModelInfo, quality?: genericModelInfo}} }
+  */
   modelRegistry = {};
 
   /** @type {Record<key, {promise: Promise<string>, resolve: function, reject: function}>} */
   currentlyTranslating = {}
   /** @type {Record<key, {promise: Promise<string>, resolve: function, reject: function}>} */
   _modelPromises = {};
+  /** 
+   * @type {string} 
+   * e.g. 'ende' 'encz'
+  */
+  currentModel = '';
 
   /** @type {Record<string, string>[]} */
   fromLanguages = [];
@@ -40,6 +58,7 @@ export class TranslationManager {
 
 
   constructor() {
+    //TODO Should default to the book language as the first element
     const enModel = {code: "en", name: "English", type: "prod"};
     this.fromLanguages.push(enModel);
     this.toLanguages.push(enModel);
@@ -47,12 +66,12 @@ export class TranslationManager {
 
 
   async initWorker() {
+    if (this.initPromise) return this.initPromise;
+
     if (window.Worker) {
       this.worker = new Worker("/BookReader/translate/worker.js");
       this.worker.postMessage(["import"]);
     }
-
-    if (this.initPromise) return this.initPromise;
 
     this.initPromise = new Promise((resolve, reject) => {
       this._initResolve = resolve;
@@ -64,8 +83,7 @@ export class TranslationManager {
       if (cmd === "translate_reply" && rest[0]) {
         const [translation, key] = rest;
         if (translation.length) {
-          const translationChunks = translation[0].split('(.)');
-          this.currentlyTranslating[key].resolve(translationChunks);
+          this.currentlyTranslating[key].resolve(translation[0]);
           this.alreadyTranslated.add({index: key, response: translation})
           delete this.currentlyTranslating[key];
         }
@@ -73,6 +91,8 @@ export class TranslationManager {
         status(e.data[1]);
         const [result, from, to] = rest;
         this._modelPromises[`${from}${to}`].resolve(result);
+        // keep as source of truth
+        this.currentModel = `${from}${to}`;
       } else if (cmd === "import_reply" && e.data[1]) {
         this.modelRegistry = e.data[1];
         for (const [langPair, value] of Object.entries(this.modelRegistry)) {
@@ -82,7 +102,6 @@ export class TranslationManager {
           if (firstLang !== "en") {
             const fromModelType = value.model.modelType !== "dev" ? langs[firstLang] : langs[firstLang] + " (βeta)";
             this.fromLanguages.push({code: firstLang, name: fromModelType, type: value.model.modelType});
-
           }
           if (secondLang !== "en") {
             const toModelType = value.model.modelType !== "dev" ? langs[secondLang] : langs[secondLang] + " (βeta)";
@@ -93,7 +112,7 @@ export class TranslationManager {
         this._initResolve([this.modelRegistry]);
         
       } else {
-        console.log("Unrecognized cmd:" + cmd + " \n Or invalid data:" + e);
+        console.log("Unrecognized cmd:" + cmd + " \n Or invalid data:", e);
       }
     }
     return this.initPromise;
@@ -111,7 +130,7 @@ export class TranslationManager {
     }
 
     const key = `${fromCode}${toCode}`;
-    if (key in this._modelPromises) {
+    if (key in this._modelPromises && this.currentModel == key) {
       return this._modelPromises[key].promise;
     }
     status(`Installing model...`);
@@ -130,7 +149,7 @@ export class TranslationManager {
       resolve: _resolve,
       reject: _reject,
     }
-
+    this.currentModel = key;
     this.worker.postMessage(["load_model", fromCode, toCode]);
     return promise;
   };
@@ -180,7 +199,6 @@ export class TranslationManager {
       this.currentlyTranslating[key].reject("No text was provided");
       return promise
     }
-
     this.loadModel(fromLang, toLang).then(() => {
       this.worker.postMessage([
         "translate",
@@ -195,4 +213,9 @@ export class TranslationManager {
 
     return promise;
   }
+  // TODO name better, maybe not needed?
+  checkModel = (fromLang, toLang) => {
+    const key = `${fromLang}${toLang}`;
+    return key in this._modelPromises;
+  };
 }

--- a/src/util/translationmanager.js
+++ b/src/util/translationmanager.js
@@ -1,0 +1,198 @@
+// @ts-check
+import { Cache } from './cache.js';
+
+const langs = /** @type {{[lang: string]: string}} */ {
+  "bg": "Bulgarian",
+  "ca": "Catalan",
+  "cs": "Czech",
+  "nl": "Dutch",
+  "en": "English",
+  "et": "Estonian",
+  "de": "German",
+  "fr": "French",
+  "is": "Icelandic",
+  "it": "Italian",
+  "nb": "Norwegian Bokmål",
+  "nn": "Norwegian Nynorsk",
+  "fa": "Persian",
+  "pl": "Polish",
+  "pt": "Portuguese",
+  "ru": "Russian",
+  "es": "Spanish",
+  "uk": "Ukrainian",
+};
+const status = message => (console.log(message));
+
+export class TranslationManager {
+  /** @type {Cache<{index: string, response: any}>} */
+  alreadyTranslated = new Cache();
+  modelRegistry = {};
+
+  /** @type {Record<key, {promise: Promise<string>, resolve: function, reject: function}>} */
+  currentlyTranslating = {}
+  /** @type {Record<key, {promise: Promise<string>, resolve: function, reject: function}>} */
+  _modelPromises = {};
+
+  /** @type {Record<string, string>[]} */
+  fromLanguages = [];
+  /** @type {Record<string, string>[]} */
+  toLanguages = [];
+
+
+  constructor() {
+    const enModel = {code: "en", name: "English", type: "prod"};
+    this.fromLanguages.push(enModel);
+    this.toLanguages.push(enModel);
+  }
+
+
+  async initWorker() {
+    if (window.Worker) {
+      this.worker = new Worker("/BookReader/translate/worker.js");
+      this.worker.postMessage(["import"]);
+    }
+
+    if (this.initPromise) return this.initPromise;
+
+    this.initPromise = new Promise((resolve, reject) => {
+      this._initResolve = resolve;
+      this._initReject = reject;
+    });
+
+    this.worker.onmessage = (e) => {
+      const [cmd, ...rest] = e.data;
+      if (cmd === "translate_reply" && rest[0]) {
+        const [translation, key] = rest;
+        if (translation.length) {
+          const translationChunks = translation[0].split('(.)');
+          this.currentlyTranslating[key].resolve(translationChunks);
+          this.alreadyTranslated.add({index: key, response: translation})
+          delete this.currentlyTranslating[key];
+        }
+      } else if (cmd === "load_model_reply" && e.data[1]) {
+        status(e.data[1]);
+        const [result, from, to] = rest;
+        this._modelPromises[`${from}${to}`].resolve(result);
+      } else if (cmd === "import_reply" && e.data[1]) {
+        this.modelRegistry = e.data[1];
+        for (const [langPair, value] of Object.entries(this.modelRegistry)) {
+          const firstLang = langPair.substring(0, 2);
+          const secondLang = langPair.substring(2, 4);
+
+          if (firstLang !== "en") {
+            const fromModelType = value.model.modelType !== "dev" ? langs[firstLang] : langs[firstLang] + " (βeta)";
+            this.fromLanguages.push({code: firstLang, name: fromModelType, type: value.model.modelType});
+
+          }
+          if (secondLang !== "en") {
+            const toModelType = value.model.modelType !== "dev" ? langs[secondLang] : langs[secondLang] + " (βeta)";
+            this.toLanguages.push({code: secondLang, name: toModelType, type: value.model.modelType});
+          }
+        }
+
+        this._initResolve([this.modelRegistry]);
+        
+      } else {
+        console.log("Unrecognized cmd:" + cmd + " \n Or invalid data:" + e);
+      }
+    }
+    return this.initPromise;
+  }
+
+  /**
+   * @param {string} fromCode
+   * @param {string} toCode
+   * @returns {Promise<string>} Promise result 
+   */
+  loadModel = async (fromCode, toCode) => {
+    if (fromCode === toCode || !this.isSupported(fromCode, toCode)) {
+      status("Language pair is not supported");
+      return;
+    }
+
+    const key = `${fromCode}${toCode}`;
+    if (key in this._modelPromises) {
+      return this._modelPromises[key].promise;
+    }
+    status(`Installing model...`);
+    console.log(`Loading model '${fromCode}${toCode}'`);
+
+    let _resolve = null;
+    let _reject = null;
+
+    const promise = new Promise((res, rej) => {
+      _resolve = res;
+      _reject = rej;
+    })
+
+    this._modelPromises[key] = {
+      promise,
+      resolve: _resolve,
+      reject: _reject,
+    }
+
+    this.worker.postMessage(["load_model", fromCode, toCode]);
+    return promise;
+  };
+
+  isSupported = (lngFrom, lngTo) => {
+    return (`${lngFrom}${lngTo}` in this.modelRegistry) || lngFrom === lngTo ||
+      ((`${lngFrom}en` in this.modelRegistry) && (`en${lngTo}` in this.modelRegistry));
+  }
+
+  /**
+   * Targets the page and paragraph of a text layer to create a translation from the "fromLang" to the "toLang"
+   * @param {string} fromLang
+   * @param {string} toLang
+   * @param {string} pageIndex
+   * @param {number} paragraphIndex
+   * @param {string} text
+   * @return {Promise<string>} translated text
+   */
+
+  getTranslation = async (fromLang, toLang, pageIndex, paragraphIndex, text) => {
+    const key = `${fromLang}${toLang}-${pageIndex}:${paragraphIndex}`;
+
+    const cachedEntry = this.alreadyTranslated.entries.find(x => x.index == key);
+    if (cachedEntry) {
+      return cachedEntry.response;
+    }
+
+    if (key in this.currentlyTranslating) {
+      return this.currentlyTranslating[key].promise;
+    }
+
+    let _resolve = null;
+    let _reject = null;
+    const promise = new Promise((res, rej) => {
+      _resolve = res;
+      _reject = rej;
+    })
+
+
+    this.currentlyTranslating[key] = {
+      promise,
+      resolve: _resolve,
+      reject: _reject,
+    };
+
+    if (!text) {
+      this.currentlyTranslating[key].reject("No text was provided");
+      return promise
+    }
+
+    this.loadModel(fromLang, toLang).then(() => {
+      this.worker.postMessage([
+        "translate",
+        fromLang,
+        toLang,
+        [text],
+        key,
+        paragraphIndex
+      ])
+    })
+    .catch(e => _reject(e));
+
+    return promise;
+  }
+}


### PR DESCRIPTION
1. Add type docs to properties of TranslatePlugin Class
2. Take translated paragraphs and divide into chunks using '.' as delimiter to show translations as lines to allow for graphics in digital works. 
    - Grabs CSS values from existing ```.BRlineElement``` and ```.BRparagraphElement``` to attempt to keep translated text within the bounds of the paragraph text being translated. 
    - Currently using overflow-y: auto to let overflow text be visible via scrolling
    - font-size property for spans are adjusted to be slightly smaller (5px smaller for now) since text from passages tends to go past the height of the container. 


![image](https://github.com/user-attachments/assets/5526cb94-731f-48a9-95a8-0e060659028f)
![image](https://github.com/user-attachments/assets/f3cc0a5d-f6fe-4346-bd9b-1e896cbb6298)