### PR TITLE
Fix Translate plugin crash in preview mode

### DIFF
--- a/src/plugins/translate/plugin.translate.js
+++ b/src/plugins/translate/plugin.translate.js
@@ -152,6 +152,10 @@ export class TranslatePlugin extends BookReaderPlugin {
     }
     /** @type {HTMLElement} textLayerElement */
     const textLayerElement = page.querySelector('.BRtextLayer');
+    if (!textLayerElement) {
+      console.warn("Translate unavailable: no text layer (preview mode?)");
+      return;
+    }
     // Should use native DOM element.style method instead of $().css method, specific issue with rendering / style calculation in Chrome
     $(pageTranslationLayer).css({
       "width": textLayerElement.style.width,
@@ -307,6 +311,12 @@ export class TranslatePlugin extends BookReaderPlugin {
   }
 
   handleToggleTranslation = async () => {
+    const hasTextLayer = document.querySelector('.BRtextLayer');
+    if (!hasTextLayer) {
+      alert("Please borrow the book to use translation.");
+      return;
+    }
+
     this.userToggleTranslate = !this.userToggleTranslate;
     this.translationManager.active = this.userToggleTranslate;
 


### PR DESCRIPTION
### Problem
Clicking the Translate button on preview-only (not borrowed) books causes the plugin to crash with:
`Cannot read properties of null (reading 'style')` and the UI enters an infinite loading state.

This happens because `.BRtextLayer` does not exist in preview mode, but the plugin assumes it is always present.

### Fix
- Added a null guard in `translateRenderedLayer` to prevent accessing missing DOM.
- Added a user-facing alert when attempting to translate a preview-only book.

### Result
- No more console errors.
- No infinite spinner.
- Users are informed that borrowing is required.
- Borrowed books continue to work normally.
