### PR TITLE
fix: Prevent translation with identical source and target languages #1488

### DIFF
--- a/src/plugins/translate/plugin.translate.js
+++ b/src/plugins/translate/plugin.translate.js
@@ -480,6 +480,11 @@ export class BrTranslatePanel extends LitElement {
   }
 
   _toggleTranslation(event) {
+    // Prevent translating when source and target are identical
+    if (this.detectedFromLang === this.detectedToLang) {
+      alert('You cannot translate to/from the same language');
+      return;
+    }
     const toggleTranslateEvent = new CustomEvent('toggleTranslation', {
       detail: {value: event.target.value},
       bubbles: true,
@@ -491,9 +496,6 @@ export class BrTranslatePanel extends LitElement {
 
   // TODO: Hardcoded warning message for now but should add more statuses
   _statusWarning() {
-    if (this.detectedFromLang == this.detectedToLang) {
-      return "Translate To language is the same as the Source language";
-    }
     return "";
   }
 


### PR DESCRIPTION
## Description
Fixes issue #1488 where clicking "Translate" with identical source and target languages causes the spinner to spin endlessly without any user feedback.

## Changes
This PR prevents translation requests when source and target languages are the same by:

1. **Added validation in `_toggleTranslation()`** - Before initiating translation, the method now checks if `detectedFromLang` equals `detectedToLang`. If they match, an alert is shown to the user with the message "You cannot translate to/from the same language" and the translation is not started.

2. **Removed redundant UI warning** - The plaintext warning "Translate To language is the same as the Source language" has been removed from the `_statusWarning()` method. This keeps the UI clean since the default language often matches the book's language anyway.

## Problem Solved
- **Before:** Clicking "Translate" with same language selected → spinner spins indefinitely with no feedback
- **After:** Clicking "Translate" with same language selected → immediate alert prevents translation attempt

## Files Changed
- `src/plugins/translate/plugin.translate.js`
  - Modified `_toggleTranslation()` method to add language validation
  - Modified `_statusWarning()` method to remove redundant message

## Testing
To test this fix:
1. Open the BookReader and navigate to the Translate panel
2. Keep the "Translate To" and "Source" languages the same
3. Click the "Translate" button
4. Verify the alert appears with the message "You cannot translate to/from the same language"
5. Verify the spinner does not appear and translation does not start
6. Verify no plaintext warning appears at the bottom of the modal

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)