### PR TITLE
fix en language code

### DIFF
--- a/src/plugins/translate/TranslationManager.js
+++ b/src/plugins/translate/TranslationManager.js
@@ -36,7 +36,7 @@ export class TranslationManager {
 
   constructor() {
     //TODO Should default to the book language as the first element
-    const enModel = {code: "en", name: "English", type: "prod"};
+    const enModel = {code: "en", name: "English (en)", type: "prod"};
     this.fromLanguages.push(enModel);
     this.toLanguages.push(enModel);
   }


### PR DESCRIPTION
#1458 Fixes inconsistency where English language didn't display its language code
- Updated English model name in TranslationManager constructor

<img width="505" height="781" alt="image" src="https://github.com/user-attachments/assets/c7fda7a4-0deb-4f4b-89d7-a58d512ddc74" />
