### PR TITLE
Switch to npm trusted publishing + Update to Node 24

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         # Keep in sync with netlify.toml
-        node-version: 20.x
+        node-version: 24.x
     - name: Cache node_modules
       uses: actions/cache@v4
       id: cache
@@ -32,7 +32,7 @@ jobs:
         # we don't use `npm ci` specifically to try to get faster CI flows. So caching
         # `node_modules` directly.
         path: 'node_modules'
-        key: ${{ runner.os }}-node-20-${{ hashFiles('package*.json') }}
+        key: ${{ runner.os }}-node-24-${{ hashFiles('package*.json') }}
     - if: steps.cache.outputs.cache-hit != 'true'
       run: npm install
 
@@ -43,13 +43,13 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: 24.x
     - name: Load node_modules from cache
       uses: actions/cache@v4
       with:
         # Use node_modules from previous jobs
         path: 'node_modules'
-        key: ${{ runner.os }}-node-20-${{ hashFiles('package*.json') }}
+        key: ${{ runner.os }}-node-24-${{ hashFiles('package*.json') }}
     - name: Cache BookReader/
       uses: actions/cache@v4
       id: build-cache
@@ -67,13 +67,13 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: 24.x
     - name: Load node_modules from cache
       uses: actions/cache@v4
       with:
         # Use node_modules from previous jobs
         path: 'node_modules'
-        key: ${{ runner.os }}-node-20-${{ hashFiles('package*.json') }}
+        key: ${{ runner.os }}-node-24-${{ hashFiles('package*.json') }}
     - run: npm run lint
     - run: npm run test
     - uses: codecov/codecov-action@v4
@@ -87,13 +87,13 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: 24.x
     - name: Load node_modules from cache
       uses: actions/cache@v4
       with:
         # Use node_modules from previous jobs
         path: 'node_modules'
-        key: ${{ runner.os }}-node-20-${{ hashFiles('package*.json') }}
+        key: ${{ runner.os }}-node-24-${{ hashFiles('package*.json') }}
     - name: Load BookReader/ from cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build.environment]
   # Keep in sync with CI in .github/workflows/node.js.yml
-  NODE_VERSION = "20"
+  NODE_VERSION = "24"
 
 [[headers]]
   # Define which paths this specific [[headers]] block will cover.


### PR DESCRIPTION
Needed a new version of node to support npm's [trusted publishers](https://docs.npmjs.com/trusted-publishers).