### PR TITLE
Fix translation plugin: prevent infinite spinner and remove redundant warning for same-language translation

### DIFF
--- a/src/plugins/translate/plugin.translate.js
+++ b/src/plugins/translate/plugin.translate.js
@@ -307,6 +307,19 @@ export class TranslatePlugin extends BookReaderPlugin {
   }
 
   handleToggleTranslation = async () => {
+    // If enabling translation, check if languages are the same
+    if (!this.userToggleTranslate) {
+      // Check if from and to languages are the same
+      if (this.langFromCode === this.langToCode) {
+        alert("You cannot translate to/from the same language.");
+        // Keep translation disabled
+        this.userToggleTranslate = false;
+        this.translationManager.active = false;
+        this._render();
+        return;
+      }
+    }
+    
     this.userToggleTranslate = !this.userToggleTranslate;
     this.translationManager.active = this.userToggleTranslate;
 
@@ -427,9 +440,6 @@ export class BrTranslatePanel extends LitElement {
           }
           </select>
       </details>
-      <div class="footer" id="status" style="margin-top:5%">
-      ${this._statusWarning()}
-      </div>
 
       <div class="lang-models-loading"> 
       ${this._languageModelStatus()}
@@ -485,16 +495,7 @@ export class BrTranslatePanel extends LitElement {
       bubbles: true,
       composed:true,
     });
-    this.userTranslationActive = !this.userTranslationActive;
     this.dispatchEvent(toggleTranslateEvent);
-  }
-
-  // TODO: Hardcoded warning message for now but should add more statuses
-  _statusWarning() {
-    if (this.detectedFromLang == this.detectedToLang) {
-      return "Translate To language is the same as the Source language";
-    }
-    return "";
   }
 
   _languageModelStatus() {


### PR DESCRIPTION
Fixes two issues in the translation plugin:

-> Prevents infinite spinner when attempting to translate with the same from/to language
-> Removes redundant warning text that appears when languages are the same

Tested:
-> Warning text no longer appears at bottom of translation panel
-> State remains consistent after dismissing alerts
-> Tested in desktop, mobile, and embed modes (per CONTRIBUTING.md guidelines)