### PR TITLE
Convert single paragraph to lines using static sentence length

### DIFF
--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -131,7 +131,6 @@
 
 .BRtranslateLayer .BRparagraphElement {
     pointer-events: auto;
-    overflow-y: auto;
     background: rgba(248, 237, 192, 0.8);
     backdrop-filter: blur(8px);
     color:black;
@@ -139,9 +138,13 @@
     text-align: justify;
 }
 
-.BRtranslateLayer .BRparagraphElement .BRlineElement {
+.BRparagraphElement .BRlineElement {
     white-space: break-spaces;
-    display: inline-block;
+    display: contents;
+    width: 100%;
+    text-wrap-mode: nowrap;
+    .BRtranslateLayer[dir=ltr] & { margin-right: 100%; }
+    .BRtranslateLayer[dir=rtl] & { margin-left: 100%; }
 }
 
 .BRtextLayer.showingTranslation {

--- a/src/plugins/translate/utils.js
+++ b/src/plugins/translate/utils.js
@@ -1,0 +1,16 @@
+/**
+ *
+ * @param {Array<string>} passageArr translated text split into array by punctuation
+ * @param {number} chunkSize average sentence length is 15-20 words (?)
+ * @return {Array<string>}
+ */
+export function passageToLines (passageArr, chunkSize = 20) {
+  const wordItems = passageArr.filter(word => word.length > 0);
+  const output = [];
+  for (let i = 0; i < wordItems.length; i += chunkSize) {
+    const chunk = wordItems.slice(i, i + chunkSize);
+    const sentence = chunk.join(" ");
+    output.push(sentence);
+  }
+  return output;
+}


### PR DESCRIPTION
Translated text is currently displayed all together in a single BRlineElement, which prevents the existing text selection protections from working as intended.

To ensure that text selection does not exceed the protected limit, the entire translated paragraph is split by space characters. Sentence strings are then re-created to be no longer than 20 words (was an arbitrary number but 15-20 words seems to be the recommended average across [multiple](https://insidegovuk.blog.gov.uk/2014/08/04/sentence-length-why-25-words-is-our-limit/) [content](https://lifelong-learning.ox.ac.uk/about/sentence-length) / [styling](https://prsay.prsa.org/2009/01/14/how-to-make-your-copy-more-readable-make-sentences-shorter/) guides) 

Also includes some CSS styling changes to prevent line breaks between sentence fragments/chunks