### PR TITLE
Add BookReader.extendOptions method for shallow options merge

### DIFF
--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -109,12 +109,16 @@ BookReader.PLUGINS = {
   autoplay: null,
   /** @type {typeof import('./plugins/plugin.chapters.js').ChaptersPlugin | null}*/
   chapters: null,
+  /** @type {typeof import('./plugins/plugin.experiments.js').ExperimentsPlugin | null}*/
+  experiments: null,
   /** @type {typeof import('./plugins/plugin.resume.js').ResumePlugin | null}*/
   resume: null,
   /** @type {typeof import('./plugins/search/plugin.search.js').SearchPlugin | null}*/
   search: null,
   /** @type {typeof import('./plugins/plugin.text_selection.js').TextSelectionPlugin | null}*/
   textSelection: null,
+  /** @type {typeof import('./plugins/translate/plugin.translate.js').TranslatePlugin | null}*/
+  translate: null,
   /** @type {typeof import('./plugins/tts/plugin.tts.js').TtsPlugin | null}*/
   tts: null,
 };
@@ -175,9 +179,11 @@ BookReader.prototype.setup = function(options) {
     archiveAnalytics: BookReader.PLUGINS.archiveAnalytics ? new BookReader.PLUGINS.archiveAnalytics(this) : null,
     autoplay: BookReader.PLUGINS.autoplay ? new BookReader.PLUGINS.autoplay(this) : null,
     chapters: BookReader.PLUGINS.chapters ? new BookReader.PLUGINS.chapters(this) : null,
+    experiments: BookReader.PLUGINS.experiments ? new BookReader.PLUGINS.experiments(this) : null,
     search: BookReader.PLUGINS.search ? new BookReader.PLUGINS.search(this) : null,
     resume: BookReader.PLUGINS.resume ? new BookReader.PLUGINS.resume(this) : null,
     textSelection: BookReader.PLUGINS.textSelection ? new BookReader.PLUGINS.textSelection(this) : null,
+    translate: BookReader.PLUGINS.translate ? new BookReader.PLUGINS.translate(this) : null,
     tts: BookReader.PLUGINS.tts ? new BookReader.PLUGINS.tts(this) : null,
   };
 

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -64,37 +64,26 @@ BookReader.extendOptions = function(...newOptions) {
   if (newOptions.length <= 1) {
     return newOptions[0];
   }
+  /** @type {Array<keyof BookReaderOptions>} */
+  const shallowOverrides = ['onePage', 'twoPage', 'vars'];
+  /** @type {Array<keyof BookReaderOptions>} */
+  const mapOverrides = ['plugins', 'controls'];
+
   const result = newOptions.shift();
   for (const opts of newOptions) {
-    // Extend the plugins individually
-    const pluginOptions = opts.plugins;
-    if (pluginOptions) {
-      result.plugins ||= {};
-      for (const pluginName in pluginOptions) {
-        result.plugins[pluginName] ||= {};
-        jQuery.extend(result.plugins[pluginName], pluginOptions[pluginName]);
+    for (const [key, value] of Object.entries(opts)) {
+      if (shallowOverrides.includes(key)) {
+        result[key] ||= {};
+        result[key] = Object.assign(result[key], value);
+      } else if (mapOverrides.includes(key)) {
+        result[key] ||= {};
+        for (const [name, mapValue] of Object.entries(value)) {
+          result[key][name] ||= {};
+          Object.assign(result[key][name], mapValue);
+        }
+      } else {
+        result[key] = value;
       }
-
-      // Temporarily delete to avoid next `extend` call overwriting the plugins
-      delete opts.plugins;
-    }
-
-    const originalControls = opts.controls;
-    if (originalControls) {
-      result.controls ||= {};
-      // These are deep for legacy reasons
-      jQuery.extend(true, result.controls, originalControls);
-      delete opts.controls;
-    }
-
-    jQuery.extend(result, opts);
-
-    if (pluginOptions) {
-      opts.plugins = pluginOptions;
-    }
-
-    if (originalControls) {
-      opts.controls = originalControls;
     }
   }
 

--- a/src/BookReader/options.js
+++ b/src/BookReader/options.js
@@ -152,6 +152,8 @@ export const DEFAULT_OPTIONS = {
     autoplay: {},
     /** @type {Partial<import('../plugins/plugin.chapters.js').ChaptersPlugin['options']>} */
     chapters: {},
+    /** @type {Partial<import('../plugins/plugin.experiments.js').ExperimentsPlugin['options']>} */
+    experiments: {},
     /** @type {Partial<import('../plugins/plugin.iiif.js').IiifPlugin['options']>} */
     iiif: {},
     /** @type {Partial<import('../plugins/plugin.resume.js').ResumePlugin['options']>} */
@@ -160,6 +162,8 @@ export const DEFAULT_OPTIONS = {
     search: {},
     /** @type {Partial<import('../plugins/plugin.text_selection.js').TextSelectionPlugin['options']>} */
     textSelection: {},
+    /** @type {Partial<import('../plugins/translate/plugin.translate.js').TranslatePlugin['options']>} */
+    translate: {},
     /** @type {Partial<import('../plugins/tts/plugin.tts.js').TtsPlugin['options']>} */
     tts: {},
   },

--- a/src/BookReader/options.js
+++ b/src/BookReader/options.js
@@ -147,21 +147,21 @@ export const DEFAULT_OPTIONS = {
    **/
   plugins: {
     /** @type {Partial<import('../plugins/plugin.archive_analytics.js').ArchiveAnalyticsPlugin['options'>]}*/
-    archiveAnalytics: null,
+    archiveAnalytics: {},
     /** @type {Partial<import('../plugins/plugin.autoplay.js').AutoplayPlugin['options'>]}*/
-    autoplay: null,
+    autoplay: {},
     /** @type {Partial<import('../plugins/plugin.chapters.js').ChaptersPlugin['options']>} */
-    chapters: null,
+    chapters: {},
     /** @type {Partial<import('../plugins/plugin.iiif.js').IiifPlugin['options']>} */
-    iiif: null,
+    iiif: {},
     /** @type {Partial<import('../plugins/plugin.resume.js').ResumePlugin['options']>} */
-    resume: null,
+    resume: {},
     /** @type {Partial<import('../plugins/search/plugin.search.js').SearchPlugin['options']>} */
-    search: null,
+    search: {},
     /** @type {Partial<import('../plugins/plugin.text_selection.js').TextSelectionPlugin['options']>} */
-    textSelection: null,
+    textSelection: {},
     /** @type {Partial<import('../plugins/tts/plugin.tts.js').TtsPlugin['options']>} */
-    tts: null,
+    tts: {},
   },
 
   /**

--- a/src/plugins/translate/plugin.translate.js
+++ b/src/plugins/translate/plugin.translate.js
@@ -12,6 +12,8 @@ export class TranslatePlugin extends BookReaderPlugin {
 
   options = {
     enabled: true,
+
+    /** @type {string | import('lit').TemplateResult} */
     panelDisclaimerText: "Translations are in alpha",
   }
 

--- a/tests/jest/BookReader/Navbar/Navbar.test.js
+++ b/tests/jest/BookReader/Navbar/Navbar.test.js
@@ -89,7 +89,7 @@ describe('Navbar slider', () => {
 
 describe('Navbar controls overrides', () => {
   const createBRWithOverrides = (overrides) => {
-    br = new BookReader($.extend(true, br.options, overrides));
+    br = new BookReader(BookReader.extendOptions(br.options, overrides));
     br.init();
     navbar = br._components.navbar;
   };


### PR DESCRIPTION
Otherwise it is impossible to specify lit `TemplateResult`s as options, because some of their internal methods get flattened out.

This will be necessary in order to show the IA feedback button via the option, otherwise was getting an error when I assigned a lit `TemplateResult`, eg

```
translations: { panelDisclaimerText: html`<ia-feedback-button ...>...</ia-feedback-button>` }
```

Apparently the `html` method returns a `TemplateResult` , which is an object that has a `.strings` field which is an array of strings. However this array has a property `.raw`, and it seems like this is getting stripped by jQuery's default `.extend` method. To avoid it running, I switched to a shallow extend instead of a deep extend, but have to add some exceptions for spots where we _do_ want a deep extend, namely the `plugins` sub-object and the legacy `controls` sub-object.