### PR TITLE
Update JS syntax for node 24

### DIFF
--- a/scripts/postversion.js
+++ b/scripts/postversion.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import PACKAGE_JSON from '../package.json' assert { type: 'json' };
+import PACKAGE_JSON from '../package.json' with { type: 'json' };
 const NEW_VERSION = PACKAGE_JSON.version;
 
 const tag = `v${NEW_VERSION}`;

--- a/scripts/preversion.js
+++ b/scripts/preversion.js
@@ -1,4 +1,4 @@
-import PACKAGE_JSON from '../package.json' assert { type: 'json' };
+import PACKAGE_JSON from '../package.json' with { type: 'json' };
 
 const OLD_VERSION = PACKAGE_JSON.version;
 const OLD_RELEASE_URL = `https://api.github.com/repos/internetarchive/bookreader/releases/tags/v${OLD_VERSION}`;

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { execSync } from 'child_process';
-import PACKAGE_JSON from '../package.json' assert { type: 'json' };
+import PACKAGE_JSON from '../package.json' with { type: 'json' };
 const NEW_VERSION = PACKAGE_JSON.version;
 
 async function main() {


### PR DESCRIPTION
Apparently the experimental `assert` keyword has been replaced with `with`. Confirmed the script now runs and no longer errors with:

```
import PACKAGE_JSON from '../package.json' assert { type: 'json' };
                                           ^^^^^^
SyntaxError: Unexpected identifier 'assert'
```