### PR TITLE
Style target text when in BR to match other highlights

### DIFF
--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -54,6 +54,13 @@
     }
 }
 
+// Style URI TextFragments, eg #:~:text=example
+.BRtextLayer ::target-text {
+    // Similar colour to the default one used in Safari, Firefox. Note Chrome uses a purple colour
+    background-color: hsla(45, 80%, 66%, 0.6);
+    color: transparent;
+}
+
 .BRparagraphElement br {
     visibility: hidden;
 }


### PR DESCRIPTION
For https://archive.org/details/goody/page/6/mode/2up#:~:text=Poor%20at%20the,Parifh

Before:

<img width="1206" height="971" alt="image" src="https://github.com/user-attachments/assets/9054b9c6-ff11-412c-8d9d-75de75787d1b" />


After:
<img width="1201" height="964" alt="image" src="https://github.com/user-attachments/assets/f30ef39b-e491-45ac-a4ed-a26ec6175353" />

Note I used a gold colour to match Safari/Firefox, not the purple colour Chrome uses. Gold seems a bit more inline with how other fragments are highlighted.