### PR TITLE
Fix CSS scaling issue in Chrome for Translation plugin

### DIFF
--- a/src/css/_BRpages.scss
+++ b/src/css/_BRpages.scss
@@ -101,7 +101,7 @@ svg.BRPageLayer {
 }
 
 // Hides page layers during page flip animation
-.BRpageFlipping .BRtextLayer, .BRpageFlipping .BRtranslateLayer {
+.BRpageFlipping .BRtextLayer {
   display: none;
 }
 

--- a/src/plugins/translate/plugin.translate.js
+++ b/src/plugins/translate/plugin.translate.js
@@ -141,7 +141,6 @@ export class TranslatePlugin extends BookReaderPlugin {
     }
 
     const pageIndex = page.dataset.index;
-
     let pageTranslationLayer;
     if (!page.querySelector('.BRPageLayer.BRtranslateLayer')) {
       pageTranslationLayer = document.createElement('div');
@@ -151,13 +150,14 @@ export class TranslatePlugin extends BookReaderPlugin {
     } else {
       pageTranslationLayer = page.querySelector('.BRPageLayer.BRtranslateLayer');
     }
-
+    /** @type {HTMLElement} textLayerElement */
     const textLayerElement = page.querySelector('.BRtextLayer');
+    // Should use native DOM element.style method instead of $().css method, specific issue with rendering / style calculation in Chrome
     $(pageTranslationLayer).css({
-      "width": $(textLayerElement).css("width"),
-      "height": $(textLayerElement).css("height"),
-      "transform": $(textLayerElement).css("transform"),
-      "pointer-events": $(textLayerElement).css("pointer-events"),
+      "width": textLayerElement.style.width,
+      "height": textLayerElement.style.height,
+      "transform": textLayerElement.style.transform,
+      "pointer-events": textLayerElement.style.pointerEvents,
       "z-index": 3,
     });
     textLayerElement.classList.add('showingTranslation');
@@ -252,17 +252,6 @@ export class TranslatePlugin extends BookReaderPlugin {
    * @param {Element} paragEl
    */
   fitVisiblePage(paragEl) {
-    // For some reason, Chrome does not detect the transform property for the translation + text layers
-    // Could not get it to fetch the transform value using $().css method
-    // Oddly enough the value is retrieved if using .style.transform instead?
-    const translateLayerEl = paragEl.parentElement;
-    if ($(translateLayerEl).css('transform') == 'none') {
-      const pageNumber = paragEl.getAttribute('data-translate-index').split('-')[0];
-      /** @type {HTMLElement} selectionTransform */
-      const textLayerEl = document.querySelector(`[data-index='${pageNumber}'] .BRtextLayer`);
-      $(translateLayerEl).css({'transform': textLayerEl.style.transform});
-    }
-
     const originalFontSize = parseInt($(paragEl).css("font-size"));
     let adjustedFontSize = originalFontSize;
     while (paragEl.clientHeight < paragEl.scrollHeight && adjustedFontSize > 0) {


### PR DESCRIPTION
Makes CSS property assignments for translation text layers before class name `showingTranslation` is added

Includes a small CSS change that hides the `BRtranslateLayer` elements during the page flip animation