### PR TITLE
Fix header footer paragraphs from being read aloud

### DIFF
--- a/src/plugins/plugin.text_selection.js
+++ b/src/plugins/plugin.text_selection.js
@@ -358,6 +358,10 @@ export class TextSelectionPlugin extends BookReaderPlugin {
   renderParagraph(ocrParagraph) {
     const paragEl = document.createElement('p');
     paragEl.classList.add('BRparagraphElement');
+    if (ocrParagraph.getAttribute("x-role")) {
+      paragEl.classList.add('ocr-role-header-footer');
+      paragEl.ariaHidden = "true";
+    }
     const [paragLeft, paragBottom, paragRight, paragTop] = $(ocrParagraph).attr("coords").split(",").map(parseFloat);
     const wordHeightArr = [];
     const lines = $(ocrParagraph).find("LINE[coords]").toArray();

--- a/src/plugins/translate/plugin.translate.js
+++ b/src/plugins/translate/plugin.translate.js
@@ -162,6 +162,11 @@ export class TranslatePlugin extends BookReaderPlugin {
         translatedParagraph.setAttribute('data-translate-index', `${pageIndex}-${pidx}`);
         translatedParagraph.className = 'BRparagraphElement';
         const originalParagraphStyle = paragraphs[pidx];
+        // check text selection paragraphs for header/footer roles
+        if (paragraph.classList.contains('ocr-role-header-footer')) {
+          translatedParagraph.ariaHidden = "true";
+          translatedParagraph.classList.add('ocr-role-header-footer');
+        }
         const fontSize = `${parseInt($(originalParagraphStyle).css("font-size"))}px`;
 
         $(translatedParagraph).css({

--- a/src/plugins/tts/PageChunk.js
+++ b/src/plugins/tts/PageChunk.js
@@ -29,8 +29,11 @@ export default class PageChunk {
 
       const pageChunks = [];
       for (const [idx, item] of paragraphs.entries()) {
-        const translatedChunk = new PageChunk(leafIndex, idx, item.textContent, []);
-        pageChunks.push(translatedChunk);
+        // Should not read paragraphs w/ header or footer roles
+        if (!item.classList.contains('ocr-role-header-footer')) {
+          const translatedChunk = new PageChunk(leafIndex, idx, item.textContent, []);
+          pageChunks.push(translatedChunk);
+        }
       }
       if (pageChunks.length === 0) {
         const placeholder = new PageChunk(leafIndex, 0, "", []);


### PR DESCRIPTION
Checks for `x-role="ocr-role-header-footer"` from text selection's djvuXML and assigns new class to translation paragraphs to prevent headers/footers from being assigned a PageChunk for ReadAloud functionality.

