### PR TITLE
Redesign Translation Side Menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.0-97",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@internetarchive/bergamot-translator": "0.4.9-ia.0",
+        "@internetarchive/bergamot-translator": "^0.4.9-ia.1",
         "@internetarchive/ia-activity-indicator": "^0.0.4",
         "@internetarchive/ia-item-navigator": "^2.1.2",
         "@internetarchive/icon-bookmark": "^1.3.4",
@@ -2179,9 +2179,9 @@
       "dev": true
     },
     "node_modules/@internetarchive/bergamot-translator": {
-      "version": "0.4.9-ia.0",
-      "resolved": "https://registry.npmjs.org/@internetarchive/bergamot-translator/-/bergamot-translator-0.4.9-ia.0.tgz",
-      "integrity": "sha512-aAPAXO7WlJsNFSv0ekwkjtcs8ODa2U7w2N8viJIWrc97UXKEzz+SorNCRTl4z+SPOK9lyl3O6CstFp/uF3lUfg=="
+      "version": "0.4.9-ia.1",
+      "resolved": "https://registry.npmjs.org/@internetarchive/bergamot-translator/-/bergamot-translator-0.4.9-ia.1.tgz",
+      "integrity": "sha512-NacODSAjU2sjyrU6bLjFdp82SgG2ZlAMq0t3WJ+yfauz+iNeSqFgt4UHgdoGfRN9W6yxoOyfWY3yWqkHxyDfAQ=="
     },
     "node_modules/@internetarchive/field-parsers": {
       "version": "0.1.3",
@@ -17909,9 +17909,9 @@
       "dev": true
     },
     "@internetarchive/bergamot-translator": {
-      "version": "0.4.9-ia.0",
-      "resolved": "https://registry.npmjs.org/@internetarchive/bergamot-translator/-/bergamot-translator-0.4.9-ia.0.tgz",
-      "integrity": "sha512-aAPAXO7WlJsNFSv0ekwkjtcs8ODa2U7w2N8viJIWrc97UXKEzz+SorNCRTl4z+SPOK9lyl3O6CstFp/uF3lUfg=="
+      "version": "0.4.9-ia.1",
+      "resolved": "https://registry.npmjs.org/@internetarchive/bergamot-translator/-/bergamot-translator-0.4.9-ia.1.tgz",
+      "integrity": "sha512-NacODSAjU2sjyrU6bLjFdp82SgG2ZlAMq0t3WJ+yfauz+iNeSqFgt4UHgdoGfRN9W6yxoOyfWY3yWqkHxyDfAQ=="
     },
     "@internetarchive/field-parsers": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/internetarchive/bookreader#readme",
   "private": false,
   "dependencies": {
-    "@internetarchive/bergamot-translator": "0.4.9-ia.0",
+    "@internetarchive/bergamot-translator": "^0.4.9-ia.1",
     "@internetarchive/ia-activity-indicator": "^0.0.4",
     "@internetarchive/ia-item-navigator": "^2.1.2",
     "@internetarchive/icon-bookmark": "^1.3.4",

--- a/src/plugins/translate/TranslationManager.js
+++ b/src/plugins/translate/TranslationManager.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { Cache } from '../../util/cache.js';
 import { BatchTranslator } from '@internetarchive/bergamot-translator/translator.js';
+import { toISO6391 } from '../tts/utils.js';
 
 export const langs = /** @type {{[lang: string]: string}} */ {
   "bg": "Bulgarian",
@@ -68,7 +69,7 @@ export class TranslationManager {
       this._initResolve = resolve;
       this._initReject = reject;
     });
-    const registryUrl = "https://cors.archive.org/cors/mozilla-translate-models/";
+    const registryUrl = "https://cors.archive.org/cors/mozilla-translate-models/firefox_models/";
     const registryJson = await fetch(registryUrl + "registry.json").then(r => r.json());
     for (const language of Object.values(registryJson)) {
       for (const file of Object.values(language)) {
@@ -97,10 +98,10 @@ export class TranslationManager {
       // List of dev models found here https://github.com/mozilla/firefox-translations-models/tree/main/models/base
       // There are also differences between the model types in the repo above here: https://github.com/mozilla/firefox-translations-models?tab=readme-ov-file#firefox-translations-models
       if (firstLang !== "en") {
-        this.fromLanguages.push({code: firstLang, name:langs[firstLang], type: "prod"});
+        this.fromLanguages.push({code: firstLang, name: toISO6391(firstLang, true), type: "prod"});
       }
       if (secondLang !== "en") {
-        this.toLanguages.push({code: secondLang, name:langs[secondLang], type: "prod"});
+        this.toLanguages.push({code: secondLang, name: toISO6391(secondLang, true), type: "prod"});
       }
     }
     this._initResolve([this.modelRegistry]);

--- a/src/plugins/translate/plugin.translate.js
+++ b/src/plugins/translate/plugin.translate.js
@@ -386,7 +386,7 @@ export class BrTranslatePanel extends LitElement {
         <label>
           <span style="font-size: 12px;color: #ccc;">Translate To</span>
           <select id="lang-to" name="to" class="lang-select" style="display:block; width:100%;" @change="${this._onLangToChange}">
-          ${sortBy(this.toLanguages, ((lang) => [...lang.name].reduce((a, char) => a + char.charCodeAt() - 96 , 0)
+          ${sortBy(this.toLanguages, ((lang) => lang.name.toLowerCase()
     )).map((lang) => {
       return html`<option value="${lang.code}" 
                         ?selected=${lang.code == this.detectedToLang}
@@ -411,7 +411,7 @@ export class BrTranslatePanel extends LitElement {
             </i> Change 
           </summary>
           <select id="lang-from" name="from" class="lang-select" value=${this.detectedFromLang} @change="${this._onLangFromChange}" style="width:65%; margin-top: 3%; margin-bottom: 3%">
-          ${sortBy(this.fromLanguages, ((lang) => [...lang.name].reduce((a, char) => a + char.charCodeAt() - 96, 0)
+          ${sortBy(this.fromLanguages, ((lang) => lang.name.toLowerCase()
           )).map((lang) => {
             return html`<option value="${lang.code}"
                       ?selected=${lang.code == this.detectedFromLang}

--- a/src/plugins/translate/plugin.translate.js
+++ b/src/plugins/translate/plugin.translate.js
@@ -53,8 +53,6 @@ export class TranslatePlugin extends BookReaderPlugin {
    */
   userToggleTranslate;
 
-  modelStatus = false;
-
   async init() {
     const currentLanguage = toISO6391(this.br.options.bookLanguage.replace(/[.,/#!$%^&*;:{}=\-_`~()]/g, ""));
     this.langFromCode = currentLanguage ?? "en";
@@ -361,7 +359,6 @@ export class BrTranslatePanel extends LitElement {
   @property({ type: Boolean }) userTranslationActive = false;
   @property({ type: String }) detectedFromLang = '';
   @property({ type: String }) detectedToLang = '';
-  @property({ type: Boolean }) modelStatus;
 
   /** @override */
   createRenderRoot() {
@@ -415,7 +412,7 @@ export class BrTranslatePanel extends LitElement {
           )).map((lang) => {
             return html`<option value="${lang.code}"
                       ?selected=${lang.code == this.detectedFromLang}
-                      >${lang.name ? lang.name : lang.code} </option`;
+                      >${lang.name ? lang.name : lang.code} </option>`;
           })
           }
           </select>
@@ -456,7 +453,7 @@ export class BrTranslatePanel extends LitElement {
   }
 
   _getSelectedLang(type) {
-    /** @type HTMLSelectElement */
+    /** @type {HTMLSelectElement} */
     const dropdown = this.querySelector(`#lang-${type}`);
     return dropdown ? dropdown.value : '';
   }
@@ -474,18 +471,6 @@ export class BrTranslatePanel extends LitElement {
     });
     this.userTranslationActive = !this.userTranslationActive;
     this.dispatchEvent(toggleTranslateEvent);
-  }
-
-  _visibilityFromLang() {
-    /** @type HTMLElement */
-    const dropdown = this.querySelector("#lang-from");
-    const currentVisibility = dropdown.style.visibility;
-    if (!currentVisibility) {
-      dropdown.style.visibility = "hidden";
-    } else {
-      dropdown.style.visibility = "";
-    }
-    return;
   }
 
   // TODO: Hardcoded warning message for now but should add more statuses

--- a/src/plugins/translate/plugin.translate.js
+++ b/src/plugins/translate/plugin.translate.js
@@ -321,7 +321,7 @@ export class TranslatePlugin extends BookReaderPlugin {
   }
 
   /**
-  * Update the table of contents based on array of TOC entries.
+  * Update translation side menu
   */
   _render() {
     this.br.shell.menuProviders['translate'] = {
@@ -452,6 +452,7 @@ export class BrTranslatePanel extends LitElement {
     if (this._getSelectedLang('from') !== event.target.value) {
       this.prevSelectedLang = this._getSelectedLang('from');
     }
+    this.detectedToLang = event.target.value;
   }
 
   _getSelectedLang(type) {
@@ -489,7 +490,7 @@ export class BrTranslatePanel extends LitElement {
 
   // TODO: Hardcoded warning message for now but should add more statuses
   _statusWarning() {
-    if (this._getSelectedLang("to") == this._getSelectedLang("from")) {
+    if (this.detectedFromLang == this.detectedToLang) {
       return "Translate To language is the same as the Source language";
     }
     return "";

--- a/src/plugins/tts/utils.js
+++ b/src/plugins/tts/utils.js
@@ -19,38 +19,48 @@ export function isAndroid(userAgent = navigator.userAgent) {
   return /android/i.test(userAgent);
 }
 
+/** @type {{[lang: string]: string}} */
+// Handle odd one-off language pairs that might show up over time
+const specialLangs =  {
+  "zh-hans": "中文 (Zhōngwén)",
+};
 /**
  * @typedef {string} ISO6391
  * Language code in ISO 639-1 format. e.g. en, fr, zh
+ * Can also retrieve language native name + ISO 639-1 code
  **/
 
 /**
  * @param {string} language in some format
+ * @param {boolean?} getName gets Native Name + language code if true
  * @return {ISO6391?}
  */
-export function toISO6391(language) {
+export function toISO6391(language, getName = false) {
   if (!language) return null;
   language = language.toLowerCase();
 
-  return searchForISO6391(language, ['iso639_1']) ||
-    searchForISO6391(language, ['iso639_2T']) ||
-    searchForISO6391(language, ['iso639_2B', 'nativeName', 'name']);
+  return searchForISO6391(language, ['iso639_1'], getName) ||
+    searchForISO6391(language, ['iso639_2T'], getName) ||
+    searchForISO6391(language, ['iso639_2B', 'nativeName', 'name'], getName);
 }
 
 /**
  * Searches for the given long in the given columns.
  * @param {string} language
  * @param {Array<keyof import('iso-language-codes').Code>} columnsToSearch
+ * @param {boolean?} getName
  * @return {ISO6391?}
  */
-function searchForISO6391(language, columnsToSearch) {
+function searchForISO6391(language, columnsToSearch, getName) {
   for (const lang of langs) {
     for (const colName of columnsToSearch) {
       if (lang[colName].split(', ').map(x => x.toLowerCase()).indexOf(language) != -1) {
+        if (getName) return `${lang.nativeName.split(", ")[0]} (${lang.iso639_1})`;
         return lang.iso639_1;
       }
     }
   }
+  if (specialLangs[language]) return `${specialLangs[language]} (${language})`;
   return null;
 }
 


### PR DESCRIPTION
Translation Plugin sidebar menu updated to using feedback from UI/UX meeting

- "From" language -> "Source" language. 
- Source language field/dropdown is not immediately available and is only visible after a user clicks on "Change"
- Add status message in sidebar if "Translate To" and "Source" languages are the same, which hints to why a translation may not work for the page.
- Misc styling

Before
----
<img width="277" height="162" alt="image" src="https://github.com/user-attachments/assets/995625db-aa25-46ce-b4e4-70bb8e687e03" />

After
----
<img width="277" height="323" alt="image" src="https://github.com/user-attachments/assets/8906475d-da0e-4e31-8e4f-e16e4ed4e2f0" /> <img width="275" height="337" alt="image" src="https://github.com/user-attachments/assets/d090f652-fc92-453a-86e8-d901b5736eb2" /> 
