### PR TITLE
Prevent duplicate custom element registration

### DIFF
--- a/src/ia-bookreader/downloads/downloads.js
+++ b/src/ia-bookreader/downloads/downloads.js
@@ -147,4 +147,6 @@ export class IABookDownloads extends LitElement {
     return [buttonStyles, mainCss];
   }
 }
-customElements.define('ia-book-downloads', IABookDownloads);
+if (!customElements.get('ia-book-downloads')) {
+  customElements.define('ia-book-downloads', IABookDownloads);
+}

--- a/src/ia-bookreader/ia-bookreader.js
+++ b/src/ia-bookreader/ia-bookreader.js
@@ -663,4 +663,6 @@ export class IaBookReader extends LitElement {
   }
 }
 
-window.customElements.define("ia-bookreader", IaBookReader);
+if (!customElements.get('ia-bookreader')) {
+  window.customElements.define("ia-bookreader", IaBookReader);
+}

--- a/src/ia-bookreader/visual-adjustments/visual-adjustments.js
+++ b/src/ia-bookreader/visual-adjustments/visual-adjustments.js
@@ -285,4 +285,6 @@ export class IABookVisualAdjustments extends LitElement {
     return [sharedStyles, main];
   }
 }
-customElements.define('ia-book-visual-adjustments', IABookVisualAdjustments);
+if (!customElements.get('ia-book-visual-adjustments')) {
+  customElements.define('ia-book-visual-adjustments', IABookVisualAdjustments);
+}

--- a/src/plugins/bookmarks/bookmark-button.js
+++ b/src/plugins/bookmarks/bookmark-button.js
@@ -62,4 +62,6 @@ export default class BookmarkButton extends LitElement {
   }
 }
 
-customElements.define('bookmark-button', BookmarkButton);
+if (!customElements.get('bookmark-button')) {
+  customElements.define('bookmark-button', BookmarkButton);
+}

--- a/src/plugins/bookmarks/bookmark-edit.js
+++ b/src/plugins/bookmarks/bookmark-edit.js
@@ -224,4 +224,6 @@ export class IABookmarkEdit extends LitElement {
     return [buttonCSS, bookmarkColorsCSS, bookmarkEditCSS];
   }
 }
-customElements.define('ia-bookmark-edit', IABookmarkEdit);
+if (!customElements.get('ia-bookmark-edit')) {
+  customElements.define('ia-bookmark-edit', IABookmarkEdit);
+}

--- a/src/plugins/bookmarks/bookmarks-list.js
+++ b/src/plugins/bookmarks/bookmarks-list.js
@@ -281,4 +281,6 @@ export class IABookmarksList extends LitElement {
     return [main, bookmarkColorsCSS];
   }
 }
-customElements.define('ia-bookmarks-list', IABookmarksList);
+if (!customElements.get('ia-bookmarks-list')) {
+  customElements.define('ia-bookmarks-list', IABookmarksList);
+}

--- a/src/plugins/bookmarks/bookmarks-loginCTA.js
+++ b/src/plugins/bookmarks/bookmarks-loginCTA.js
@@ -25,4 +25,6 @@ class BookmarksLogin extends LitElement {
   }
 }
 
-customElements.define('bookmarks-login', BookmarksLogin);
+if (!customElements.get('bookmarks-login')) {
+  customElements.define('bookmarks-login', BookmarksLogin);
+}

--- a/src/plugins/bookmarks/delete-modal-actions.js
+++ b/src/plugins/bookmarks/delete-modal-actions.js
@@ -46,4 +46,6 @@ export default class DeleteModalActions extends LitElement {
   }
 }
 
-customElements.define('delete-modal-actions', DeleteModalActions);
+if (!customElements.get('delete-modal-actions')) {
+  customElements.define('delete-modal-actions', DeleteModalActions);
+}

--- a/src/plugins/bookmarks/ia-bookmarks.js
+++ b/src/plugins/bookmarks/ia-bookmarks.js
@@ -546,4 +546,6 @@ class IABookmarks extends LitElement {
   }
 }
 
-customElements.define('ia-bookmarks', IABookmarks);
+if (!customElements.get('ia-bookmarks')) {
+  customElements.define('ia-bookmarks', IABookmarks);
+}

--- a/src/plugins/search/search-results.js
+++ b/src/plugins/search/search-results.js
@@ -386,4 +386,6 @@ export class IABookSearchResults extends LitElement {
     return [sharedStyles, buttonCSS, mainCSS];
   }
 }
-customElements.define('ia-book-search-results', IABookSearchResults);
+if (!customElements.get('ia-book-search-results')) {
+  customElements.define('ia-book-search-results', IABookSearchResults);
+}


### PR DESCRIPTION
Description

# Fixes #1496  
where BookReader logs multiple
`CustomElementRegistry.define` DOMException errors when embedded or when
modules are loaded more than once.

The errors occur because several modules attempt to register the same
custom elements multiple times using `customElements.define()`. While this
does not break functionality, it clutters the console and makes debugging
more difficult.

---

Changes

This PR prevents duplicate custom element registration by:

- Adding an existence check before calling `customElements.define()`
- Ensuring each custom element is registered only once, even when modules
  are loaded multiple times
- Preserving existing behavior without introducing new dependencies

---

Problem Solved

Before:
Embedding or reloading BookReader results in multiple
`CustomElementRegistry.define` DOMException errors in the browser console.

After:
BookReader loads cleanly with no duplicate custom element registration
errors, while continuing to function as expected.

---

Files Changed

- Updated modules that register custom elements to guard
  `customElements.define()` calls

---

Testing

To test this fix:

- Embed BookReader in a standalone HTML page
- Reload the page multiple times
- Open modal dialogs, share panel, and viewable files panel
- Instantiate multiple BookReader instances on the same page
- Verify no `CustomElementRegistry.define` DOMException errors appear in the
  browser console

Tested in:
- Chrome 
- Firefox 
- Desktop and mobile responsive modes

---

Type of Change

Bug fix (non-breaking change that resolves issue #1496 )
