### PR TITLE
Prevent 0px left/top OCR words from rendering on the page

### DIFF
--- a/src/plugins/plugin.text_selection.js
+++ b/src/plugins/plugin.text_selection.js
@@ -142,8 +142,8 @@ export class TextSelectionPlugin extends BookReaderPlugin {
     $(XMLpage).find("WORD").filter((_, ele) => {
       const [left, , , top] = ele.getAttribute('coords').split(",").map(parseFloat);
       if (left == 0 && top == 0) {
-          console.error("Found invalid ocr word coordinates");
-          return true;
+        console.error("Found invalid ocr word coordinates");
+        return true;
       }
     }).remove();
     recursivelyAddCoords(XMLpage);


### PR DESCRIPTION
Closes #1452, see comment for screenshot of the fix 

Filters the XMLpage contents by `WORD` and looks for `coords` attributes where the left or top coordinates are 0px. These word elements will not be rendered onto the page since there is no reliable way to extrapolate the position of the text. 

We can be confident that these fields should not exist in the leftmost/topmost part of a work for a significant majority of cases. 

