### PR TITLE
Fix: Detect browser language and use for Translate plugin 'To' language

### DIFF
--- a/src/plugins/translate/plugin.translate.js
+++ b/src/plugins/translate/plugin.translate.js
@@ -107,18 +107,18 @@ export class TranslatePlugin extends BookReaderPlugin {
     await this.translationManager.initWorker();
     // Note await above lets _render function properly, since it gives the browser
     // time to render the rest of bookreader, which _render depends on
-    
+
     // Detect browser language and use as default "To" language if available
     const browserLang = navigator.language;
     const browserLangCode = toISO6391(browserLang);
-    const browserLangAvailable = browserLangCode && 
+    const browserLangAvailable = browserLangCode &&
       this.translationManager.toLanguages.some(lang => lang.code === browserLangCode);
-    
+
     // Set browser language as default if available, otherwise fallback to English
-    this.langToCode = browserLangAvailable 
-      ? browserLangCode 
+    this.langToCode = browserLangAvailable
+      ? browserLangCode
       : this.translationManager.toLanguages[0].code;
-    
+
     this._render();
   }
 


### PR DESCRIPTION
- Detect browser language using navigator.language
- Convert to ISO6391 format using toISO6391 utility
- Check if browser language is available in translation models
- Set browser language as default 'To' language if available, otherwise fallback to English
- Fixes issue #1459
here is the screenshot of the fix:
<img width="1302" height="613" alt="translate" src="https://github.com/user-attachments/assets/c9efb811-2d6d-4c5c-8504-c050f4cfaf0f" />
