### PR TITLE
"Copy link to highlight" experiment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@internetarchive/icon-magnify-minus": "^1.4.0",
         "@internetarchive/icon-magnify-plus": "^1.4.0",
         "@internetarchive/icon-search": "^1.4.0",
+        "@internetarchive/icon-share": "1.4.0",
         "@internetarchive/icon-toc": "^1.4.0",
         "@internetarchive/icon-visual-adjustment": "^1.4.0",
         "@internetarchive/modal-manager": "2.0.5",
@@ -2621,12 +2622,19 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@internetarchive/icon-share": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-share/-/icon-share-1.3.4.tgz",
-      "integrity": "sha512-02xI0WYHtnD++uV4s4rtdgqiBZTN23gjvy6iDw9J23/wzVU4mkQDS6CYCyMVr5uU+5TYCA1k87Dj90TaQn1LsA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-share/-/icon-share-1.4.0.tgz",
+      "integrity": "sha512-ddXdcLDRBs4nTTdnKSIme4K502CVKG2AJCFyeLCBHiB3CtUCq9E9b0NXy3gtiMVcGwe/Ejmzi1x9vKZv0IwDbA==",
+      "license": "AGPL-3.0-only",
       "dependencies": {
-        "lit": "^2.0.2"
+        "lit-html": "^1.2.1"
       }
+    },
+    "node_modules/@internetarchive/icon-share/node_modules/lit-html": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
+      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@internetarchive/icon-toc": {
       "version": "1.4.0",
@@ -18943,11 +18951,18 @@
       }
     },
     "@internetarchive/icon-share": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@internetarchive/icon-share/-/icon-share-1.3.4.tgz",
-      "integrity": "sha512-02xI0WYHtnD++uV4s4rtdgqiBZTN23gjvy6iDw9J23/wzVU4mkQDS6CYCyMVr5uU+5TYCA1k87Dj90TaQn1LsA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-share/-/icon-share-1.4.0.tgz",
+      "integrity": "sha512-ddXdcLDRBs4nTTdnKSIme4K502CVKG2AJCFyeLCBHiB3CtUCq9E9b0NXy3gtiMVcGwe/Ejmzi1x9vKZv0IwDbA==",
       "requires": {
-        "lit": "^2.0.2"
+        "lit-html": "^1.2.1"
+      },
+      "dependencies": {
+        "lit-html": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
+          "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA=="
+        }
       }
     },
     "@internetarchive/icon-toc": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@internetarchive/icon-magnify-minus": "^1.4.0",
     "@internetarchive/icon-magnify-plus": "^1.4.0",
     "@internetarchive/icon-search": "^1.4.0",
+    "@internetarchive/icon-share": "1.4.0",
     "@internetarchive/icon-toc": "^1.4.0",
     "@internetarchive/icon-visual-adjustment": "^1.4.0",
     "@internetarchive/modal-manager": "2.0.5",

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -1958,7 +1958,7 @@ BookReader.prototype.queryStringFromParams = function(
   urlMode = 'hash',
 ) {
   const newParams = new URLSearchParams(currQueryString);
-  let textFragmentParam = '';
+
   if (params.view) {
     // Set ?view=theater when fullscreen
     newParams.set('view', params.view);
@@ -1970,14 +1970,25 @@ BookReader.prototype.queryStringFromParams = function(
   if (params.search && urlMode === 'history') {
     newParams.set('q', params.search);
   }
+
+  let textFragmentParam = '';
+  // Need to pull out text separately to avoid the spaces becoming encoded as +, which
+  // the browser seems not to handle with the text fragment
   if (newParams.get('text')) {
     newParams.delete('text');
-    textFragmentParam = `text=${currQueryString.match(/(?<=&?text=)[^&]*/)}`;
+    textFragmentParam = `text=${this.urlPlugin.retrieveTextFragment(currQueryString)}`;
   }
+
   // https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/toString
   // Note: This method returns the query string without the question mark.
-  const result = textFragmentParam ? newParams.toString() + textFragmentParam : newParams.toString();
-  return result ? '?' + result : '';
+  let result = newParams.toString();
+  if (textFragmentParam) {
+    if (result) result += '&';
+    result += textFragmentParam;
+  }
+  if (result) result = '?' + result;
+
+  return result;
 };
 
 /**

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -1958,7 +1958,7 @@ BookReader.prototype.queryStringFromParams = function(
   urlMode = 'hash',
 ) {
   const newParams = new URLSearchParams(currQueryString);
-
+  let textFragmentParam = '';
   if (params.view) {
     // Set ?view=theater when fullscreen
     newParams.set('view', params.view);
@@ -1970,9 +1970,13 @@ BookReader.prototype.queryStringFromParams = function(
   if (params.search && urlMode === 'history') {
     newParams.set('q', params.search);
   }
+  if (newParams.get('text')) {
+    newParams.delete('text');
+    textFragmentParam = `text=${currQueryString.match(/(?<=&?text=)[^&]*/)}`;
+  }
   // https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/toString
   // Note: This method returns the query string without the question mark.
-  const result = newParams.toString();
+  const result = textFragmentParam ? newParams.toString() + textFragmentParam : newParams.toString();
   return result ? '?' + result : '';
 };
 

--- a/src/BookReader/Mode2UpLit.js
+++ b/src/BookReader/Mode2UpLit.js
@@ -628,9 +628,7 @@ export class Mode2UpLit extends LitElement {
       progression == 'lr' ? [nextSpread.left, nextSpread.right] : [nextSpread.right, nextSpread.left]
     ).filter(x => x);
     nextPageContainers.forEach(c => {
-      this.br.trigger('pageVisible', {
-        pageContainerEl: c.$container[0],
-      });
+      this.br.trigger('pageVisible', {pageContainerEl: c.$container[0]});
     });
   }
 

--- a/src/BookReader/utils/SelectionObserver.js
+++ b/src/BookReader/utils/SelectionObserver.js
@@ -4,6 +4,7 @@ export class SelectionObserver {
   startedInSelector = false;
   /** @type {HTMLElement} */
   target = null;
+  /** @type {Node} */
   lastKnownFocusNode = null;
 
   /**

--- a/src/BookReader/utils/SelectionObserver.js
+++ b/src/BookReader/utils/SelectionObserver.js
@@ -39,7 +39,7 @@ export class SelectionObserver {
       this.handler('started', this.target);
     }
 
-    if (this.selecting && (this.lastKnownFocusNode != sel.focusNode || sel.toString())) {
+    if (this.selecting && (this.lastKnownFocusNode != sel.focusNode || sel.toString() && !sel.isCollapsed)) {
       this.lastKnownFocusNode = sel.focusNode;
       this.handler('focusChanged', this.target);
     }

--- a/src/BookReader/utils/SelectionObserver.js
+++ b/src/BookReader/utils/SelectionObserver.js
@@ -4,10 +4,11 @@ export class SelectionObserver {
   startedInSelector = false;
   /** @type {HTMLElement} */
   target = null;
+  lastKnownFocusNode = null;
 
   /**
    * @param {string} selector
-   * @param {function('started' | 'cleared', HTMLElement): any} handler
+   * @param {function('started' | 'cleared' | 'focusChanged', HTMLElement): any} handler
    */
   constructor(selector, handler) {
     this.selector = selector;
@@ -34,7 +35,13 @@ export class SelectionObserver {
       if (!target) return;
       this.target = target;
       this.selecting = true;
+      this.lastKnownFocusNode = sel.focusNode;
       this.handler('started', this.target);
+    }
+
+    if (this.selecting && (this.lastKnownFocusNode != sel.focusNode || sel.toString())) {
+      this.lastKnownFocusNode = sel.focusNode;
+      this.handler('focusChanged', this.target);
     }
 
     if (this.selecting && (sel.isCollapsed || !sel.toString() || !$(sel.anchorNode).closest(this.selector)[0])) {

--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -152,7 +152,7 @@
     display: none;
 }
 
-.br-selection-menu__root {
+.br-select-menu__root {
   display: none;
   border-radius: 20px;
   background-color: #333;
@@ -161,15 +161,15 @@
   overflow: hidden;
   transition: border-radius 0.2s;
 }
-.br-selection-menu__root:hover {
+.br-select-menu__root:hover {
   border-radius: 8px;
 }
 
-.br-selection-menu__root:hover .textFragmentButton {
+.br-select-menu__root:hover .br-select-menu__option {
   border-radius: 6px;
 }
 
-.textFragmentButton {
+.br-select-menu__option {
   --iconWidth: 15px;
   --iconHeight: 15px;
   --iconFillColor: currentColor;
@@ -185,18 +185,18 @@
   padding: 4px;
 }
 
-.textFragmentButton:hover {
+.br-select-menu__option:hover {
   background-color: rgba(255, 255, 255, 0.1);
 }
 
-.textFragmentButton ia-icon-share {
+.br-select-menu__icon {
   display: block;
   flex-shrink: 0;
   width: 17px;
   height: 17px;
 }
 
-.menuOptionTitle {
+.br-select-menu__label {
   width: 0px;
   opacity: 0;
   interpolate-size: allow-keywords;
@@ -205,7 +205,7 @@
 }
 
 
-.br-selection-menu__root:hover .menuOptionTitle {
+.br-select-menu__root:hover .br-select-menu__label {
   width: auto;
   margin-left: 4px;
   opacity: 1;

--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -151,3 +151,14 @@
 .BRtranslateLayer .BRparagraphElement.BRtranslateHidden {
     display: none;
 }
+
+.textFragmentButton {
+    background: inherit;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-color: darksalmon;
+    width: 60px;
+    height: 30px;
+    top: inherit;
+    left: inherit;
+}

--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -162,3 +162,7 @@
     top: inherit;
     left: inherit;
 }
+
+.textFragmentButtonBar {
+    display: none;
+}

--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -152,17 +152,61 @@
     display: none;
 }
 
-.textFragmentButton {
-    background: inherit;
-    background-position: center;
-    background-repeat: no-repeat;
-    background-color: darksalmon;
-    width: 60px;
-    height: 30px;
-    top: inherit;
-    left: inherit;
+.br-selection-menu__root {
+  display: none;
+  border-radius: 20px;
+  background-color: #333;
+  color-scheme: dark;
+  padding: 2px;
+  overflow: hidden;
+  transition: border-radius 0.2s;
+}
+.br-selection-menu__root:hover {
+  border-radius: 8px;
 }
 
-.textFragmentButtonBar {
-    display: none;
+.br-selection-menu__root:hover .textFragmentButton {
+  border-radius: 6px;
+}
+
+.textFragmentButton {
+  --iconWidth: 15px;
+  --iconHeight: 15px;
+  --iconFillColor: currentColor;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  border-radius: 20px;
+  font-family: inherit;
+  border: 0;
+  transition: background-color 0.2s, border-radius 0.2s;
+  cursor: pointer;
+  text-wrap: nowrap;
+  padding: 4px;
+}
+
+.textFragmentButton:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.textFragmentButton ia-icon-share {
+  display: block;
+  flex-shrink: 0;
+  width: 17px;
+  height: 17px;
+}
+
+.menuOptionTitle {
+  width: 0px;
+  opacity: 0;
+  interpolate-size: allow-keywords;
+  transition: width 0.2s;
+  font-size: 12px;
+}
+
+
+.br-selection-menu__root:hover .menuOptionTitle {
+  width: auto;
+  margin-left: 4px;
+  opacity: 1;
 }

--- a/src/plugins/plugin.experiments.js
+++ b/src/plugins/plugin.experiments.js
@@ -51,20 +51,20 @@ export class ExperimentsPlugin extends BookReaderPlugin {
     localStorageKey: 'BrExperiments',
 
     /** The experiments that should be shown in the experiments panel */
-    enabledExperiments: ['translate', 'copyToSelectionUrl'],
+    enabledExperiments: ['translate', 'copyLinkToHighlight'],
   }
 
   /** @type {ExperimentModel[]} */
   allExperiments = [
     new class extends ExperimentModel {
-      name = 'copyToSelectionUrl';
+      name = 'copyLinkToHighlight';
       title = 'Copy to Selection URL';
       description = 'Share text selection via URL';
       learnMore = 'none';
       icon = null;
       enabled = false;
       async enable ({ manual = false }) {
-        this.br.plugins.textSelection.enableExperiment();
+        this.br.plugins.textSelection.enableSelectionMenu();
       }
       async disable() {
         sleep(0).then(() => {

--- a/src/plugins/plugin.experiments.js
+++ b/src/plugins/plugin.experiments.js
@@ -51,7 +51,7 @@ export class ExperimentsPlugin extends BookReaderPlugin {
     localStorageKey: 'BrExperiments',
 
     /** The experiments that should be shown in the experiments panel */
-    enabledExperiments: ['translate'],
+    enabledExperiments: ['translate', 'hypothesis'],
   }
 
   /** @type {ExperimentModel[]} */

--- a/src/plugins/plugin.experiments.js
+++ b/src/plugins/plugin.experiments.js
@@ -51,17 +51,17 @@ export class ExperimentsPlugin extends BookReaderPlugin {
     localStorageKey: 'BrExperiments',
 
     /** The experiments that should be shown in the experiments panel */
-    enabledExperiments: ['translate', 'highlightUrl'],
+    enabledExperiments: ['translate', 'copyToSelectionUrl'],
   }
 
   /** @type {ExperimentModel[]} */
   allExperiments = [
     new class extends ExperimentModel {
-      name = 'highlightUrl';
-      title = 'URL Link to Highlight';
-      description = 'Share highlighted content via URL';
+      name = 'copyToSelectionUrl';
+      title = 'Copy to Selection URL';
+      description = 'Share text selection via URL';
       learnMore = 'none';
-      icon = 'images/translate.svg';
+      icon = null;
       enabled = false;
       async enable ({ manual = false }) {
         this.br.plugins.textSelection.enableExperiment();

--- a/src/plugins/plugin.experiments.js
+++ b/src/plugins/plugin.experiments.js
@@ -51,11 +51,27 @@ export class ExperimentsPlugin extends BookReaderPlugin {
     localStorageKey: 'BrExperiments',
 
     /** The experiments that should be shown in the experiments panel */
-    enabledExperiments: ['translate'],
+    enabledExperiments: ['translate', 'highlightUrl'],
   }
 
   /** @type {ExperimentModel[]} */
   allExperiments = [
+    new class extends ExperimentModel {
+      name = 'highlightUrl';
+      title = 'URL Link to Highlight';
+      description = 'Share highlighted content via URL';
+      learnMore = 'none';
+      icon = 'images/translate.svg';
+      enabled = false;
+      async enable ({ manual = false }) {
+        this.br.plugins.textSelection.enableExperiment();
+      }
+      async disable() {
+        sleep(0).then(() => {
+          window.location.reload();
+        });
+      }
+    }(),
     new class extends ExperimentModel {
       name = 'translate';
       title = 'Translate Plugin';

--- a/src/plugins/plugin.experiments.js
+++ b/src/plugins/plugin.experiments.js
@@ -51,7 +51,7 @@ export class ExperimentsPlugin extends BookReaderPlugin {
     localStorageKey: 'BrExperiments',
 
     /** The experiments that should be shown in the experiments panel */
-    enabledExperiments: ['translate', 'hypothesis'],
+    enabledExperiments: ['translate'],
   }
 
   /** @type {ExperimentModel[]} */

--- a/src/plugins/plugin.experiments.js
+++ b/src/plugins/plugin.experiments.js
@@ -139,7 +139,9 @@ export class ExperimentsPlugin extends BookReaderPlugin {
     for (const experiment of this.allExperiments) {
       // TODO: imagesBaseURL should be replaced with assetRoot everywhere
       experiment.assetRoot = this.br.options.imagesBaseURL.replace(/images\/$/, '');
-      experiment.icon = experiment.buildAssetPath(experiment.icon);
+      if (experiment.icon) {
+        experiment.icon = experiment.buildAssetPath(experiment.icon);
+      }
       experiment.br = this.br;
     }
 
@@ -285,7 +287,7 @@ export class BrExperimentToggle extends LitElement {
     return html`
       <div class="experiment-card" style="margin-bottom: 10px;">
         <div style="display: flex; align-items: center; gap: 10px;">
-          <img src="${this.icon}" style="width: 20px; height: 20px;" alt="" />
+          ${this.icon ? html`<img src="${this.icon}" style="width: 20px; height: 20px;" alt="" />` : ''}
           <div style="flex-grow: 1; font-weight: bold;">${this.title}</div>
         </div>
         <p style="opacity: 0.9">

--- a/src/plugins/plugin.text_selection.js
+++ b/src/plugins/plugin.text_selection.js
@@ -63,7 +63,7 @@ export class TextSelectionPlugin extends BookReaderPlugin {
     this.textSelectionManager.init();
   }
 
-  enableExperiment() {
+  enableSelectionMenu() {
     this.textSelectionManager.selectionMenuEnabled = true;
     this.textSelectionManager.renderSelectionMenu();
   }

--- a/src/plugins/plugin.text_selection.js
+++ b/src/plugins/plugin.text_selection.js
@@ -53,6 +53,12 @@ export class TextSelectionPlugin extends BookReaderPlugin {
   init() {
     if (!this.options.enabled) return;
 
+    this.br.on('pageVisible', (_, {pageContainerEl}) => {
+      if (pageContainerEl.querySelector('.BRtextLayer')) {
+        this.br.trigger('textLayerVisible', {pageContainerEl});
+      }
+    });
+
     this.loadData();
     this.textSelectionManager.init();
   }
@@ -202,6 +208,11 @@ export class TextSelectionPlugin extends BookReaderPlugin {
       pageIndex,
       pageContainer,
     });
+
+    // Check if page is visible
+    if ($container.hasClass('BRpage-visible')) {
+      this.br.trigger('textLayerVisible', {pageContainerEl: $container[0]});
+    }
   }
 
   /**

--- a/src/plugins/plugin.text_selection.js
+++ b/src/plugins/plugin.text_selection.js
@@ -64,9 +64,8 @@ export class TextSelectionPlugin extends BookReaderPlugin {
   }
 
   enableExperiment() {
-    if (!this.textSelectionManager) return;
-    this.textSelectionManager.highlightEnabled = true;
-    this.textSelectionManager.addHighlightBar();
+    this.textSelectionManager.selectionMenuEnabled = true;
+    this.textSelectionManager.renderSelectionMenu();
   }
 
   /**

--- a/src/plugins/plugin.text_selection.js
+++ b/src/plugins/plugin.text_selection.js
@@ -188,6 +188,7 @@ export class TextSelectionPlugin extends BookReaderPlugin {
       paragEl.style.marginTop = `${newTop}px`;
       yAdded += newTop;
       textLayer.appendChild(paragEl);
+      textLayer.appendChild(document.createTextNode('\n'));
     }
     $container.append(textLayer);
     this.textSelectionManager.stopPageFlip($container);

--- a/src/plugins/plugin.text_selection.js
+++ b/src/plugins/plugin.text_selection.js
@@ -57,6 +57,12 @@ export class TextSelectionPlugin extends BookReaderPlugin {
     this.textSelectionManager.init();
   }
 
+  enableExperiment() {
+    if (!this.textSelectionManager) return;
+    this.textSelectionManager.highlightEnabled = true;
+    this.textSelectionManager.addHighlightBar();
+  }
+
   /**
    * @override
    * @param {PageContainer} pageContainer

--- a/src/plugins/url/UrlPlugin.js
+++ b/src/plugins/url/UrlPlugin.js
@@ -157,18 +157,6 @@ export class UrlPlugin {
   }
 
   /**
-   * Get the hash out of the current URL. Also augments it with the text
-   * from the main part of the URL, since that is not readable by JS
-   * from the actual hash
-   * @returns
-   */
-  getHash = () => {
-    const text = this.retrieveTextFragment(window.location.search);
-    const textFragment = text ? `:~:text=${text[0]}` : '';
-    return `${window.location.hash.slice(1)}${textFragment}`;
-  }
-
-  /**
    * Get the url and check if it has changed
    * If it was changeed, update the urlState
    */
@@ -199,6 +187,18 @@ export class UrlPlugin {
       ? (location.pathname.substr(this.urlHistoryBasePath.length) + location.search)
       : location.hash.substr(1);
     this.urlState = this.urlStringToUrlState(path);
+  }
+
+  /**
+   * Get the hash out of the current URL. Also augments it with the text
+   * from the main part of the URL, since that is not readable by JS
+   * from the actual hash
+   * @returns
+   */
+  getHash() {
+    const text = this.retrieveTextFragment(window.location.search);
+    const textFragment = text ? `:~:text=${text[0]}` : '';
+    return `${window.location.hash.slice(1)}${textFragment}`;
   }
 
   /**

--- a/src/plugins/url/UrlPlugin.js
+++ b/src/plugins/url/UrlPlugin.js
@@ -156,12 +156,20 @@ export class UrlPlugin {
     this.oldLocationHash = urlStrPath;
   }
 
+    getHash = () => {
+      const text = window.location.search.match(/(?<=[&?]text=)[^&]*/);
+      if (text) {
+        return `${window.location.hash.slice(1)}:~:text=${text[0]}`;
+      }
+      return window.location.hash.slice(1);
+    }
+
   /**
    * Get the url and check if it has changed
    * If it was changeed, update the urlState
    */
   listenForHashChanges() {
-    this.oldLocationHash = window.location.hash.substr(1);
+    this.oldLocationHash = this.getHash();
     if (this.urlLocationPollId) {
       clearInterval(this.urlLocationPollId);
       this.urlLocationPollId = null;
@@ -169,7 +177,7 @@ export class UrlPlugin {
 
     // check if the URL changes
     const updateHash = () => {
-      const newFragment = window.location.hash.substr(1);
+      const newFragment = this.getHash();
       const hasFragmentChange = newFragment != this.oldLocationHash;
 
       if (!hasFragmentChange) { return; }

--- a/src/plugins/url/UrlPlugin.js
+++ b/src/plugins/url/UrlPlugin.js
@@ -155,45 +155,52 @@ export class UrlPlugin {
     }
     this.oldLocationHash = urlStrPath;
   }
-
+  /**
+   * Get the hash out of the current URL. Also augments it with the text
+   * from the main part of the URL, since that is not readable by JS
+   * from the actual hash
+   * @returns
+   */
     getHash = () => {
-      const text = window.location.search.match(/(?<=[&?]text=)[^&]*/);
-      if (text) {
-        return `${window.location.hash.slice(1)}:~:text=${text[0]}`;
-      }
-      return window.location.hash.slice(1);
+      const text = this.retrieveTextFragment(window.location.search);
+      const textFragment = text ? `:~:text=${text[0]}` : '';
+      return `${window.location.hash.slice(1)}${textFragment}`;
     }
 
-  /**
+    /**
    * Get the url and check if it has changed
    * If it was changeed, update the urlState
    */
-  listenForHashChanges() {
-    this.oldLocationHash = this.getHash();
-    if (this.urlLocationPollId) {
-      clearInterval(this.urlLocationPollId);
-      this.urlLocationPollId = null;
+    listenForHashChanges() {
+      this.oldLocationHash = this.getHash();
+      if (this.urlLocationPollId) {
+        clearInterval(this.urlLocationPollId);
+        this.urlLocationPollId = null;
+      }
+
+      // check if the URL changes
+      const updateHash = () => {
+        const newFragment = this.getHash();
+        const hasFragmentChange = newFragment != this.oldLocationHash;
+
+        if (!hasFragmentChange) { return; }
+
+        this.urlState = this.urlStringToUrlState(newFragment);
+      };
+      this.urlLocationPollId = setInterval(updateHash, 500);
     }
 
-    // check if the URL changes
-    const updateHash = () => {
-      const newFragment = this.getHash();
-      const hasFragmentChange = newFragment != this.oldLocationHash;
-
-      if (!hasFragmentChange) { return; }
-
-      this.urlState = this.urlStringToUrlState(newFragment);
-    };
-    this.urlLocationPollId = setInterval(updateHash, 500);
-  }
-
-  /**
+    /**
    * Will read either the hash or URL and return the bookreader fragment
    */
-  pullFromAddressBar (location = window.location) {
-    const path = this.urlMode === 'history'
-      ? (location.pathname.substr(this.urlHistoryBasePath.length) + location.search)
-      : location.hash.substr(1);
-    this.urlState = this.urlStringToUrlState(path);
-  }
+    pullFromAddressBar (location = window.location) {
+      const path = this.urlMode === 'history'
+        ? (location.pathname.substr(this.urlHistoryBasePath.length) + location.search)
+        : location.hash.substr(1);
+      this.urlState = this.urlStringToUrlState(path);
+    }
+
+    retrieveTextFragment (urlString) {
+      return urlString.match(/(?<=&text=)[^&]*/);
+    }
 }

--- a/src/plugins/url/UrlPlugin.js
+++ b/src/plugins/url/UrlPlugin.js
@@ -164,36 +164,36 @@ export class UrlPlugin {
       return window.location.hash.slice(1);
     }
 
-    /**
+  /**
    * Get the url and check if it has changed
    * If it was changeed, update the urlState
    */
-    listenForHashChanges() {
-      this.oldLocationHash = this.getHash();
-      if (this.urlLocationPollId) {
-        clearInterval(this.urlLocationPollId);
-        this.urlLocationPollId = null;
-      }
-
-      // check if the URL changes
-      const updateHash = () => {
-        const newFragment = this.getHash();
-        const hasFragmentChange = newFragment != this.oldLocationHash;
-
-        if (!hasFragmentChange) { return; }
-
-        this.urlState = this.urlStringToUrlState(newFragment);
-      };
-      this.urlLocationPollId = setInterval(updateHash, 500);
+  listenForHashChanges() {
+    this.oldLocationHash = this.getHash();
+    if (this.urlLocationPollId) {
+      clearInterval(this.urlLocationPollId);
+      this.urlLocationPollId = null;
     }
 
-    /**
+    // check if the URL changes
+    const updateHash = () => {
+      const newFragment = this.getHash();
+      const hasFragmentChange = newFragment != this.oldLocationHash;
+
+      if (!hasFragmentChange) { return; }
+
+      this.urlState = this.urlStringToUrlState(newFragment);
+    };
+    this.urlLocationPollId = setInterval(updateHash, 500);
+  }
+
+  /**
    * Will read either the hash or URL and return the bookreader fragment
    */
-    pullFromAddressBar (location = window.location) {
-      const path = this.urlMode === 'history'
-        ? (location.pathname.substr(this.urlHistoryBasePath.length) + location.search)
-        : location.hash.substr(1);
-      this.urlState = this.urlStringToUrlState(path);
-    }
+  pullFromAddressBar (location = window.location) {
+    const path = this.urlMode === 'history'
+      ? (location.pathname.substr(this.urlHistoryBasePath.length) + location.search)
+      : location.hash.substr(1);
+    this.urlState = this.urlStringToUrlState(path);
+  }
 }

--- a/src/plugins/url/UrlPlugin.js
+++ b/src/plugins/url/UrlPlugin.js
@@ -155,52 +155,57 @@ export class UrlPlugin {
     }
     this.oldLocationHash = urlStrPath;
   }
+
   /**
    * Get the hash out of the current URL. Also augments it with the text
    * from the main part of the URL, since that is not readable by JS
    * from the actual hash
    * @returns
    */
-    getHash = () => {
-      const text = this.retrieveTextFragment(window.location.search);
-      const textFragment = text ? `:~:text=${text[0]}` : '';
-      return `${window.location.hash.slice(1)}${textFragment}`;
-    }
+  getHash = () => {
+    const text = this.retrieveTextFragment(window.location.search);
+    const textFragment = text ? `:~:text=${text[0]}` : '';
+    return `${window.location.hash.slice(1)}${textFragment}`;
+  }
 
-    /**
+  /**
    * Get the url and check if it has changed
    * If it was changeed, update the urlState
    */
-    listenForHashChanges() {
-      this.oldLocationHash = this.getHash();
-      if (this.urlLocationPollId) {
-        clearInterval(this.urlLocationPollId);
-        this.urlLocationPollId = null;
-      }
-
-      // check if the URL changes
-      const updateHash = () => {
-        const newFragment = this.getHash();
-        const hasFragmentChange = newFragment != this.oldLocationHash;
-
-        if (!hasFragmentChange) { return; }
-
-        this.urlState = this.urlStringToUrlState(newFragment);
-      };
-      this.urlLocationPollId = setInterval(updateHash, 500);
+  listenForHashChanges() {
+    this.oldLocationHash = this.getHash();
+    if (this.urlLocationPollId) {
+      clearInterval(this.urlLocationPollId);
+      this.urlLocationPollId = null;
     }
 
-    /**
+    // check if the URL changes
+    const updateHash = () => {
+      const newFragment = this.getHash();
+      const hasFragmentChange = newFragment != this.oldLocationHash;
+
+      if (!hasFragmentChange) { return; }
+
+      this.urlState = this.urlStringToUrlState(newFragment);
+    };
+    this.urlLocationPollId = setInterval(updateHash, 500);
+  }
+
+  /**
    * Will read either the hash or URL and return the bookreader fragment
    */
-    pullFromAddressBar (location = window.location) {
-      const path = this.urlMode === 'history'
-        ? (location.pathname.substr(this.urlHistoryBasePath.length) + location.search)
-        : location.hash.substr(1);
-      this.urlState = this.urlStringToUrlState(path);
-    }
+  pullFromAddressBar(location = window.location) {
+    const path = this.urlMode === 'history'
+      ? (location.pathname.substr(this.urlHistoryBasePath.length) + location.search)
+      : location.hash.substr(1);
+    this.urlState = this.urlStringToUrlState(path);
+  }
 
-    retrieveTextFragment (urlString) {
-      return urlString.match(/(?<=&?text=)[^&]*/);
-    }
+  /**
+   * @param {string} urlString
+   * @returns {string}
+   */
+  retrieveTextFragment(urlString) {
+    return urlString.match(/(?<=[&?]?text=)[^&]*/);
+  }
 }

--- a/src/plugins/url/UrlPlugin.js
+++ b/src/plugins/url/UrlPlugin.js
@@ -201,6 +201,6 @@ export class UrlPlugin {
     }
 
     retrieveTextFragment (urlString) {
-      return urlString.match(/(?<=&text=)[^&]*/);
+      return urlString.match(/(?<=&?text=)[^&]*/);
     }
 }

--- a/src/plugins/url/UrlPlugin.js
+++ b/src/plugins/url/UrlPlugin.js
@@ -164,36 +164,36 @@ export class UrlPlugin {
       return window.location.hash.slice(1);
     }
 
-  /**
+    /**
    * Get the url and check if it has changed
    * If it was changeed, update the urlState
    */
-  listenForHashChanges() {
-    this.oldLocationHash = this.getHash();
-    if (this.urlLocationPollId) {
-      clearInterval(this.urlLocationPollId);
-      this.urlLocationPollId = null;
+    listenForHashChanges() {
+      this.oldLocationHash = this.getHash();
+      if (this.urlLocationPollId) {
+        clearInterval(this.urlLocationPollId);
+        this.urlLocationPollId = null;
+      }
+
+      // check if the URL changes
+      const updateHash = () => {
+        const newFragment = this.getHash();
+        const hasFragmentChange = newFragment != this.oldLocationHash;
+
+        if (!hasFragmentChange) { return; }
+
+        this.urlState = this.urlStringToUrlState(newFragment);
+      };
+      this.urlLocationPollId = setInterval(updateHash, 500);
     }
 
-    // check if the URL changes
-    const updateHash = () => {
-      const newFragment = this.getHash();
-      const hasFragmentChange = newFragment != this.oldLocationHash;
-
-      if (!hasFragmentChange) { return; }
-
-      this.urlState = this.urlStringToUrlState(newFragment);
-    };
-    this.urlLocationPollId = setInterval(updateHash, 500);
-  }
-
-  /**
+    /**
    * Will read either the hash or URL and return the bookreader fragment
    */
-  pullFromAddressBar (location = window.location) {
-    const path = this.urlMode === 'history'
-      ? (location.pathname.substr(this.urlHistoryBasePath.length) + location.search)
-      : location.hash.substr(1);
-    this.urlState = this.urlStringToUrlState(path);
-  }
+    pullFromAddressBar (location = window.location) {
+      const path = this.urlMode === 'history'
+        ? (location.pathname.substr(this.urlHistoryBasePath.length) + location.search)
+        : location.hash.substr(1);
+      this.urlState = this.urlStringToUrlState(path);
+    }
 }

--- a/src/plugins/url/plugin.url.js
+++ b/src/plugins/url/plugin.url.js
@@ -155,7 +155,7 @@ BookReader.prototype.urlUpdateFragment = function() {
     } else {
       const baseWithoutSlash = this.options.urlHistoryBasePath.replace(/\/+$/, '');
       const newFragmentWithSlash = newFragment === '' ? '' : `/${newFragment}`;
-      let textFragment = ""
+      let textFragment = "";
       if (this.urlPlugin.retrieveTextFragment(newQueryString)) {
         textFragment = this.urlParamsFiltersOnlySearch(this.readQueryString());
         // newQueryString = newQueryString.replace(this.urlPlugin.retrieveTextFragment(newQueryString)[0], "").replace(/(\?text=)/, "")
@@ -165,11 +165,11 @@ BookReader.prototype.urlUpdateFragment = function() {
       console.log("this is newURLPath", newUrlPath);
       try {
         window.history.replaceState({}, null, newUrlPath);
-        this.oldLocationHash = newFragment + newQueryString;
-        if (textFragment) {
-          window.location.replace('#' + textFragment);
-          this.oldLocationHash = textFragment;
-        }
+        this.oldLocationHash = newFragment + newQueryString + textFragment;
+        // if (textFragment) {
+        //   window.location.replace('#' + textFragment);
+        //   this.oldLocationHash = textFragment;
+        // }
       } catch (e) {
         // DOMException on Chrome when in sandboxed iframe
         this.options.urlMode = 'hash';
@@ -210,7 +210,6 @@ BookReader.prototype.urlParamsFiltersOnlySearch = function(url) {
 BookReader.prototype.urlReadFragment = function() {
   const { urlMode, urlHistoryBasePath } = this.options;
   if (urlMode === 'history') {
-    console.log("within plugin.url", window.location);
     return window.location.pathname.substr(urlHistoryBasePath.length);
   } else {
     return this.urlPlugin.getHash();
@@ -231,7 +230,9 @@ export class BookreaderUrlPlugin extends BookReader {
       const location = this.getLocationSearch();
       if (location.includes("text=")) {
         this.on('textLayerRendered', (_, {pageIndex, container}) => {
-          console.log("line 235 plugin.url.js window.location.replace", `#${this.oldLocationHash}`);
+          window.location.replace(`#${this.oldLocationHash}`);
+        });
+        this.on('pageVisible', (_) => {
           window.location.replace(`#${this.oldLocationHash}`);
         });
       }

--- a/src/plugins/url/plugin.url.js
+++ b/src/plugins/url/plugin.url.js
@@ -255,7 +255,12 @@ export class BookreaderUrlPlugin extends BookReader {
       if (location.includes("text=")) {
         this.on('textLayerVisible', async (_, {pageContainerEl}) => {
           const visiblePageNum = pageContainerEl.getAttribute('data-page-num');
-          await new Promise(resolve => setTimeout(resolve, 100));
+          let renderPageDelay = 100;
+          if (this.mode === 1) {
+            // maybe add some more time to have the page "settle down" from user scrolling
+            renderPageDelay = 900;
+          }
+          await new Promise(resolve => setTimeout(resolve, renderPageDelay));
           // No textFragment found or the textFragment stored doesn't match current visible page loaded
           if (!this.textFragment || this.textFragmentPage !== visiblePageNum) return;
           if (this.options.urlMode === 'history') {

--- a/src/plugins/url/plugin.url.js
+++ b/src/plugins/url/plugin.url.js
@@ -144,7 +144,8 @@ BookReader.prototype.urlUpdateFragment = function() {
   const currFragment = this.urlReadFragment();
   const currQueryString = this.getLocationSearch();
   const newQueryString = this.queryStringFromParams(params, currQueryString, this.options.urlMode);
-  if (currFragment === newFragment && currQueryString === newQueryString) {
+  const hasTextParam = currQueryString.includes("text");
+  if (currFragment === newFragment && currQueryString === newQueryString && !hasTextParam) {
     return;
   }
 
@@ -154,11 +155,21 @@ BookReader.prototype.urlUpdateFragment = function() {
     } else {
       const baseWithoutSlash = this.options.urlHistoryBasePath.replace(/\/+$/, '');
       const newFragmentWithSlash = newFragment === '' ? '' : `/${newFragment}`;
-
+      let textFragment = ""
+      if (this.urlPlugin.retrieveTextFragment(newQueryString)) {
+        textFragment = this.urlParamsFiltersOnlySearch(this.readQueryString());
+        // newQueryString = newQueryString.replace(this.urlPlugin.retrieveTextFragment(newQueryString)[0], "").replace(/(\?text=)/, "")
+      }
+      console.log("this is newQueryString", newQueryString);
       const newUrlPath = `${baseWithoutSlash}${newFragmentWithSlash}${newQueryString}`;
+      console.log("this is newURLPath", newUrlPath);
       try {
         window.history.replaceState({}, null, newUrlPath);
         this.oldLocationHash = newFragment + newQueryString;
+        if (textFragment) {
+          window.location.replace('#' + textFragment);
+          this.oldLocationHash = textFragment;
+        }
       } catch (e) {
         // DOMException on Chrome when in sandboxed iframe
         this.options.urlMode = 'hash';
@@ -199,6 +210,7 @@ BookReader.prototype.urlParamsFiltersOnlySearch = function(url) {
 BookReader.prototype.urlReadFragment = function() {
   const { urlMode, urlHistoryBasePath } = this.options;
   if (urlMode === 'history') {
+    console.log("within plugin.url", window.location);
     return window.location.pathname.substr(urlHistoryBasePath.length);
   } else {
     return this.urlPlugin.getHash();
@@ -219,6 +231,7 @@ export class BookreaderUrlPlugin extends BookReader {
       const location = this.getLocationSearch();
       if (location.includes("text=")) {
         this.on('textLayerRendered', (_, {pageIndex, container}) => {
+          console.log("line 235 plugin.url.js window.location.replace", `#${this.oldLocationHash}`);
           window.location.replace(`#${this.oldLocationHash}`);
         });
       }

--- a/src/plugins/url/plugin.url.js
+++ b/src/plugins/url/plugin.url.js
@@ -88,7 +88,6 @@ BookReader.prototype.shortTitle = function(maximumCharacters) {
  */
 BookReader.prototype.urlStartLocationPolling = function() {
   this.oldLocationHash = this.urlReadFragment();
-  console.log("BookReader.urlStartLocationPolling this.oldLocationHash", this.oldLocationHash);
 
   if (this.locationPollId) {
     clearInterval(this.locationPollId);
@@ -161,7 +160,6 @@ BookReader.prototype.urlUpdateFragment = function() {
       try {
         window.history.replaceState({}, null, newUrlPath);
         this.oldLocationHash = newFragment + newQueryString;
-        console.log("changed oldLocationHash in BookReader.setup", this.oldLocationHash);
       } catch (e) {
         // DOMException on Chrome when in sandboxed iframe
         this.options.urlMode = 'hash';
@@ -170,17 +168,9 @@ BookReader.prototype.urlUpdateFragment = function() {
   }
 
   if (this.options.urlMode === 'hash')  {
-    let newQueryStringSearch = this.urlParamsFiltersOnlySearch(this.readQueryString());
-    // console.log("checking the newQueryStringSearch", newQueryStringSearch, typeof newQueryStringSearch);
-    // if (newQueryStringSearch.indexOf(":~:") != -1) {
-    //   // if (newQueryStringSearch.includes("-,") || newQueryStringSearch.includes(",-")){
-    //   //   console.log("actively replacing commas w/ URI encoded components");
-    //   //   newQueryStringSearch = newQueryStringSearch.replaceAll(/(?<!-),(?!-)/g, "%2C");
-    //   // }
-    // }
+    const newQueryStringSearch = this.urlParamsFiltersOnlySearch(this.readQueryString());
     window.location.replace('#' + newFragment + newQueryStringSearch);
     this.oldLocationHash = newFragment + newQueryStringSearch;
-    console.log("changed oldLocationHash here", this.oldLocationHash);
   }
 };
 
@@ -194,13 +184,11 @@ BookReader.prototype.urlUpdateFragment = function() {
 
 // testing with this URL http://127.0.0.1:8000/BookReaderDemo/demo-internetarchive.html?ocaid=adventureofsherl0000unse&text=Well%2C I found my plans very seriously menaced.&q=breaking the law#page/18/mode/2up
 BookReader.prototype.urlParamsFiltersOnlySearch = function(url) {
-  console.log("this is input, plugin.url.js", url)
-  const text = url.match(/(?<=[&?]text=)[^&]*/);
+  const text = url.match(/(?<=&text=)[^&]*/);
   const params = new URLSearchParams(url);
   let output = '';
-  output += params.has('q') ? `?${new URLSearchParams({ q: params.get('q') })}&` : ''
+  output += params.has('q') ? `?${new URLSearchParams({ q: params.get('q') })}` : '';
   output += text ? `:~:text=${text[0]}` : '';
-  console.log("this is output, plugin.url.js", output)
   return output;
 };
 
@@ -235,15 +223,8 @@ export class BookreaderUrlPlugin extends BookReader {
         const textFragment = `${extractText}`;
         this.options.shareHighlight = textFragment;
         this.on('textLayerRendered', (_, {pageIndex, container}) => {
-          console.log("this.oldLocationHash", this.oldLocationHash);
-          // if (this.oldLocationHash.indexOf(":~:") != -1) {
-          //   if (this.oldLocationHash.includes("-,") || this.oldLocationHash.includes(",-")) {
-          //     // console.log("Replacing commas w/ URI encoded components");
-          //     this.oldLocationHash = this.oldLocationHash.replaceAll(/(?<!-),(?!-)/g, "%2C");
-          //   }
-          // }
-          window.location.replace(`#${this.oldLocationHash}`)
-        })
+          window.location.replace(`#${this.oldLocationHash}`);
+        });
       }
       this.bind(BookReader.eventNames.PostInit, () => {
         const { urlMode } = this.options;

--- a/src/plugins/url/plugin.url.js
+++ b/src/plugins/url/plugin.url.js
@@ -140,11 +140,21 @@ BookReader.prototype.urlUpdateFragment = function() {
     return validParams;
   }, {});
 
+  // eg 'page/3/mode/2up'; no query params (in hash mode, it might have /search/term)
+  // Does NOT have the :~:text fragment
   const newFragment = this.fragmentFromParams(params, this.options.urlMode);
+  // eg 'page/3/mode/2up'; no query params
+  // WILL CONTAIN the :~:text fragment in hash mode (!)
   const currFragment = this.urlReadFragment();
+  // This should have both ?q=foo&text=bar (and any other params) as an encoded string
   const currQueryString = this.getLocationSearch();
+  // Eg ?q=foo&text=bar; only query params, no fragment
   const newQueryString = this.queryStringFromParams(params, currQueryString, this.options.urlMode);
-  const hasTextParam = currQueryString.includes("text");
+
+  // NOTE: If ?text is in the URL, we will fire fragment change events on every render; which is
+  // not desireable, but currently don't have a way to handle re-writing ?text to the hash text
+  // fragment form, :~:text=foo.
+  const hasTextParam = this.urlPlugin.retrieveTextFragment(currQueryString);
   if (currFragment === newFragment && currQueryString === newQueryString && !hasTextParam) {
     return;
   }
@@ -155,21 +165,14 @@ BookReader.prototype.urlUpdateFragment = function() {
     } else {
       const baseWithoutSlash = this.options.urlHistoryBasePath.replace(/\/+$/, '');
       const newFragmentWithSlash = newFragment === '' ? '' : `/${newFragment}`;
-      let textFragment = "";
-      if (this.urlPlugin.retrieveTextFragment(newQueryString)) {
-        textFragment = this.urlParamsFiltersOnlySearch(this.readQueryString());
-        // newQueryString = newQueryString.replace(this.urlPlugin.retrieveTextFragment(newQueryString)[0], "").replace(/(\?text=)/, "")
-      }
-      console.log("this is newQueryString", newQueryString);
+      const textFragment = this.urlPlugin.retrieveTextFragment(newQueryString);
       const newUrlPath = `${baseWithoutSlash}${newFragmentWithSlash}${newQueryString}`;
-      console.log("this is newURLPath", newUrlPath);
       try {
         window.history.replaceState({}, null, newUrlPath);
-        this.oldLocationHash = newFragment + newQueryString + textFragment;
-        // if (textFragment) {
-        //   window.location.replace('#' + textFragment);
-        //   this.oldLocationHash = textFragment;
-        // }
+        this.oldLocationHash = newFragment + newQueryString;
+        if (textFragment) {
+          this.oldLocationHash += `:~:text=${textFragment[0]}`;
+        }
       } catch (e) {
         // DOMException on Chrome when in sandboxed iframe
         this.options.urlMode = 'hash';
@@ -179,8 +182,12 @@ BookReader.prototype.urlUpdateFragment = function() {
 
   if (this.options.urlMode === 'hash')  {
     const newQueryStringSearch = this.urlParamsFiltersOnlySearch(this.readQueryString());
-    window.location.replace('#' + newFragment + newQueryStringSearch);
-    this.oldLocationHash = newFragment + newQueryStringSearch;
+    let textFragment = this.urlPlugin.retrieveTextFragment(this.readQueryString());
+    if (textFragment) {
+      textFragment = `:~:text=${textFragment[0]}`;
+    }
+    window.location.replace('#' + newFragment + newQueryStringSearch + textFragment);
+    this.oldLocationHash = newFragment + newQueryStringSearch + textFragment;
   }
 };
 
@@ -194,11 +201,9 @@ BookReader.prototype.urlUpdateFragment = function() {
 
 // testing with this URL http://127.0.0.1:8000/BookReaderDemo/demo-internetarchive.html?ocaid=adventureofsherl0000unse&text=Well%2C I found my plans very seriously menaced.&q=breaking the law#page/18/mode/2up
 BookReader.prototype.urlParamsFiltersOnlySearch = function(url) {
-  const text = this.urlPlugin.retrieveTextFragment(url);
   const params = new URLSearchParams(url);
   let output = '';
   output += params.has('q') ? `?${new URLSearchParams({ q: params.get('q') })}` : '';
-  output += text ? `:~:text=${text[0]}` : '';
   return output;
 };
 
@@ -230,10 +235,15 @@ export class BookreaderUrlPlugin extends BookReader {
       const location = this.getLocationSearch();
       if (location.includes("text=")) {
         this.on('textLayerRendered', (_, {pageIndex, container}) => {
-          window.location.replace(`#${this.oldLocationHash}`);
-        });
-        this.on('pageVisible', (_) => {
-          window.location.replace(`#${this.oldLocationHash}`);
+          if (this.options.urlMode === 'history') {
+            // only want the text fragment forwarded
+            if (this.oldLocationHash.includes(':~:')) {
+              const newHash = this.oldLocationHash.split(':~:')[1];
+              window.location.replace(`#:~:${newHash}`);
+            }
+          } else {
+            window.location.replace(`#${this.oldLocationHash}`);
+          }
         });
       }
       this.bind(BookReader.eventNames.PostInit, () => {

--- a/src/plugins/url/plugin.url.js
+++ b/src/plugins/url/plugin.url.js
@@ -29,7 +29,6 @@ jQuery.extend(BookReader.defaultOptions, {
 
   /** If true, don't update the URL when `page == n0 (eg "/page/n0")` */
   urlTrackIndex0: false,
-  shareHighlight: null,
 });
 
 /** @override */
@@ -184,7 +183,7 @@ BookReader.prototype.urlUpdateFragment = function() {
 
 // testing with this URL http://127.0.0.1:8000/BookReaderDemo/demo-internetarchive.html?ocaid=adventureofsherl0000unse&text=Well%2C I found my plans very seriously menaced.&q=breaking the law#page/18/mode/2up
 BookReader.prototype.urlParamsFiltersOnlySearch = function(url) {
-  const text = url.match(/(?<=&text=)[^&]*/);
+  const text = this.urlPlugin.retrieveTextFragment(url);
   const params = new URLSearchParams(url);
   let output = '';
   output += params.has('q') ? `?${new URLSearchParams({ q: params.get('q') })}` : '';
@@ -219,9 +218,6 @@ export class BookreaderUrlPlugin extends BookReader {
       this.urlPlugin = new UrlPlugin(this.options);
       const location = this.getLocationSearch();
       if (location.includes("text=")) {
-        const extractText = location.match(/(text=[\w\d\W]*)/);
-        const textFragment = `${extractText}`;
-        this.options.shareHighlight = textFragment;
         this.on('textLayerRendered', (_, {pageIndex, container}) => {
           window.location.replace(`#${this.oldLocationHash}`);
         });

--- a/src/plugins/url/plugin.url.js
+++ b/src/plugins/url/plugin.url.js
@@ -147,6 +147,7 @@ BookReader.prototype.urlUpdateFragment = function() {
   // eg 'page/3/mode/2up'; no query params (in hash mode, it might have /search/term)
   // Does NOT have the :~:text fragment
   const newFragment = this.fragmentFromParams(params, this.options.urlMode);
+  const newFragmentWithSlash = newFragment === '' ? '' : `/${newFragment}`;
   // eg 'page/3/mode/2up'; no query params
   // WILL CONTAIN the :~:text fragment in hash mode (!)
   const currFragment = this.urlReadFragment();
@@ -168,7 +169,6 @@ BookReader.prototype.urlUpdateFragment = function() {
       this.options.urlMode = 'hash';
     } else {
       const baseWithoutSlash = this.options.urlHistoryBasePath.replace(/\/+$/, '');
-      const newFragmentWithSlash = newFragment === '' ? '' : `/${newFragment}`;
       const textFragment = this.urlPlugin.retrieveTextFragment(newQueryString);
       const newUrlPath = `${baseWithoutSlash}${newFragmentWithSlash}${newQueryString}`;
       const extractedPage = this.urlPlugin.urlStringToUrlState(newFragmentWithSlash)?.page;
@@ -192,10 +192,8 @@ BookReader.prototype.urlUpdateFragment = function() {
   if (this.options.urlMode === 'hash')  {
     const newQueryStringSearch = this.urlParamsFiltersOnlySearch(this.readQueryString());
     let textFragment = this.urlPlugin.retrieveTextFragment(this.readQueryString());
-    let extractedPage = newFragment.match(/(?<=\/)n?\d+(?=\/)/);
-    if (extractedPage) {
-      extractedPage = extractedPage[0];
-    }
+    const extractedPage = this.urlPlugin.urlStringToUrlState(newFragmentWithSlash)?.page;
+
     if (textFragment) {
       textFragment = `:~:text=${textFragment[0]}`;
     } else {

--- a/src/plugins/url/plugin.url.js
+++ b/src/plugins/url/plugin.url.js
@@ -42,6 +42,10 @@ BookReader.prototype.setup = (function(super_) {
     this.locationPollId = null;
     this.oldLocationHash = null;
     this.oldUserHash = null;
+    // Should include the :~:text= prefix
+    this.textFragment = null;
+    // Tracks the original textFragment page num when first loaded
+    this.textFragmentPage = null;
   };
 })(BookReader.prototype.setup);
 
@@ -167,6 +171,14 @@ BookReader.prototype.urlUpdateFragment = function() {
       const newFragmentWithSlash = newFragment === '' ? '' : `/${newFragment}`;
       const textFragment = this.urlPlugin.retrieveTextFragment(newQueryString);
       const newUrlPath = `${baseWithoutSlash}${newFragmentWithSlash}${newQueryString}`;
+      let extractedPage = newFragmentWithSlash.match(/(?<=\/)n?\d+(?=\/)/);
+      if (extractedPage) {
+        extractedPage = extractedPage[0];
+      }
+      if (!this.textFragmentPage && textFragment) {
+        this.textFragmentPage =  extractedPage ? extractedPage : null;
+        this.textFragment = `:~:text=${textFragment}`;
+      }
       try {
         window.history.replaceState({}, null, newUrlPath);
         this.oldLocationHash = newFragment + newQueryString;
@@ -183,8 +195,20 @@ BookReader.prototype.urlUpdateFragment = function() {
   if (this.options.urlMode === 'hash')  {
     const newQueryStringSearch = this.urlParamsFiltersOnlySearch(this.readQueryString());
     let textFragment = this.urlPlugin.retrieveTextFragment(this.readQueryString());
+    let extractedPage = newFragment.match(/(?<=\/)n?\d+(?=\/)/);
+    if (extractedPage) {
+      extractedPage = extractedPage[0];
+    }
     if (textFragment) {
       textFragment = `:~:text=${textFragment[0]}`;
+    } else {
+      textFragment = '';
+    }
+    if (!this.textFragmentPage && textFragment) {
+      this.textFragmentPage = extractedPage ? extractedPage : null;
+      this.textFragment = textFragment;
+    } else if (this.textFragmentPage && extractedPage != this.textFragmentPage) {
+      textFragment = '';
     }
     window.location.replace('#' + newFragment + newQueryStringSearch + textFragment);
     this.oldLocationHash = newFragment + newQueryStringSearch + textFragment;
@@ -234,15 +258,17 @@ export class BookreaderUrlPlugin extends BookReader {
       this.urlPlugin = new UrlPlugin(this.options);
       const location = this.getLocationSearch();
       if (location.includes("text=")) {
-        this.on('textLayerRendered', (_, {pageIndex, container}) => {
+        this.on('textLayerVisible', async (_, {pageContainerEl}) => {
+          const visiblePageNum = pageContainerEl.getAttribute('data-page-num');
+          await new Promise(resolve => setTimeout(resolve, 100));
           if (this.options.urlMode === 'history') {
-            // only want the text fragment forwarded
-            if (this.oldLocationHash.includes(':~:')) {
-              const newHash = this.oldLocationHash.split(':~:')[1];
-              window.location.replace(`#:~:${newHash}`);
+            if (this.textFragment && this.textFragmentPage == visiblePageNum) {
+              window.location.replace(`#${this.textFragment}`);
             }
           } else {
-            window.location.replace(`#${this.oldLocationHash}`);
+            if (this.textFragment && this.textFragmentPage == visiblePageNum) {
+              window.location.replace(`#${this.oldLocationHash}`);
+            }
           }
         });
       }

--- a/src/plugins/url/plugin.url.js
+++ b/src/plugins/url/plugin.url.js
@@ -25,10 +25,11 @@ jQuery.extend(BookReader.defaultOptions, {
   urlHistoryBasePath: '/',
 
   /** Only these params will be reflected onto the URL */
-  urlTrackedParams: ['page', 'search', 'mode', 'region', 'highlight', 'view'],
+  urlTrackedParams: ['page', 'search', 'mode', 'region', 'highlight', 'view', 'text'],
 
   /** If true, don't update the URL when `page == n0 (eg "/page/n0")` */
   urlTrackIndex0: false,
+  shareHighlight: null,
 });
 
 /** @override */
@@ -87,6 +88,7 @@ BookReader.prototype.shortTitle = function(maximumCharacters) {
  */
 BookReader.prototype.urlStartLocationPolling = function() {
   this.oldLocationHash = this.urlReadFragment();
+  console.log("BookReader.urlStartLocationPolling this.oldLocationHash", this.oldLocationHash);
 
   if (this.locationPollId) {
     clearInterval(this.locationPollId);
@@ -159,6 +161,7 @@ BookReader.prototype.urlUpdateFragment = function() {
       try {
         window.history.replaceState({}, null, newUrlPath);
         this.oldLocationHash = newFragment + newQueryString;
+        console.log("changed oldLocationHash in BookReader.setup", this.oldLocationHash);
       } catch (e) {
         // DOMException on Chrome when in sandboxed iframe
         this.options.urlMode = 'hash';
@@ -167,9 +170,17 @@ BookReader.prototype.urlUpdateFragment = function() {
   }
 
   if (this.options.urlMode === 'hash')  {
-    const newQueryStringSearch = this.urlParamsFiltersOnlySearch(this.readQueryString());
+    let newQueryStringSearch = this.urlParamsFiltersOnlySearch(this.readQueryString());
+    // console.log("checking the newQueryStringSearch", newQueryStringSearch, typeof newQueryStringSearch);
+    // if (newQueryStringSearch.indexOf(":~:") != -1) {
+    //   // if (newQueryStringSearch.includes("-,") || newQueryStringSearch.includes(",-")){
+    //   //   console.log("actively replacing commas w/ URI encoded components");
+    //   //   newQueryStringSearch = newQueryStringSearch.replaceAll(/(?<!-),(?!-)/g, "%2C");
+    //   // }
+    // }
     window.location.replace('#' + newFragment + newQueryStringSearch);
     this.oldLocationHash = newFragment + newQueryStringSearch;
+    console.log("changed oldLocationHash here", this.oldLocationHash);
   }
 };
 
@@ -180,9 +191,17 @@ BookReader.prototype.urlUpdateFragment = function() {
  * @param {string} url
  * @return {string}
  * */
+
+// testing with this URL http://127.0.0.1:8000/BookReaderDemo/demo-internetarchive.html?ocaid=adventureofsherl0000unse&text=Well%2C I found my plans very seriously menaced.&q=breaking the law#page/18/mode/2up
 BookReader.prototype.urlParamsFiltersOnlySearch = function(url) {
+  console.log("this is input, plugin.url.js", url)
+  const text = url.match(/(?<=[&?]text=)[^&]*/);
   const params = new URLSearchParams(url);
-  return params.has('q') ? `?${new URLSearchParams({ q: params.get('q') })}` : '';
+  let output = '';
+  output += params.has('q') ? `?${new URLSearchParams({ q: params.get('q') })}&` : ''
+  output += text ? `:~:text=${text[0]}` : '';
+  console.log("this is output, plugin.url.js", output)
+  return output;
 };
 
 
@@ -195,7 +214,7 @@ BookReader.prototype.urlReadFragment = function() {
   if (urlMode === 'history') {
     return window.location.pathname.substr(urlHistoryBasePath.length);
   } else {
-    return window.location.hash.substr(1);
+    return this.urlPlugin.getHash();
   }
 };
 
@@ -210,6 +229,22 @@ export class BookreaderUrlPlugin extends BookReader {
   init() {
     if (this.options.enableUrlPlugin) {
       this.urlPlugin = new UrlPlugin(this.options);
+      const location = this.getLocationSearch();
+      if (location.includes("text=")) {
+        const extractText = location.match(/(text=[\w\d\W]*)/);
+        const textFragment = `${extractText}`;
+        this.options.shareHighlight = textFragment;
+        this.on('textLayerRendered', (_, {pageIndex, container}) => {
+          console.log("this.oldLocationHash", this.oldLocationHash);
+          // if (this.oldLocationHash.indexOf(":~:") != -1) {
+          //   if (this.oldLocationHash.includes("-,") || this.oldLocationHash.includes(",-")) {
+          //     // console.log("Replacing commas w/ URI encoded components");
+          //     this.oldLocationHash = this.oldLocationHash.replaceAll(/(?<!-),(?!-)/g, "%2C");
+          //   }
+          // }
+          window.location.replace(`#${this.oldLocationHash}`)
+        })
+      }
       this.bind(BookReader.eventNames.PostInit, () => {
         const { urlMode } = this.options;
 

--- a/src/plugins/url/plugin.url.js
+++ b/src/plugins/url/plugin.url.js
@@ -1,6 +1,7 @@
 /* global BookReader */
 
 import { UrlPlugin } from "./UrlPlugin.js";
+import { sleep } from "../../BookReader/utils.js";
 
 /**
  * Plugin for URL management in BookReader
@@ -217,13 +218,9 @@ BookReader.prototype.urlUpdateFragment = function() {
  * @param {string} url
  * @return {string}
  * */
-
-// testing with this URL http://127.0.0.1:8000/BookReaderDemo/demo-internetarchive.html?ocaid=adventureofsherl0000unse&text=Well%2C I found my plans very seriously menaced.&q=breaking the law#page/18/mode/2up
 BookReader.prototype.urlParamsFiltersOnlySearch = function(url) {
   const params = new URLSearchParams(url);
-  let output = '';
-  output += params.has('q') ? `?${new URLSearchParams({ q: params.get('q') })}` : '';
-  return output;
+  return params.has('q') ? `?${new URLSearchParams({ q: params.get('q') })}` : '';
 };
 
 
@@ -255,12 +252,10 @@ export class BookreaderUrlPlugin extends BookReader {
       if (location.includes("text=")) {
         this.on('textLayerVisible', async (_, {pageContainerEl}) => {
           const visiblePageNum = pageContainerEl.getAttribute('data-page-num');
-          let renderPageDelay = 100;
-          if (this.mode === 1) {
-            // maybe add some more time to have the page "settle down" from user scrolling
-            renderPageDelay = 900;
-          }
-          await new Promise(resolve => setTimeout(resolve, renderPageDelay));
+
+          // Hack: More time mode 1up page "settle down" from user scrolling
+          await sleep(this.mode === 1 ? 900 : 100);
+
           // No textFragment found or the textFragment stored doesn't match current visible page loaded
           if (!this.textFragment || this.textFragmentPage !== visiblePageNum) return;
           if (this.options.urlMode === 'history') {

--- a/src/plugins/url/plugin.url.js
+++ b/src/plugins/url/plugin.url.js
@@ -171,10 +171,7 @@ BookReader.prototype.urlUpdateFragment = function() {
       const newFragmentWithSlash = newFragment === '' ? '' : `/${newFragment}`;
       const textFragment = this.urlPlugin.retrieveTextFragment(newQueryString);
       const newUrlPath = `${baseWithoutSlash}${newFragmentWithSlash}${newQueryString}`;
-      let extractedPage = newFragmentWithSlash.match(/(?<=\/)n?\d+(?=\/)/);
-      if (extractedPage) {
-        extractedPage = extractedPage[0];
-      }
+      const extractedPage = this.urlPlugin.urlStringToUrlState(newFragmentWithSlash)?.page;
       if (!this.textFragmentPage && textFragment) {
         this.textFragmentPage =  extractedPage ? extractedPage : null;
         this.textFragment = `:~:text=${textFragment}`;
@@ -261,14 +258,13 @@ export class BookreaderUrlPlugin extends BookReader {
         this.on('textLayerVisible', async (_, {pageContainerEl}) => {
           const visiblePageNum = pageContainerEl.getAttribute('data-page-num');
           await new Promise(resolve => setTimeout(resolve, 100));
+          // No textFragment found or the textFragment stored doesn't match current visible page loaded
+          if (!this.textFragment || this.textFragmentPage !== visiblePageNum) return;
           if (this.options.urlMode === 'history') {
-            if (this.textFragment && this.textFragmentPage == visiblePageNum) {
-              window.location.replace(`#${this.textFragment}`);
-            }
+            window.location.replace(`#${this.textFragment}`);
           } else {
-            if (this.textFragment && this.textFragmentPage == visiblePageNum) {
-              window.location.replace(`#${this.oldLocationHash}`);
-            }
+            // for urlMode hash, textFragment is stored in oldLocationHash already
+            window.location.replace(`#${this.oldLocationHash}`);
           }
         });
       }

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -2,6 +2,7 @@
 import { SelectionObserver } from "../BookReader/utils/SelectionObserver.js";
 
 export class TextSelectionManager {
+  hlightBarEl;
   options = {
     // Current Translation plugin implementation does not have words, will limit to one BRlineElement for now
     maxProtectedWords: 200,
@@ -156,7 +157,12 @@ export class TextSelectionManager {
     $(textLayer).off(".textSelectPluginHandler");
 
     $(textLayer).on("mousedown.textSelectPluginHandler", (event) => {
+      if (event.which != 1) return;
       this.mouseIsDown = true;
+      if (this.hlightBarEl) {
+        this.hlightBarEl.remove();
+        window.getSelection().empty(); // selection is checked at mouseup, need to clear it here to prevent button from lingering
+      }
       event.stopPropagation();
     });
 
@@ -164,9 +170,74 @@ export class TextSelectionManager {
     $(textLayer).on('mouseup.textSelectPluginHandler', (event) => {
       this.mouseIsDown = false;
       event.stopPropagation();
+      if (event.which != 1) return;
+      this.hlightBarEl?.remove();
+      if (window.getSelection().toString()) {
+        this.highlightToolbar(event);
+      } else {
+        this.hlightBarEl?.remove();
+      }
+    });
+    
+    $(document.body).on('mouseup', (_) => {
+      this.hlightBarEl?.remove();
     });
   }
 
+  highlightToolbar(_) {
+    const hlButton = document.createElement('button');
+    
+    if (this.hlightBarEl) {
+      this.hlightBarEl.remove();
+    }
+    this.hlightBarEl = hlButton;
+    const currentSelection = window.getSelection();
+    const start = currentSelection.anchorNode.parentElement
+    const end = currentSelection.focusNode.parentElement // will always be a text node
+    const selectionTextLayer = start.closest('.BRtextLayer'); 
+    const endBoundingRect = end.getBoundingClientRect();
+    const width = 60;
+    const height = 30;
+    let hlButtonTop = endBoundingRect.top;
+    let hlButtonLeft = endBoundingRect.left;
+    if (currentSelection.direction == 'backward') {
+      hlButtonTop -= (height + start.getBoundingClientRect().height);
+    } else {
+      hlButtonTop += (height / 2);
+      hlButtonLeft += (width / 2);
+    }
+    hlButton.className = "FINDME";
+
+    $(hlButton).css({
+      'top': `${hlButtonTop}px`,
+      'left': `${hlButtonLeft}px`,
+      'width': `${width}px`,
+      'height': `${height}px`,
+      'position': 'absolute',
+      'z-index': 1,
+      'background': `url(..${this.br.imagesBaseURL}translate.svg)`,
+      'background-position': 'center',
+      'background-repeat': 'no-repeat',
+      'background-color': 'darksalmon',
+    })
+    $(hlButton).on('mousedown', (event) => {
+      event.stopPropagation();
+      let currentUrl = window.location;
+      const textContentParams = document.getSelection()
+      let currentParams = this.br.readQueryString();
+      if (currentParams.includes('text')) {
+        currentParams = currentParams.replace(/(text=)[\w\W\d%]+/, createParam(textContentParams, selectionTextLayer));
+      } else {
+        currentParams = `${currentParams}&${createParam(document.getSelection(), selectionTextLayer)}`;
+      }
+      navigator.clipboard.writeText(`${currentUrl.origin}${currentUrl.pathname}${currentParams}${currentUrl?.hash}`);
+    });
+
+    $(hlButton).on('mouseup', (event) => {
+      event.stopPropagation();
+    })
+    document.body.append(hlButton);
+  }
 
   _limitSelection = () => {
     const selection = window.getSelection();
@@ -206,6 +277,220 @@ export class TextSelectionManager {
   };
 }
 
+/** TODO -> 
+ * Can import something that handles this more gracefully? see - https://web.dev/articles/text-fragments#:~:text=In%20its%20simplest%20form%2C%20the%20syntax%20of,percent%2Dencoded%20text%20I%20want%20to%20link%20to. 
+ */
+/**
+ * 
+ * @param {*} text - document.getSelection() 
+ * @param {*} pageLayer - anchorNode.parentElement.closest('.BRtextLayer')
+ * @returns 
+ */
+export function createParam(text, pageLayer = null) {
+  const highlightedText = text.toString().replaceAll(/[\s]+/g, " ").trim().split(" ");
+  const anchorWord = text.anchorNode.textContent;
+  const focusWord = text.focusNode.textContent;
+  let textStart, textEnd; // :~:text=[prefix-,]textStart[,textEnd][,-suffix]
+  const direction = text.direction;
+  function findContext(startLine, endLine) {
+    if (window.getSelection().direction == 'backward') {
+      const tempWords = startLine;
+      startLine = endLine;
+      endLine = tempWords;
+    }
+    const surroundingStart = text.anchorNode.parentElement.closest(".BRlineElement");
+    const surroundingEnd = text.focusNode.parentElement.closest(".BRlineElement");
+    /** if (surroundingStart === surroundingEnd) {
+    //   // If the selection has the same line
+    //   const parentLineArray = surroundingStart.textContent.split(/[\s]+/);
+    //   let startIdx = parentLineArray.indexOf(startLine);
+    //   let endIdx = parentLineArray.indexOf(endLine);
+    //   let beforeStart, afterEnd;
+
+    //   if (window.getSelection().direction == 'backward') {
+    //     beforeStart = startIdx + 3 >= parentLineArray.length ? parentLineArray.length : startIdx + 3;
+    //     afterEnd = endIdx - 2 < 0 ? endIdx : endIdx - 2;
+    //   } else {
+    //     beforeStart = startIdx - 2 < 0 ? startIdx : startIdx - 2;
+    //     afterEnd = endIdx + 3 >= parentLineArray.length ? parentLineArray.length : endIdx + 3;
+    //   }
+    //   const beforeStartWords = parentLineArray.slice(beforeStart, startIdx).join(" ");
+    //   const afterEndWords = parentLineArray.slice(endIdx + 1, afterEnd).join(" ");
+
+    //   const prefixURI = beforeStartWords ? `${encodeURIComponent(beforeStartWords)}-,` : ""
+    //   const suffixURI = afterEndWords ? `,-${encodeURIComponent(afterEndWords)}` : ""
+    //   return `text=${prefixURI}${encodeURIComponent(removeNewLine.join(" "))}${suffixURI}`
+      } else { 
+    */
+      // If the selection is across multiple lines
+      let parentStartLineArray = surroundingStart.textContent.split(/[\s]+/);
+      let parentEndLineArray = surroundingEnd.textContent.split(/[\s]+/);
+      // console.log("parentStartLineArray", parentStartLineArray);
+      let startIdx = parentStartLineArray.indexOf(startLine);
+      let endIdx = parentEndLineArray.indexOf(endLine);
+      // console.log("this is the start and end", startIdx, endIdx, parentEndLineArray);
+      if (startIdx == 0) {
+        if (!surroundingStart.previousElementSibling) {
+          let previousParagraph = Array.from(surroundingStart.parentElement.previousElementSibling.childNodes).filter((ele) => ele.className == 'BRlineElement');
+          parentStartLineArray = previousParagraph.slice(-1)[0].textContent.split(/[\s]+/);
+        } else {
+          parentStartLineArray = surroundingStart.previousElementSibling.textContent.split(/[\s]+/);
+        }
+        startIdx = parentStartLineArray.length + 1;
+      }
+      if (endIdx + 1 == parentEndLineArray.length) { // Need to check the next line
+        if (surroundingEnd.nextSibling.className != 'BRlineElement') {
+          let nextParagraph = Array.from(surroundingEnd.parentElement.nextSibling.childNodes).filter((ele) => ele.className == 'BRlineElement');
+          parentEndLineArray = nextParagraph.slice(0)[0].textContent.split(/[\s]+/);
+        } else {
+          parentEndLineArray = surroundingEnd.nextSibling.textContent.split(/[\s]+/);
+        }
+        endIdx = -1;
+      }
+      // console.log("this is parentStartLineArray", parentStartLineArray);
+      let beforeStart = startIdx - 2 <= 0 ? 0 : startIdx - 2;
+      let afterEnd = endIdx + 3 >= parentEndLineArray.length ? parentEndLineArray.length : endIdx + 3;
+      if (window.getSelection().direction == "backward") {
+        beforeStart = endIdx - 2 <= 0 ? 0 : endIdx - 2;
+        afterEnd = startIdx + 3 >= parentStartLineArray.length ? parentStartLineArray.length : startIdx + 3;
+        // console.log("reversing the indexes", 
+        //   `beforeStart: ${beforeStart},
+        //   afterEnd: ${afterEnd},
+        //   startIdx: ${startIdx}, ${parentStartLineArray[startIdx]},
+        //   endIdx: ${endIdx}, ${parentEndLineArray[endIdx]},
+        //   preStartWords = ${parentStartLineArray.slice(beforeStart, startIdx)},
+        //   ${parentStartLineArray};
+        //   `);
+      }
+      const preStartWords = parentStartLineArray.slice(beforeStart, startIdx).join (" ");
+      const postEndWords = parentEndLineArray.slice(endIdx + 1, afterEnd).join(" ");
+      // console.log("removeNewLine", highlightedText);
+      // console.log("beforeStart, afterEnd", beforeStart, afterEnd);
+      // console.log("should show quote", parentStartLineArray, beforeStart, startIdx);
+
+      // console.log("highlighted text", highlightedText);
+      const prefixURI = preStartWords ? `${encodeURIComponent(preStartWords)}-,` : "";
+      const suffixURI = postEndWords ? `,-${encodeURIComponent(postEndWords)}` : ""
+      return `text=${prefixURI}${encodeURIComponent(highlightedText.join(" "))}${suffixURI}`;
+    // }
+    
+  }
+  if (pageLayer) {
+    // Duplicated spaces in pageLayer.textContent for some reason
+    const wholePageText = pageLayer.textContent.replaceAll("  ", " ");
+    if (direction == 'backward') {
+      textStart = focusWord.replaceAll(/[\s]+/g, "") ? focusWord: highlightedText[0]
+      textEnd = anchorWord.replaceAll(/[\s]+/g, "") ? anchorWord : highlightedText[highlightedText.length - 1];
+    } else {
+      textStart = anchorWord.replaceAll(/[\s]+/g, "")? anchorWord : highlightedText[0]
+      textEnd = focusWord.replaceAll(/[\s]+/g, "") ? focusWord : highlightedText[highlightedText.length - 1];
+    }
+    const escapedStart = RegExp.escape(textStart);
+    const escapedEnd = RegExp.escape(textEnd);
+    const testRegExp = new RegExp(String.raw`(?=(${escapedStart}).*?(?:(${escapedEnd})))`, "gi")
+    // const testRegExp = new RegExp(String.raw`(\S+\s+){3}${escapedStart}[\s\S]*?${escapedEnd}(\s+\S+){3}`, "gi");
+    /** otherRegExp probably doesn't work; textContent doesn't preserve newlines and innerText jumbles lines within paragraphs
+     * const otherRegExp = new RegExp(String.raw`(\S+\s){3}${escapedStart}.*?${escapedEnd}(\s\S+){3}`, "gi")
+     * console.log("otherRegExp", otherRegExp);
+     * const surroundingFoundMatches = pageLayer.innerText.replaceAll(/[\s+]/g, " ").matchAll(otherRegExp).toArray();
+     * console.log("surroundingFoundMatches", surroundingFoundMatches);
+    */
+    // const foundMatches = wholePageText.matchAll(testRegExp).toArray();
+    // console.log("this is foundMatches", foundMatches, textStart, textEnd);
+    // if (foundMatches.length == 1) {
+      // should be safe to use the match that was found here
+      // console.log("found a unique match from just the page");
+      // return `text=${textStart},${textEnd}`;
+    // } else {
+      let preStartRange = document.createRange();
+      let postEndRange = document.createRange();
+      if (direction == 'backward') {
+        // preStartRange.setStart(text.focusNode, text.focusNode.textContent.length);
+        // preStartRange.setEnd(pageLayer.lastElementChild, pageLayer.lastElementChild);
+
+        // postEndRange.setEnd(text.anchorNode, 0);
+        // postEndRange.setStart(pageLayer.firstElementChild, 0);
+        preStartRange.setStart(pageLayer.firstElementChild, 0);
+        preStartRange.setEnd(text.focusNode, 0);
+
+        postEndRange.setStart(text.anchorNode, text.anchorNode.textContent.length);
+        postEndRange.setEnd(pageLayer.lastElementChild, pageLayer.lastElementChild.childElementCount)
+
+      } else {
+        preStartRange.setStart(pageLayer.firstElementChild, 0);
+        preStartRange.setEnd(text.anchorNode, 0);
+
+        postEndRange.setStart(text.focusNode, text.focusNode.textContent.length);
+        postEndRange.setEnd(pageLayer.lastElementChild, pageLayer.lastElementChild.childElementCount);
+      }
+      console.log("preStartRange", preStartRange.toString());
+      console.log("postEndRange", postEndRange.toString());
+      
+      let startRegex = new RegExp(String.raw`(\s+\S+){3}\s*?$`)
+      let endRegex = new RegExp(String.raw`^\S*?(\s+\S+){3}`);
+      // prefixes/suffixes cannot contain paragraph breaks
+      let prefixes = preStartRange.toString().match(startRegex)[0]
+        .replace(/[ ]+/g, " ")
+        .trim()
+        .replace(/^[^\n]*\n/gm, "");
+      console.log(postEndRange.toString().match(endRegex));
+      let suffixes = postEndRange.toString().match(endRegex)[0]
+        .replace(/[ ]+/g, " ")
+        .trim()
+        .replace(/\n[^\n]*$/gm, "");
+      // console.log("prefixes", prefixes);
+      // console.log("suffixes", suffixes);
+
+      // console.log(textStart, textEnd);
+      if (textStart === textEnd) {
+        console.log("these are the same things");
+        textEnd = "";
+      }
+
+      const selection = window.getSelection();
+      let constructHighlight = selection.toString().replace(/[\s]+/g, " ").split(/[ ]+/g);
+      console.log({constructHighlight});
+      if (direction == 'backward') {
+        constructHighlight[0] = selection.focusNode.textContent;
+        constructHighlight[constructHighlight.length - 1] = selection.anchorNode.textContent;
+      } else {
+        constructHighlight[0] = selection.anchorNode.textContent;
+        constructHighlight[constructHighlight.length - 1] = selection.focusNode.textContent;
+      }
+      const fullHighlight = constructHighlight.join(" ").trim().split(" ");
+      console.log({fullHighlight});
+      let quote = [fullHighlight.join(" ")];
+      if (fullHighlight.length > 6) {
+        console.log("this is fullHighlight.length", fullHighlight.length, direction);
+        if (direction == 'backward') {
+          console.log("why is this not showing in the console")
+          console.log("this is backwards", fullHighlight.slice(-3).join(' '));
+          console.log("other backwards half", fullHighlight.slice(0, 3).join(" "));
+          quote = [fullHighlight.slice(0, 3).join(" "), fullHighlight.slice(-3).join(" ")];
+        } else {
+          console.log(fullHighlight.slice(0, 3).join(" "))
+          console.log("negative slice", fullHighlight.slice(-3), fullHighlight.slice(-1), fullHighlight.slice(-2));
+          quote = [fullHighlight.slice(0, 3).join(" "), fullHighlight.slice(-3).join(" ")];
+        }
+      }
+      console.log({prefixes, quote, suffixes});
+      
+      // highlight can also not contain newline characters
+      console.log(fullHighlight.join(' '));
+      return `text=${[
+        `${prefixes}-`,
+        ...quote,
+        `-${suffixes}`,
+      ].map(encodeURIComponent).join(',')}`;
+    // }
+    return findContext(textStart, textEnd);
+    }
+
+    return findContext(textStart, textEnd);
+  // }
+  console.log("Last case scenario: Attempt to use whole line", `${highlightedText.join(" ")}`);
+  return `text=${encodeURIComponent(highlightedText.join(" "))}`
+}
 /**
  * @template T
  * Get the i-th element of an iterable
@@ -280,3 +565,37 @@ export function* walkBetweenNodes(start, end) {
 
   yield* walk(start);
 }
+
+
+export class TextFragment {
+  /** @type {string | null} */
+  prefix
+  /** @type {string} */
+  textStart
+  /** @type {string | null} */
+  textEnd
+  /** @type {string | null} */
+  suffix
+
+  /** @returns {string} */
+  toString() {}
+
+  /**
+   * @param {string} urlString
+   * @returns {TextFragment}
+   **/
+  static fromString(urlString) {}
+
+  /**
+   * @param {Selection} selection
+   * @returns {TextFragment}
+   */
+  static fromSelection(selection) {}
+}
+
+
+/**
+ * Prefix “That is easily-,
+ * textstart %20 got.” “ And%20 
+ * Suffix - help.”“That is
+*/

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -461,9 +461,18 @@ class brHighlightBar extends LitElement {
     if (currentParams.includes('text')) {
       currentParams = currentParams.replace(/(text=)[\w\W\d%]+/, createParam(currentSelection, textLayer));
     } else {
-      currentParams = `${currentParams}&${createParam(currentSelection, textLayer)}`;
+      if (this.br.options.urlMode === 'history') {
+        currentParams = `?${createParam(currentSelection, textLayer)}`
+      } else {
+        currentParams = `${currentParams}&${createParam(currentSelection, textLayer)}`;
+      }
     }
-    navigator.clipboard.writeText(`${currentUrl.origin}${currentUrl.pathname}${currentParams}${currentUrl?.hash}`);
+    console.log("this is after copying", currentParams, currentUrl.pathname);
+    if (this.br.options.urlMode === 'history') {
+      navigator.clipboard.writeText(`${currentUrl.origin}${currentUrl.pathname}${currentParams}`)
+    } else {
+      navigator.clipboard.writeText(`${currentUrl.origin}${currentUrl.pathname}${currentParams}${currentUrl?.hash}`);
+    }
   }
 
   addHighlightButtonStyling() {

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -5,13 +5,15 @@ import { customElement } from 'lit/decorators.js';
 import '@internetarchive/icon-share';
 
 export class TextSelectionManager {
-  /** @type {BRSelectMenu} */
-  selectMenu;
-  selectionMenuEnabled;
   options = {
     // Current Translation plugin implementation does not have words, will limit to one BRlineElement for now
     maxProtectedWords: 200,
   }
+
+  /** @type {BRSelectMenu} */
+  selectMenu;
+  /** @type {boolean} */
+  selectionMenuEnabled = false;
 
   /**
    * @param {string} layer Selector for the text layer to manage
@@ -29,8 +31,8 @@ export class TextSelectionManager {
     this.selectionElement = selectionElement;
     this.selectionObserver = new SelectionObserver(this.layer, this._onSelectionChange);
     this.options.maxProtectedWords = maxWords ? maxWords : 200;
-    this.selectMenu = new BRSelectMenu(br);
 
+    this.selectMenu = new BRSelectMenu(br);
     this.selectMenu.className = "br-select-menu__root";
   }
 
@@ -66,7 +68,9 @@ export class TextSelectionManager {
   // Need attach + detach methods to toggle w/ Translation plugin
   attach() {
     this.selectionObserver.attach();
-    this.renderSelectionMenu();
+    if (this.selectionMenuEnabled) {
+      this.renderSelectionMenu();
+    }
     if (this.br.protected) {
       document.addEventListener('selectionchange', this._limitSelection);
       // Prevent right clicking when selected text
@@ -94,9 +98,7 @@ export class TextSelectionManager {
 
   renderSelectionMenu() {
     if (document.querySelector('.br-select-menu__option')) return;
-    if (this.selectionMenuEnabled) {
-      document.body.append(this.selectMenu);
-    }
+    document.body.append(this.selectMenu);
   }
   /**
    * @param {'started' | 'cleared' | 'focusChanged'} type
@@ -244,18 +246,18 @@ export class TextSelectionManager {
   };
 }
 
-/** TODO ->
- * Can import something that handles this more gracefully? see - https://web.dev/articles/text-fragments#:~:text=In%20its%20simplest%20form%2C%20the%20syntax%20of,percent%2Dencoded%20text%20I%20want%20to%20link%20to.
- */
 /**
- * Builds a URL string in the format of a TextFragment within the URL params, which differs from browser "Copy to link to highlighted text" format
- * Does not include the fragment directive (`:~:`) and is not after the URL hash
+ * Builds a TextFragment string from a given text selection.
+ * Note does not include the fragment directive `:~:` or # symbol
  * See https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments
- * @param {Selection} selection - document.getSelection()
- * @param {HTMLElement} pageLayer - anchorNode.parentElement.closest('.BRtextLayer')
- * @returns {string} - i.e. http://127.0.0.1:8000/BookReaderDemo/demo-internetarchive.html?ocaid=adventureofsherl0000unse&text=undefined,undefined#page/10/mode/2up
+ * @param {Selection} selection currently selected text, eg `document.getSelection()`
+ * @param {HTMLElement[]} contextElements elements providing context for the selection
+ * @returns {string}
  */
-export function createTextFragmentUrlParam(selection, pageLayer) {
+export function createTextFragmentUrlParam(selection, contextElements) {
+  // TODO: Can import something that handles this more gracefully? see -
+  // https://web.dev/articles/text-fragments#:~:text=In%20its%20simplest%20form%2C%20the%20syntax%20of,percent%2Dencoded%20text%20I%20want%20to%20link%20to.
+
   // :~:text=[prefix-,]textStart[,textEnd][,-suffix]
   const highlightedText = selection.toString().replace(/[\s]+/g, " ").trim().split(" ");
   const direction = selection.direction;
@@ -274,12 +276,12 @@ export function createTextFragmentUrlParam(selection, pageLayer) {
   const endPhraseMatchRe = new RegExp(String.raw`(${textStartRe})(?=.*?(${textEndRe}))`, "gis");
 
   // Duplicated spaces in pageLayer.textContent for some reason
-  const wholePageText = Array.from(document.querySelectorAll('.BRpage-visible'))
-    .map((item) => item.textContent)
+  const selectionContext = contextElements
+    .map((el) => el.textContent)
     .join(' ')
-    .replace(/\s+/g, " ") || pageLayer.textContent.replace(/\s+/g, " ");
-  const startPhraseFoundMatches = wholePageText.matchAll(startPhraseMatchRe).toArray();
-  const endPhraseFoundMatches = wholePageText.matchAll(endPhraseMatchRe).toArray();
+    .replace(/\s+/g, " ");
+  const startPhraseFoundMatches = selectionContext.matchAll(startPhraseMatchRe).toArray();
+  const endPhraseFoundMatches = selectionContext.matchAll(endPhraseMatchRe).toArray();
   if (startPhraseFoundMatches.length == 1 && endPhraseFoundMatches.length == 1) {
     // If `startWord...endWord` quote is unambiguous and only occurs once, no prefix-/-suffix is needed for the URL param
     return `text=${encodeURIComponent(startWord)},${encodeURIComponent(endWord)}`;
@@ -287,24 +289,14 @@ export function createTextFragmentUrlParam(selection, pageLayer) {
 
   // Need to add some additional context to `startWord...endWord` by including surrounding words before and after the keywords
   const preStartRange = document.createRange();
-
-  const previousPageContainer = pageLayer.parentElement?.previousElementSibling;
-  if (previousPageContainer?.classList.contains("BRpage-visible")) {
-    preStartRange.setStart(previousPageContainer, 0);
-  } else {
-    preStartRange.setStart(pageLayer.firstElementChild, 0);
-  }
+  preStartRange.setStart(contextElements[0].firstElementChild, 0);
   preStartRange.setEnd(startNode, 0);
+
   const postEndRange = document.createRange();
   postEndRange.setStart(endNode, endNode.textContent.length);
-  const nextPageContainer = pageLayer.parentElement.nextElementSibling;
-  if (nextPageContainer?.classList.contains("BRpage-visible")) {
-    const nextPageLastWord = getLastestElement(nextPageContainer);
-    postEndRange.setEnd(nextPageLastWord, Math.max(0, nextPageLastWord.textContent.length - 1));
-  } else {
-    const lastWordOfPageEl = getLastestElement(pageLayer);
-    postEndRange.setEnd(lastWordOfPageEl, Math.max(0, lastWordOfPageEl.textContent.length - 1));
-  }
+  const lastWordOfPageEl = getLastMostElement(contextElements[contextElements.length - 1]);
+  postEndRange.setEnd(lastWordOfPageEl, Math.max(0, lastWordOfPageEl.textContent.length - 1));
+
   // prefixes/suffixes cannot contain paragraph breaks, words that are from more than one line break away should not be included
   const prefix = getLastWords(3, preStartRange.toString())
     .replace(/[ ]+/g, " ")
@@ -446,33 +438,38 @@ class BRSelectMenu extends LitElement {
     `;
   }
 
+  /**
+   * @param {MouseEvent} e
+   */
   handleCopyLinkToHighlight(e) {
     e.preventDefault();
-    const currentUrl = window.location;
-    let currentParams = this.br.readQueryString();
+
+    const currentParams = this.br.readQueryString();
     const currentSelection = window.getSelection();
     /** @type {HTMLElement} */
     const textLayer = currentSelection.anchorNode.parentElement.closest('.BRtextLayer');
-    // To do - updateResumeValue + getCookiePath in plugin.resume.js overrides the adjustedUrlPageNumPath, check how to workaround this
-    const adjustedUrlPageNumPath = currentUrl.pathname.toString().replace(/(?<=\/page\/)\d+(?=\/)/, textLayer.parentElement.getAttribute('data-page-num'));
+    const textFragmentUrlParam = createTextFragmentUrlParam(currentSelection, Array.from(document.querySelectorAll('.BRpage-visible')));
+
+    // Note: Have to do a param construction to avoid url-encoding of commas in the text fragment param
+    let linkToHighlightParams = currentParams;
     if (currentParams.includes('text=')) {
-      currentParams = currentParams.replace(/(text=)[\w\W\d%]+/, createTextFragmentUrlParam(currentSelection, textLayer));
+      linkToHighlightParams = currentParams.replace(/(text=)[\w\W\d%]+/, textFragmentUrlParam);
     } else {
-      if (this.br.options.urlMode === 'history') {
-        currentParams = `?${createTextFragmentUrlParam(currentSelection, textLayer)}`;
-      } else {
-        currentParams = `${currentParams}&${createTextFragmentUrlParam(currentSelection, textLayer)}`;
-      }
+      const sep = linkToHighlightParams ? '&' : '?';
+      linkToHighlightParams += `${sep}${textFragmentUrlParam}`;
     }
-    if (this.br.options.urlMode === 'history') {
-      navigator.clipboard.writeText(`${currentUrl.origin}${adjustedUrlPageNumPath}${currentParams}`);
-    } else {
-      navigator.clipboard.writeText(`${currentUrl.origin}${adjustedUrlPageNumPath}${currentParams}${currentUrl?.hash}`);
-    }
+
+    const currentUrl = window.location;
+    // TODO - updateResumeValue + getCookiePath in plugin.resume.js overrides the adjustedUrlPageNumPath, check how to workaround this
+    // TODO - won't work with hash mode
+    const adjustedUrlPageNumPath = currentUrl.pathname.toString().replace(/(?<=\/page\/)\d+(?=\/)/, textLayer.parentElement.getAttribute('data-page-num'));
+
+    const linkToHighlight = `${currentUrl.origin}${adjustedUrlPageNumPath}${linkToHighlightParams}${currentUrl?.hash || ''}`;
+    navigator.clipboard.writeText(linkToHighlight);
   }
 
   showMenu() {
-    if (this.br.plugins.translate) return;
+    if (this.br.plugins.translate?.userToggleTranslate) return;
     const currentSelection = window.getSelection();
     const start = currentSelection.anchorNode.parentElement;
     const end = currentSelection.focusNode.parentElement; // will always be a text node
@@ -490,7 +487,7 @@ class BRSelectMenu extends LitElement {
     this.style.left = `${hlButtonLeft}px`;
     this.style.zIndex = '1';
     this.style.position = 'absolute';
-    this.style.display = 'inline';
+    this.style.display = 'block';
   }
 
   hideMenu = () => {
@@ -527,7 +524,7 @@ export function getLastWords(numWords, text) {
  * @param {HTMLElement | Element} parent
  * @returns {Node}
  */
-export function getLastestElement(parent) {
+export function getLastMostElement(parent) {
   while (parent.lastElementChild) {
     parent = parent.lastElementChild;
   }

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -1,8 +1,11 @@
 // @ts-check
 import { SelectionObserver } from "../BookReader/utils/SelectionObserver.js";
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 
 export class TextSelectionManager {
-  hlightBarEl;
+  /** @type {brHighlightBar} */
+  highlightBar;
   options = {
     // Current Translation plugin implementation does not have words, will limit to one BRlineElement for now
     maxProtectedWords: 200,
@@ -24,6 +27,8 @@ export class TextSelectionManager {
     this.selectionElement = selectionElement;
     this.selectionObserver = new SelectionObserver(this.layer, this._onSelectionChange);
     this.options.maxProtectedWords = maxWords ? maxWords : 200;
+    this.highlightBar = new brHighlightBar(br);
+    this.highlightBar.className = "textFragmentBar";
   }
 
   init() {
@@ -36,6 +41,16 @@ export class TextSelectionManager {
         // Set a class on the page to avoid hiding it when zooming/etc
         this.br.refs.$br.find('.BRpagecontainer--hasSelection').removeClass('BRpagecontainer--hasSelection');
         $(window.getSelection().anchorNode).closest('.BRpagecontainer').addClass('BRpagecontainer--hasSelection');
+        this.highlightBar.addHighlightButtonStyling();
+      }
+
+      if (selectEvent == 'focusChanged') {
+        // hide the button as user changes their selection
+        if (this.mouseIsDown) {
+          this.highlightBar.hideHighlightStyle();
+        } else {
+          this.highlightBar.addHighlightButtonStyling();
+        }
       }
     }).attach();
   }
@@ -43,6 +58,9 @@ export class TextSelectionManager {
   // Need attach + detach methods to toggle w/ Translation plugin
   attach() {
     this.selectionObserver.attach();
+    if (!this.br.plugins.translate) {
+      document.body.append(this.highlightBar);
+    }
     if (this.br.protected) {
       document.addEventListener('selectionchange', this._limitSelection);
       // Prevent right clicking when selected text
@@ -69,11 +87,11 @@ export class TextSelectionManager {
   }
 
   /**
-   * @param {'started' | 'cleared'} type
+   * @param {'started' | 'cleared' | 'focusChanged'} type
    * @param {HTMLElement} target
    */
   _onSelectionChange = (type, target) => {
-    if (type === 'started') {
+    if (type === 'started' || type === 'focusChanged') {
       this.textSelectingMode(target);
     } else if (type === 'cleared') {
       this.defaultMode(target);
@@ -135,6 +153,7 @@ export class TextSelectionManager {
 
     $(textLayer).on("mouseup.textSelectPluginHandler", (event) => {
       this.mouseIsDown = false;
+      this.highlightBar.hideHighlightStyle();
       textLayer.style.pointerEvents = "none";
       if (skipNextMouseup) {
         skipNextMouseup = false;
@@ -159,83 +178,16 @@ export class TextSelectionManager {
     $(textLayer).on("mousedown.textSelectPluginHandler", (event) => {
       if (event.which != 1) return;
       this.mouseIsDown = true;
-      if (this.hlightBarEl) {
-        this.hlightBarEl.remove();
-        window.getSelection().empty(); // selection is checked at mouseup, cleared here to prevent button from lingering
-      }
       event.stopPropagation();
     });
 
     // Prevent page flip on click
     $(textLayer).on('mouseup.textSelectPluginHandler', (event) => {
       this.mouseIsDown = false;
-      event.stopPropagation();
       if (event.which != 1) return;
-      this.hlightBarEl?.remove();
-      if (window.getSelection().toString()) {
-        this.highlightToolbar(event);
-      } else {
-        this.hlightBarEl?.remove();
-      }
-    });
-
-    $(document.body).on('mouseup', (_) => {
-      this.hlightBarEl?.remove();
-    });
-  }
-
-  highlightToolbar(_) {
-    const hlButton = document.createElement('button');
-
-    if (this.hlightBarEl) {
-      this.hlightBarEl.remove();
-    }
-    this.hlightBarEl = hlButton;
-    const currentSelection = window.getSelection();
-    const start = currentSelection.anchorNode.parentElement;
-    const end = currentSelection.focusNode.parentElement; // will always be a text node
-    const height = 30;
-    const width = 60;
-    const selectionTextLayer = start.closest('.BRtextLayer');
-    const startBoundingRect = start.getBoundingClientRect();
-    const endBoundingRect = end.getBoundingClientRect();
-    let hlButtonTop = startBoundingRect.top - height;
-    let hlButtonLeft = startBoundingRect.left - width;
-    if (currentSelection.direction == 'backward') {
-      hlButtonTop = endBoundingRect.top - height;
-      hlButtonLeft = endBoundingRect.left - width;
-    }
-    hlButton.className = "textFragmentCopy";
-
-    $(hlButton).css({
-      'top': `${hlButtonTop}px`,
-      'left': `${hlButtonLeft}px`,
-      'width': `${width}px`,
-      'height': `${height}px`,
-      'position': 'absolute',
-      'z-index': 1,
-      'background': `url(..${this.br.imagesBaseURL}translate.svg)`,
-      'background-position': 'center',
-      'background-repeat': 'no-repeat',
-      'background-color': 'darksalmon',
-    });
-    $(hlButton).on('mousedown', (event) => {
       event.stopPropagation();
-      const currentUrl = window.location;
-      const textContentParams = document.getSelection();
-      let currentParams = this.br.readQueryString();
-      if (currentParams.includes('text')) {
-        currentParams = currentParams.replace(/(text=)[\w\W\d%]+/, createParam(textContentParams, selectionTextLayer));
-      } else {
-        currentParams = `${currentParams}&${createParam(document.getSelection(), selectionTextLayer)}`;
-      }
-      navigator.clipboard.writeText(`${currentUrl.origin}${currentUrl.pathname}${currentParams}${currentUrl?.hash}`);
+      this.highlightBar.addHighlightButtonStyling();
     });
-
-    $(hlButton).on('mouseup', (event) => {
-      event.stopPropagation();
-    });
-    document.body.append(hlButton);
   }
 
   _limitSelection = () => {
@@ -280,26 +232,27 @@ export class TextSelectionManager {
  * Can import something that handles this more gracefully? see - https://web.dev/articles/text-fragments#:~:text=In%20its%20simplest%20form%2C%20the%20syntax%20of,percent%2Dencoded%20text%20I%20want%20to%20link%20to.
  */
 /**
- *
- * @param {*} text - document.getSelection()
- * @param {*} pageLayer - anchorNode.parentElement.closest('.BRtextLayer')
+ * Builds a string in the format of a TextFragment.
+ * See https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments
+ * @param {Selection} selection - document.getSelection()
+ * @param {HTMLElement} pageLayer - anchorNode.parentElement.closest('.BRtextLayer')
  * @returns
  */
-export function createParam(text, pageLayer = null) {
-  const highlightedText = text.toString().replaceAll(/[\s]+/g, " ").trim().split(" ");
-  const anchorWord = text.anchorNode.textContent;
-  const focusWord = text.focusNode.textContent;
+export function createParam(selection, pageLayer) {
+  const highlightedText = selection.toString().replace(/[\s]+/g, " ").trim().split(" ");
+  const anchorWord = selection.anchorNode.textContent;
+  const focusWord = selection.focusNode.textContent;
   let textStart, textEnd; // :~:text=[prefix-,]textStart[,textEnd][,-suffix]
-  const direction = text.direction;
+  const direction = selection.direction;
 
   // Duplicated spaces in pageLayer.textContent for some reason
   const wholePageText = pageLayer.textContent.replaceAll("  ", " ");
   if (direction == 'backward') {
-    textStart = focusWord.replaceAll(/[\s]+/g, "") ? focusWord : highlightedText[0];
-    textEnd = anchorWord.replaceAll(/[\s]+/g, "") ? anchorWord : highlightedText[highlightedText.length - 1];
+    textStart = focusWord.replace(/[\s]+/g, "") ? focusWord : highlightedText[0];
+    textEnd = anchorWord.replace(/[\s]+/g, "") ? anchorWord : highlightedText[highlightedText.length - 1];
   } else {
-    textStart = anchorWord.replaceAll(/[\s]+/g, "") ? anchorWord : highlightedText[0];
-    textEnd = focusWord.replaceAll(/[\s]+/g, "") ? focusWord : highlightedText[highlightedText.length - 1];
+    textStart = anchorWord.replace(/[\s]+/g, "") ? anchorWord : highlightedText[0];
+    textEnd = focusWord.replace(/[\s]+/g, "") ? focusWord : highlightedText[highlightedText.length - 1];
   }
 
   const escapedStart = RegExp.escape(textStart);
@@ -314,16 +267,16 @@ export function createParam(text, pageLayer = null) {
   const postEndRange = document.createRange();
   if (direction == 'backward') {
     preStartRange.setStart(pageLayer.firstElementChild, 0);
-    preStartRange.setEnd(text.focusNode, 0);
+    preStartRange.setEnd(selection.focusNode, 0);
 
-    postEndRange.setStart(text.anchorNode, text.anchorNode.textContent.length);
+    postEndRange.setStart(selection.anchorNode, selection.anchorNode.textContent.length);
     postEndRange.setEnd(pageLayer.lastElementChild, pageLayer.lastElementChild.childElementCount);
 
   } else {
     preStartRange.setStart(pageLayer.firstElementChild, 0);
-    preStartRange.setEnd(text.anchorNode, 0);
+    preStartRange.setEnd(selection.anchorNode, 0);
 
-    postEndRange.setStart(text.focusNode, text.focusNode.textContent.length);
+    postEndRange.setStart(selection.focusNode, selection.focusNode.textContent.length);
     postEndRange.setEnd(pageLayer.lastElementChild, pageLayer.lastElementChild.childElementCount);
   }
 
@@ -364,7 +317,6 @@ export function createParam(text, pageLayer = null) {
     textEnd = "";
   }
 
-  const selection = window.getSelection();
   const constructHighlight = selection.toString().replace(/[\s]+/g, " ").split(/[ ]+/g);
   if (direction == 'backward') {
     constructHighlight[0] = selection.focusNode.textContent;
@@ -463,36 +415,84 @@ export function* walkBetweenNodes(start, end) {
   yield* walk(start);
 }
 
+@customElement('br-highlight-bar')
+class brHighlightBar extends LitElement {
+  /** @type {import('../BookReader.js').default} */
+  br;
 
-export class TextFragment {
-  /** @type {string | null} */
-  prefix
-  /** @type {string} */
-  textStart
-  /** @type {string | null} */
-  textEnd
-  /** @type {string | null} */
-  suffix
+  constructor(br) {
+    super();
+    this.br = br;
+  }
 
-  /** @returns {string} */
-  toString() {}
+  /** @override */
+  createRenderRoot() {
+    // Disable shadow DOM; that would require a huge rejiggering of CSS
+    return this;
+  }
 
-  /**
-   * @param {string} urlString
-   * @returns {TextFragment}
-   **/
-  static fromString(urlString) {}
+  /** @override */
+  connectedCallback() {
+    super.connectedCallback();
+    this.dispatchEvent(new CustomEvent('showingHighlightBar'));
+  }
 
-  /**
-   * @param {Selection} selection
-   * @returns {TextFragment}
-   */
-  static fromSelection(selection) {}
+  /** @override */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.dispatchEvent(new CustomEvent('hidingHighlightBar'));
+  }
+
+  render() {
+    return html`
+      <button @click=${this.handleClick} class="textFragmentButton">
+      </button>
+    `;
+  }
+
+  handleClick(e) {
+    e.preventDefault();
+    this.dispatchEvent(new CustomEvent('textFragmentButtonClicked'));
+    const currentUrl = window.location;
+    let currentParams = this.br.readQueryString();
+    const currentSelection = window.getSelection();
+    /** @type {HTMLElement} */
+    const textLayer = currentSelection.anchorNode.parentElement.closest('.BRtextLayer');
+    if (currentParams.includes('text')) {
+      currentParams = currentParams.replace(/(text=)[\w\W\d%]+/, createParam(currentSelection, textLayer));
+    } else {
+      currentParams = `${currentParams}&${createParam(currentSelection, textLayer)}`;
+    }
+    navigator.clipboard.writeText(`${currentUrl.origin}${currentUrl.pathname}${currentParams}${currentUrl?.hash}`);
+  }
+
+  addHighlightButtonStyling() {
+    const currentSelection = window.getSelection();
+    const start = currentSelection.anchorNode.parentElement;
+    const end = currentSelection.focusNode.parentElement; // will always be a text node
+    const height = 30;
+    const width = 60;
+    const startBoundingRect = start.getBoundingClientRect();
+    const endBoundingRect = end.getBoundingClientRect();
+    let hlButtonTop = startBoundingRect.top - height;
+    let hlButtonLeft = startBoundingRect.left - width;
+    if (currentSelection.direction == 'backward') {
+      hlButtonTop = endBoundingRect.top - height;
+      hlButtonLeft = endBoundingRect.left - width;
+    }
+    this.style.top = `${hlButtonTop}px`;
+    this.style.left = `${hlButtonLeft}px`;
+    this.style.zIndex = '1';
+    this.style.position = 'absolute';
+    this.style.display = 'inline';
+  }
+
+  attachSelectionListeners = () => {
+    return;
+  }
+
+  hideHighlightStyle = () => {
+    this.style.display = 'none';
+    return;
+  }
 }
-
-
-/**
- * Prefix “That is easily-,
- * textstart %20 got.” “ And%20
- * Suffix - help.”“That is
-*/

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -453,6 +453,8 @@ class BRSelectMenu extends LitElement {
     const currentSelection = window.getSelection();
     /** @type {HTMLElement} */
     const textLayer = currentSelection.anchorNode.parentElement.closest('.BRtextLayer');
+    // To do - updateResumeValue + getCookiePath in plugin.resume.js overrides the adjustedUrlPageNumPath, check how to workaround this
+    const adjustedUrlPageNumPath = currentUrl.pathname.toString().replace(/(?<=\/page\/)\d+(?=\/)/, textLayer.parentElement.getAttribute('data-page-num'));
     if (currentParams.includes('text=')) {
       currentParams = currentParams.replace(/(text=)[\w\W\d%]+/, createTextFragmentUrlParam(currentSelection, textLayer));
     } else {
@@ -463,9 +465,9 @@ class BRSelectMenu extends LitElement {
       }
     }
     if (this.br.options.urlMode === 'history') {
-      navigator.clipboard.writeText(`${currentUrl.origin}${currentUrl.pathname}${currentParams}`);
+      navigator.clipboard.writeText(`${currentUrl.origin}${adjustedUrlPageNumPath}${currentParams}`);
     } else {
-      navigator.clipboard.writeText(`${currentUrl.origin}${currentUrl.pathname}${currentParams}${currentUrl?.hash}`);
+      navigator.clipboard.writeText(`${currentUrl.origin}${adjustedUrlPageNumPath}${currentParams}${currentUrl?.hash}`);
     }
   }
 

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -269,7 +269,7 @@ export function createTextFragmentUrlParam(selection, pageLayer) {
   const textEndRe = RegExp.escape(endWord);
 
   // 's' regex modifier ensures the `.` also captures newline characters
-  const phraseMatchRe = new RegExp(String.raw`(?=(${textStartRe}).*?(?:(${textEndRe})))`, "gis");
+  const phraseMatchRe = new RegExp(String.raw`(?<=(${textStartRe}).*?)(${textEndRe})`, "gis");
   // Duplicated spaces in pageLayer.textContent for some reason
   const wholePageText = pageLayer.textContent.replaceAll("  ", " ");
   const foundMatches = wholePageText.matchAll(phraseMatchRe).toArray();

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -5,8 +5,8 @@ import { customElement } from 'lit/decorators.js';
 import '@internetarchive/icon-share';
 
 export class TextSelectionManager {
-  /** @type {BRSelectionMenu} */
-  highlightBar;
+  /** @type {BRSelectMenu} */
+  selectMenu;
   selectionMenuEnabled;
   options = {
     // Current Translation plugin implementation does not have words, will limit to one BRlineElement for now
@@ -29,9 +29,9 @@ export class TextSelectionManager {
     this.selectionElement = selectionElement;
     this.selectionObserver = new SelectionObserver(this.layer, this._onSelectionChange);
     this.options.maxProtectedWords = maxWords ? maxWords : 200;
-    this.highlightBar = new BRSelectionMenu(br);
+    this.selectMenu = new BRSelectMenu(br);
 
-    this.highlightBar.className = "br-selection-menu__root";
+    this.selectMenu.className = "br-select-menu__root";
   }
 
   init() {
@@ -44,21 +44,21 @@ export class TextSelectionManager {
         // Set a class on the page to avoid hiding it when zooming/etc
         this.br.refs.$br.find('.BRpagecontainer--hasSelection').removeClass('BRpagecontainer--hasSelection');
         $(window.getSelection().anchorNode).closest('.BRpagecontainer').addClass('BRpagecontainer--hasSelection');
-        this.highlightBar.showMenu();
+        this.selectMenu.showMenu();
 
       }
 
       if (selectEvent == 'focusChanged') {
         // hide the button as user changes their selection
         if (this.mouseIsDown) {
-          this.highlightBar.hideMenu();
+          this.selectMenu.hideMenu();
         } else if (window.getSelection().toString()) {
-          this.highlightBar.showMenu();
+          this.selectMenu.showMenu();
         }
       }
 
       if (selectEvent == 'cleared') {
-        this.highlightBar.hideMenu();
+        this.selectMenu.hideMenu();
       }
     }).attach();
   }
@@ -93,9 +93,9 @@ export class TextSelectionManager {
   }
 
   renderSelectionMenu() {
-    if (document.querySelector('.textFragmentBar')) return;
+    if (document.querySelector('.br-select-menu__option')) return;
     if (this.selectionMenuEnabled) {
-      document.body.append(this.highlightBar);
+      document.body.append(this.selectMenu);
     }
   }
   /**
@@ -160,7 +160,7 @@ export class TextSelectionManager {
     // blocking selection
     $(textLayer).on("mousedown.textSelectPluginHandler", (event) => {
       this.mouseIsDown = true;
-      this.highlightBar.hideMenu();
+      this.selectMenu.hideMenu();
       if ($(event.target).is(this.selectionElement.join(", "))) {
         event.stopPropagation();
       }
@@ -168,7 +168,7 @@ export class TextSelectionManager {
 
     $(textLayer).on("mouseup.textSelectPluginHandler", (event) => {
       this.mouseIsDown = false;
-      this.highlightBar.hideMenu();
+      this.selectMenu.hideMenu();
       textLayer.style.pointerEvents = "none";
       if (skipNextMouseup) {
         skipNextMouseup = false;
@@ -194,7 +194,7 @@ export class TextSelectionManager {
       if (event.which != 1) return;
       this.mouseIsDown = true;
       event.stopPropagation();
-      this.highlightBar.hideMenu();
+      this.selectMenu.hideMenu();
     });
 
     // Prevent page flip on click
@@ -202,7 +202,7 @@ export class TextSelectionManager {
       this.mouseIsDown = false;
       if (event.which != 1) return;
       event.stopPropagation();
-      this.highlightBar.showMenu();
+      this.selectMenu.showMenu();
     });
   }
 
@@ -256,8 +256,8 @@ export class TextSelectionManager {
  * @returns {string} - i.e. http://127.0.0.1:8000/BookReaderDemo/demo-internetarchive.html?ocaid=adventureofsherl0000unse&text=undefined,undefined#page/10/mode/2up
  */
 export function createTextFragmentUrlParam(selection, pageLayer) {
+  // :~:text=[prefix-,]textStart[,textEnd][,-suffix]
   const highlightedText = selection.toString().replace(/[\s]+/g, " ").trim().split(" ");
-  let textStart, textEnd; // :~:text=[prefix-,]textStart[,textEnd][,-suffix]
   const direction = selection.direction;
   const startNode = direction == 'backward' ? selection.focusNode : selection.anchorNode;
   const endNode = direction == 'backward' ? selection.anchorNode : selection.focusNode;
@@ -269,86 +269,55 @@ export function createTextFragmentUrlParam(selection, pageLayer) {
   const textEndRe = RegExp.escape(endWord);
 
   // 's' regex modifier ensures the `.` also captures newline characters
-  const phraseMatchRe = new RegExp(String.raw`(?<=(${textStartRe}).*?)(${textEndRe})`, "gis");
+  // Need to use lookahead/lookbehind assertions to allow for overlapping quotes (i.e. multiple "Holmes" on the same page)
+  const startPhraseMatchRe = new RegExp(String.raw`(?<=(${textStartRe}).*?)(${textEndRe})`, "gis");
+  const endPhraseMatchRe = new RegExp(String.raw`(${textStartRe})(?=.*?(${textEndRe}))`, "gis");
+
   // Duplicated spaces in pageLayer.textContent for some reason
-  const wholePageText = pageLayer.textContent.replaceAll("  ", " ");
-  const foundMatches = wholePageText.matchAll(phraseMatchRe).toArray();
-  if (foundMatches.length == 1) {
+  const wholePageText = pageLayer.textContent.replace(/\s+/g, " ");
+  const startPhraseFoundMatches = wholePageText.matchAll(startPhraseMatchRe).toArray();
+  const endPhraseFoundMatches = wholePageText.matchAll(endPhraseMatchRe).toArray();
+  if (startPhraseFoundMatches.length == 1 && endPhraseFoundMatches.length == 1) {
     // If `startWord...endWord` quote is unambiguous and only occurs once, no prefix-/-suffix is needed for the URL param
     return `text=${encodeURIComponent(startWord)},${encodeURIComponent(endWord)}`;
   }
+
   // Need to add some additional context to `startWord...endWord` by including surrounding words before and after the keywords
   const preStartRange = document.createRange();
+  preStartRange.setStart(pageLayer.firstElementChild, 0);
+  preStartRange.setEnd(startNode, 0);
   const postEndRange = document.createRange();
-  if (direction == 'backward') {
-    preStartRange.setStart(pageLayer.firstElementChild, 0);
-    preStartRange.setEnd(selection.focusNode, 0);
-
-    postEndRange.setStart(selection.anchorNode, selection.anchorNode.textContent.length);
-    postEndRange.setEnd(pageLayer.lastElementChild, pageLayer.lastElementChild.childElementCount);
-
-  } else {
-    preStartRange.setStart(pageLayer.firstElementChild, 0);
-    preStartRange.setEnd(selection.anchorNode, 0);
-
-    postEndRange.setStart(selection.focusNode, selection.focusNode.textContent.length);
-    postEndRange.setEnd(pageLayer.lastElementChild, pageLayer.lastElementChild.childElementCount);
-  }
+  postEndRange.setStart(endNode, endNode.textContent.length);
+  postEndRange.setEnd(pageLayer.lastElementChild, pageLayer.lastElementChild.childElementCount);
 
   // prefixes/suffixes cannot contain paragraph breaks, words that are from more than one line break away should not be included
-  const prefixRe = new RegExp(String.raw`(\s+\S+){1,3}\s*?$`);
-  const suffixRe = new RegExp(String.raw`^\S*?(\s+\S+){1,3}`);
-
-  const textFragmentArr = [];
-  let [prefixes, suffixes] = "";
-  const getFirstWords = (sentence, patternRe) => {
-    if (sentence.toString().match(patternRe)) {
-      return sentence.toString().match(patternRe)[0];
-    } else {
-      return sentence.toString();
-    }
-  };
-
-  if (getFirstWords(preStartRange, prefixRe)) {
-    prefixes = `${getFirstWords(preStartRange.toString(), prefixRe)
-      .replace(/[ ]+/g, " ")
-      .trim()
-      .replace(/^[^\n]*\n/gm, "")}-`;
-  }
-  if (getFirstWords(postEndRange, suffixRe)) {
-    suffixes = `-${postEndRange.toString().match(suffixRe)[0]
-      .replace(/[ ]+/g, " ")
-      .trim()
-      .replace(/\n[^\n]*$/gm, "")}`;
-  }
-
-  if (textStart === textEnd) {
-    // if just one word ("Holmes") is selected, the browser API for text fragment will try to look for matches for strings like "Holmes, Holmes"
-    // providing the prefix and suffix should be enough to locate it on the page
-    textEnd = "";
-  }
+  const prefix = getLastWords(3, preStartRange.toString())
+    .replace(/[ ]+/g, " ")
+    .trim()
+    .replace(/^[^\n]*\n/gm, "");
+  const suffix = getFirstWords(3, postEndRange.toString())
+    .replace(/[ ]+/g, " ")
+    .trim()
+    .replace(/\n[^\n]*$/gm, "");
 
   // Partially selected words need to be captured completely
-  const constructHighlight = selection.toString().replace(/[\s]+/g, " ").split(/[ ]+/g);
-  if (direction == 'backward') {
-    constructHighlight[0] = selection.focusNode.textContent;
-    constructHighlight[constructHighlight.length - 1] = selection.anchorNode.textContent;
-  } else {
-    constructHighlight[0] = selection.anchorNode.textContent;
-    constructHighlight[constructHighlight.length - 1] = selection.focusNode.textContent;
-  }
-  const fullHighlight = constructHighlight.join(" ").trim().split(" ");
+  const fullHighlight = selection.toString().replace(/\s+/g, " ").trim().split(/\s/g);
+  fullHighlight[0] = startNode.textContent;
+  fullHighlight[fullHighlight.length - 1] = endNode.textContent;
+
   let quote = [fullHighlight.join(" ")];
   if (fullHighlight.length > 6) {
     quote = [fullHighlight.slice(0, 3).join(" "), fullHighlight.slice(-3).join(" ")];
   }
-  if (prefixes) textFragmentArr.push(prefixes);
+
+  const textFragmentArr = [];
+  if (prefix) textFragmentArr.push(`${prefix}-`);
   textFragmentArr.push(...quote);
-  if (suffixes.length != 0) {
-    textFragmentArr.push(suffixes ? suffixes : "");
-  }
+  if (suffix) textFragmentArr.push(`-${suffix}`);
+
   return `text=${textFragmentArr.map(encodeURIComponent).join(',')}`;
 }
+
 /**
  * @template T
  * Get the i-th element of an iterable
@@ -424,8 +393,8 @@ export function* walkBetweenNodes(start, end) {
   yield* walk(start);
 }
 
-@customElement('br-highlight-bar')
-class BRSelectionMenu extends LitElement {
+@customElement('br-select-menu')
+class BRSelectMenu extends LitElement {
   /** @type {import('../BookReader.js').default} */
   br;
 
@@ -442,9 +411,9 @@ class BRSelectionMenu extends LitElement {
 
   render() {
     return html`
-      <button @click=${this.handleCopyLinkToHighlight} class="textFragmentButton">
-        <ia-icon-share aria-hidden="true"></ia-icon-share>
-        <span class="menuOptionTitle">Copy Link to Highlight</span>
+      <button @click=${this.handleCopyLinkToHighlight} class="br-select-menu__option">
+        <ia-icon-share class="br-select-menu__icon" aria-hidden="true"></ia-icon-share>
+        <span class="br-select-menu__label">Copy Link to Highlight</span>
       </button>
     `;
   }
@@ -498,4 +467,28 @@ class BRSelectionMenu extends LitElement {
     this.style.display = 'none';
     return;
   }
+}
+
+/**
+ * @param {number} numWords
+ * @param {string} text
+ * @return {string}
+ */
+export function getFirstWords(numWords, text) {
+  text = text.trim();
+  const re = new RegExp(String.raw`^(\S+(\s+|$)){1,${numWords}}`);
+  const m = text.match(re);
+  return m ? m[0].trim() : "";
+}
+
+/**
+ * @param {number} numWords
+ * @param {string} text
+ * @return {string}
+ */
+export function getLastWords(numWords, text) {
+  text = text.trim();
+  const re = new RegExp(String.raw`((^|\s+)\S+){1,${numWords}}\s*?$`);
+  const m = text.match(re);
+  return m ? m[0].trim() : "";
 }

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -108,10 +108,12 @@ export class TextSelectionManager {
    * @param {HTMLElement} target
    */
   _onSelectionChange = (type, target) => {
-    if (type === 'started' || type === 'focusChanged') {
+    if (type === 'started') {
       this.textSelectingMode(target);
     } else if (type === 'cleared') {
       this.defaultMode(target);
+    } else if (type === 'focusChanged') {
+      // do nothing, just wait for the mouseup to trigger the styling change
     } else {
       throw new Error(`Unknown type ${type}`);
     }

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -2,11 +2,12 @@
 import { SelectionObserver } from "../BookReader/utils/SelectionObserver.js";
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
+import '@internetarchive/icon-share';
 
 export class TextSelectionManager {
-  /** @type {brHighlightBar} */
+  /** @type {BRSelectionMenu} */
   highlightBar;
-  highlightEnabled;
+  selectionMenuEnabled;
   options = {
     // Current Translation plugin implementation does not have words, will limit to one BRlineElement for now
     maxProtectedWords: 200,
@@ -28,9 +29,9 @@ export class TextSelectionManager {
     this.selectionElement = selectionElement;
     this.selectionObserver = new SelectionObserver(this.layer, this._onSelectionChange);
     this.options.maxProtectedWords = maxWords ? maxWords : 200;
-    this.highlightBar = new brHighlightBar(br);
+    this.highlightBar = new BRSelectionMenu(br);
 
-    this.highlightBar.className = "textFragmentBar";
+    this.highlightBar.className = "br-selection-menu__root";
   }
 
   init() {
@@ -43,25 +44,21 @@ export class TextSelectionManager {
         // Set a class on the page to avoid hiding it when zooming/etc
         this.br.refs.$br.find('.BRpagecontainer--hasSelection').removeClass('BRpagecontainer--hasSelection');
         $(window.getSelection().anchorNode).closest('.BRpagecontainer').addClass('BRpagecontainer--hasSelection');
-        this.highlightBar.addHighlightButtonStyling();
+        this.highlightBar.showMenu();
 
       }
 
       if (selectEvent == 'focusChanged') {
         // hide the button as user changes their selection
         if (this.mouseIsDown) {
-          this.highlightBar.hideHighlightStyle();
-
-        } else {
-          if (window.getSelection().toString().length != 0) {
-            this.highlightBar.addHighlightButtonStyling();
-
-          }
+          this.highlightBar.hideMenu();
+        } else if (window.getSelection().toString()) {
+          this.highlightBar.showMenu();
         }
       }
 
       if (selectEvent == 'cleared') {
-        this.highlightBar.hideHighlightStyle();
+        this.highlightBar.hideMenu();
       }
     }).attach();
   }
@@ -69,9 +66,7 @@ export class TextSelectionManager {
   // Need attach + detach methods to toggle w/ Translation plugin
   attach() {
     this.selectionObserver.attach();
-    if (!this.br.plugins.translate && this.highlightEnabled) {
-      document.body.append(this.highlightBar);
-    }
+    this.renderSelectionMenu();
     if (this.br.protected) {
       document.addEventListener('selectionchange', this._limitSelection);
       // Prevent right clicking when selected text
@@ -97,9 +92,9 @@ export class TextSelectionManager {
     }
   }
 
-  addHighlightBar() {
+  renderSelectionMenu() {
     if (document.querySelector('.textFragmentBar')) return;
-    if (this.highlightEnabled && !this.br.plugins.translate) {
+    if (this.selectionMenuEnabled) {
       document.body.append(this.highlightBar);
     }
   }
@@ -165,7 +160,7 @@ export class TextSelectionManager {
     // blocking selection
     $(textLayer).on("mousedown.textSelectPluginHandler", (event) => {
       this.mouseIsDown = true;
-      this.highlightBar.hideHighlightStyle();
+      this.highlightBar.hideMenu();
       if ($(event.target).is(this.selectionElement.join(", "))) {
         event.stopPropagation();
       }
@@ -173,7 +168,7 @@ export class TextSelectionManager {
 
     $(textLayer).on("mouseup.textSelectPluginHandler", (event) => {
       this.mouseIsDown = false;
-      this.highlightBar.hideHighlightStyle();
+      this.highlightBar.hideMenu();
       textLayer.style.pointerEvents = "none";
       if (skipNextMouseup) {
         skipNextMouseup = false;
@@ -199,7 +194,7 @@ export class TextSelectionManager {
       if (event.which != 1) return;
       this.mouseIsDown = true;
       event.stopPropagation();
-      this.highlightBar.hideHighlightStyle();
+      this.highlightBar.hideMenu();
     });
 
     // Prevent page flip on click
@@ -207,7 +202,7 @@ export class TextSelectionManager {
       this.mouseIsDown = false;
       if (event.which != 1) return;
       event.stopPropagation();
-      this.highlightBar.addHighlightButtonStyling();
+      this.highlightBar.showMenu();
     });
   }
 
@@ -253,39 +248,36 @@ export class TextSelectionManager {
  * Can import something that handles this more gracefully? see - https://web.dev/articles/text-fragments#:~:text=In%20its%20simplest%20form%2C%20the%20syntax%20of,percent%2Dencoded%20text%20I%20want%20to%20link%20to.
  */
 /**
- * Builds a string in the format of a TextFragment.
+ * Builds a URL string in the format of a TextFragment within the URL params, which differs from browser "Copy to link to highlighted text" format
+ * Does not include the fragment directive (`:~:`) and is not after the URL hash
  * See https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments
  * @param {Selection} selection - document.getSelection()
  * @param {HTMLElement} pageLayer - anchorNode.parentElement.closest('.BRtextLayer')
- * @returns
+ * @returns {string} - i.e. http://127.0.0.1:8000/BookReaderDemo/demo-internetarchive.html?ocaid=adventureofsherl0000unse&text=undefined,undefined#page/10/mode/2up
  */
-export function createParam(selection, pageLayer) {
+export function createTextFragmentUrlParam(selection, pageLayer) {
   const highlightedText = selection.toString().replace(/[\s]+/g, " ").trim().split(" ");
-  const anchorWord = selection.anchorNode.textContent;
-  const focusWord = selection.focusNode.textContent;
   let textStart, textEnd; // :~:text=[prefix-,]textStart[,textEnd][,-suffix]
   const direction = selection.direction;
+  const startNode = direction == 'backward' ? selection.focusNode : selection.anchorNode;
+  const endNode = direction == 'backward' ? selection.anchorNode : selection.focusNode;
+  // If text selection begins or ends with a space, we look for the next eligible word to serve as the start or end word
+  const startWord = startNode.textContent.replace(/[\s]+/g, "") ? startNode.textContent : highlightedText[0];
+  const endWord = endNode.textContent.replace(/[\s]+/g, "") ? endNode.textContent : highlightedText[highlightedText.length - 1];
 
+  const textStartRe = RegExp.escape(startWord);
+  const textEndRe = RegExp.escape(endWord);
+
+  // 's' regex modifier ensures the `.` also captures newline characters
+  const phraseMatchRe = new RegExp(String.raw`(?=(${textStartRe}).*?(?:(${textEndRe})))`, "gis");
   // Duplicated spaces in pageLayer.textContent for some reason
   const wholePageText = pageLayer.textContent.replaceAll("  ", " ");
-  if (direction == 'backward') {
-    textStart = focusWord.replace(/[\s]+/g, "") ? focusWord : highlightedText[0];
-    textEnd = anchorWord.replace(/[\s]+/g, "") ? anchorWord : highlightedText[highlightedText.length - 1];
-  } else {
-    textStart = anchorWord.replace(/[\s]+/g, "") ? anchorWord : highlightedText[0];
-    textEnd = focusWord.replace(/[\s]+/g, "") ? focusWord : highlightedText[highlightedText.length - 1];
-  }
-
-  const escapedStart = RegExp.escape(textStart);
-  const escapedEnd = RegExp.escape(textEnd);
-
-  // added 's' regex modifier to ensure that the matchAll actually captures instances where the escaped start / end words have whitespace
-  const testRegExp = new RegExp(String.raw`(?=(${escapedStart}).*?(?:(${escapedEnd})))`, "gis");
-
-  const foundMatches = wholePageText.matchAll(testRegExp).toArray();
+  const foundMatches = wholePageText.matchAll(phraseMatchRe).toArray();
   if (foundMatches.length == 1) {
-    return `text=${encodeURIComponent(textStart)},${encodeURIComponent(textEnd)}`;
+    // If `startWord...endWord` quote is unambiguous and only occurs once, no prefix-/-suffix is needed for the URL param
+    return `text=${encodeURIComponent(startWord)},${encodeURIComponent(endWord)}`;
   }
+  // Need to add some additional context to `startWord...endWord` by including surrounding words before and after the keywords
   const preStartRange = document.createRange();
   const postEndRange = document.createRange();
   if (direction == 'backward') {
@@ -303,43 +295,40 @@ export function createParam(selection, pageLayer) {
     postEndRange.setEnd(pageLayer.lastElementChild, pageLayer.lastElementChild.childElementCount);
   }
 
-  const startRegex = new RegExp(String.raw`(\s+\S+){1,3}\s*?$`);
-  const endRegex = new RegExp(String.raw`^\S*?(\s+\S+){1,3}`);
-  // prefixes/suffixes cannot contain paragraph breaks
+  // prefixes/suffixes cannot contain paragraph breaks, words that are from more than one line break away should not be included
+  const prefixRe = new RegExp(String.raw`(\s+\S+){1,3}\s*?$`);
+  const suffixRe = new RegExp(String.raw`^\S*?(\s+\S+){1,3}`);
+
   const textFragmentArr = [];
-  let [prefixes, suffixes] = ["", ""];
-  if (preStartRange.toString().length !== 0) {
-    if (!preStartRange.toString().match(startRegex)) {
-      prefixes = `${preStartRange.toString()
-        .replace(/[ ]+/g, " ")
-        .trim()
-        .replace(/^[^\n]*\n/gm, "")}-`;
+  let [prefixes, suffixes] = "";
+  const getFirstWords = (sentence, patternRe) => {
+    if (sentence.toString().match(patternRe)) {
+      return sentence.toString().match(patternRe)[0];
     } else {
-      prefixes = `${preStartRange.toString().match(startRegex)[0]
-        .replace(/[ ]+/g, " ")
-        .trim()
-        .replace(/^[^\n]*\n/gm, "")}-`;
+      return sentence.toString();
     }
-    textFragmentArr.push(prefixes);
+  };
+
+  if (getFirstWords(preStartRange, prefixRe)) {
+    prefixes = `${getFirstWords(preStartRange.toString(), prefixRe)
+      .replace(/[ ]+/g, " ")
+      .trim()
+      .replace(/^[^\n]*\n/gm, "")}-`;
   }
-  if (postEndRange.toString().length !== 0) {
-    if (!postEndRange.toString().match(endRegex)) {
-      suffixes = `-${postEndRange.toString()
-        .replace(/[ ]+/g, " ")
-        .trim()
-        .replace(/^[^\n]*\n/gm, "")}`;
-    } else {
-      suffixes = `-${postEndRange.toString().match(endRegex)[0]
-        .replace(/[ ]+/g, " ")
-        .trim()
-        .replace(/\n[^\n]*$/gm, "")}`;
-    }
+  if (getFirstWords(postEndRange, suffixRe)) {
+    suffixes = `-${postEndRange.toString().match(suffixRe)[0]
+      .replace(/[ ]+/g, " ")
+      .trim()
+      .replace(/\n[^\n]*$/gm, "")}`;
   }
 
   if (textStart === textEnd) {
+    // if just one word ("Holmes") is selected, the browser API for text fragment will try to look for matches for strings like "Holmes, Holmes"
+    // providing the prefix and suffix should be enough to locate it on the page
     textEnd = "";
   }
 
+  // Partially selected words need to be captured completely
   const constructHighlight = selection.toString().replace(/[\s]+/g, " ").split(/[ ]+/g);
   if (direction == 'backward') {
     constructHighlight[0] = selection.focusNode.textContent;
@@ -351,15 +340,12 @@ export function createParam(selection, pageLayer) {
   const fullHighlight = constructHighlight.join(" ").trim().split(" ");
   let quote = [fullHighlight.join(" ")];
   if (fullHighlight.length > 6) {
-    if (direction == 'backward') {
-      quote = [fullHighlight.slice(0, 3).join(" "), fullHighlight.slice(-3).join(" ")];
-    } else {
-      quote = [fullHighlight.slice(0, 3).join(" "), fullHighlight.slice(-3).join(" ")];
-    }
+    quote = [fullHighlight.slice(0, 3).join(" "), fullHighlight.slice(-3).join(" ")];
   }
+  if (prefixes) textFragmentArr.push(prefixes);
   textFragmentArr.push(...quote);
   if (suffixes.length != 0) {
-    textFragmentArr.push(suffixes);
+    textFragmentArr.push(suffixes ? suffixes : "");
   }
   return `text=${textFragmentArr.map(encodeURIComponent).join(',')}`;
 }
@@ -439,7 +425,7 @@ export function* walkBetweenNodes(start, end) {
 }
 
 @customElement('br-highlight-bar')
-class brHighlightBar extends LitElement {
+class BRSelectionMenu extends LitElement {
   /** @type {import('../BookReader.js').default} */
   br;
 
@@ -454,40 +440,29 @@ class brHighlightBar extends LitElement {
     return this;
   }
 
-  /** @override */
-  connectedCallback() {
-    super.connectedCallback();
-    this.dispatchEvent(new CustomEvent('showingHighlightBar'));
-  }
-
-  /** @override */
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this.dispatchEvent(new CustomEvent('hidingHighlightBar'));
-  }
-
   render() {
     return html`
-      <button @click=${this.handleClick} class="textFragmentButton">
+      <button @click=${this.handleCopyLinkToHighlight} class="textFragmentButton">
+        <ia-icon-share aria-hidden="true"></ia-icon-share>
+        <span class="menuOptionTitle">Copy Link to Highlight</span>
       </button>
     `;
   }
 
-  handleClick(e) {
+  handleCopyLinkToHighlight(e) {
     e.preventDefault();
-    this.dispatchEvent(new CustomEvent('textFragmentButtonClicked'));
     const currentUrl = window.location;
     let currentParams = this.br.readQueryString();
     const currentSelection = window.getSelection();
     /** @type {HTMLElement} */
     const textLayer = currentSelection.anchorNode.parentElement.closest('.BRtextLayer');
-    if (currentParams.includes('text')) {
-      currentParams = currentParams.replace(/(text=)[\w\W\d%]+/, createParam(currentSelection, textLayer));
+    if (currentParams.includes('text=')) {
+      currentParams = currentParams.replace(/(text=)[\w\W\d%]+/, createTextFragmentUrlParam(currentSelection, textLayer));
     } else {
       if (this.br.options.urlMode === 'history') {
-        currentParams = `?${createParam(currentSelection, textLayer)}`;
+        currentParams = `?${createTextFragmentUrlParam(currentSelection, textLayer)}`;
       } else {
-        currentParams = `${currentParams}&${createParam(currentSelection, textLayer)}`;
+        currentParams = `${currentParams}&${createTextFragmentUrlParam(currentSelection, textLayer)}`;
       }
     }
     if (this.br.options.urlMode === 'history') {
@@ -497,7 +472,8 @@ class brHighlightBar extends LitElement {
     }
   }
 
-  addHighlightButtonStyling() {
+  showMenu() {
+    if (this.br.plugins.translate) return;
     const currentSelection = window.getSelection();
     const start = currentSelection.anchorNode.parentElement;
     const end = currentSelection.focusNode.parentElement; // will always be a text node
@@ -518,11 +494,7 @@ class brHighlightBar extends LitElement {
     this.style.display = 'inline';
   }
 
-  attachSelectionListeners = () => {
-    return;
-  }
-
-  hideHighlightStyle = () => {
+  hideMenu = () => {
     this.style.display = 'none';
     return;
   }

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -6,6 +6,7 @@ import { customElement } from 'lit/decorators.js';
 export class TextSelectionManager {
   /** @type {brHighlightBar} */
   highlightBar;
+  highlightEnabled;
   options = {
     // Current Translation plugin implementation does not have words, will limit to one BRlineElement for now
     maxProtectedWords: 200,
@@ -28,6 +29,7 @@ export class TextSelectionManager {
     this.selectionObserver = new SelectionObserver(this.layer, this._onSelectionChange);
     this.options.maxProtectedWords = maxWords ? maxWords : 200;
     this.highlightBar = new brHighlightBar(br);
+
     this.highlightBar.className = "textFragmentBar";
   }
 
@@ -42,15 +44,24 @@ export class TextSelectionManager {
         this.br.refs.$br.find('.BRpagecontainer--hasSelection').removeClass('BRpagecontainer--hasSelection');
         $(window.getSelection().anchorNode).closest('.BRpagecontainer').addClass('BRpagecontainer--hasSelection');
         this.highlightBar.addHighlightButtonStyling();
+
       }
 
       if (selectEvent == 'focusChanged') {
         // hide the button as user changes their selection
         if (this.mouseIsDown) {
           this.highlightBar.hideHighlightStyle();
+
         } else {
-          this.highlightBar.addHighlightButtonStyling();
+          if (window.getSelection().toString().length != 0) {
+            this.highlightBar.addHighlightButtonStyling();
+
+          }
         }
+      }
+
+      if (selectEvent == 'cleared') {
+        this.highlightBar.hideHighlightStyle();
       }
     }).attach();
   }
@@ -58,7 +69,7 @@ export class TextSelectionManager {
   // Need attach + detach methods to toggle w/ Translation plugin
   attach() {
     this.selectionObserver.attach();
-    if (!this.br.plugins.translate) {
+    if (!this.br.plugins.translate && this.highlightEnabled) {
       document.body.append(this.highlightBar);
     }
     if (this.br.protected) {
@@ -86,6 +97,12 @@ export class TextSelectionManager {
     }
   }
 
+  addHighlightBar() {
+    if (document.querySelector('.textFragmentBar')) return;
+    if (this.highlightEnabled && !this.br.plugins.translate) {
+      document.body.append(this.highlightBar);
+    }
+  }
   /**
    * @param {'started' | 'cleared' | 'focusChanged'} type
    * @param {HTMLElement} target
@@ -146,6 +163,7 @@ export class TextSelectionManager {
     // blocking selection
     $(textLayer).on("mousedown.textSelectPluginHandler", (event) => {
       this.mouseIsDown = true;
+      this.highlightBar.hideHighlightStyle();
       if ($(event.target).is(this.selectionElement.join(", "))) {
         event.stopPropagation();
       }
@@ -179,6 +197,7 @@ export class TextSelectionManager {
       if (event.which != 1) return;
       this.mouseIsDown = true;
       event.stopPropagation();
+      this.highlightBar.hideHighlightStyle();
     });
 
     // Prevent page flip on click
@@ -462,14 +481,13 @@ class brHighlightBar extends LitElement {
       currentParams = currentParams.replace(/(text=)[\w\W\d%]+/, createParam(currentSelection, textLayer));
     } else {
       if (this.br.options.urlMode === 'history') {
-        currentParams = `?${createParam(currentSelection, textLayer)}`
+        currentParams = `?${createParam(currentSelection, textLayer)}`;
       } else {
         currentParams = `${currentParams}&${createParam(currentSelection, textLayer)}`;
       }
     }
-    console.log("this is after copying", currentParams, currentUrl.pathname);
     if (this.br.options.urlMode === 'history') {
-      navigator.clipboard.writeText(`${currentUrl.origin}${currentUrl.pathname}${currentParams}`)
+      navigator.clipboard.writeText(`${currentUrl.origin}${currentUrl.pathname}${currentParams}`);
     } else {
       navigator.clipboard.writeText(`${currentUrl.origin}${currentUrl.pathname}${currentParams}${currentUrl?.hash}`);
     }

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -161,7 +161,7 @@ export class TextSelectionManager {
       this.mouseIsDown = true;
       if (this.hlightBarEl) {
         this.hlightBarEl.remove();
-        window.getSelection().empty(); // selection is checked at mouseup, need to clear it here to prevent button from lingering
+        window.getSelection().empty(); // selection is checked at mouseup, cleared here to prevent button from lingering
       }
       event.stopPropagation();
     });
@@ -178,7 +178,7 @@ export class TextSelectionManager {
         this.hlightBarEl?.remove();
       }
     });
-    
+
     $(document.body).on('mouseup', (_) => {
       this.hlightBarEl?.remove();
     });
@@ -186,27 +186,26 @@ export class TextSelectionManager {
 
   highlightToolbar(_) {
     const hlButton = document.createElement('button');
-    
+
     if (this.hlightBarEl) {
       this.hlightBarEl.remove();
     }
     this.hlightBarEl = hlButton;
     const currentSelection = window.getSelection();
-    const start = currentSelection.anchorNode.parentElement
-    const end = currentSelection.focusNode.parentElement // will always be a text node
-    const selectionTextLayer = start.closest('.BRtextLayer'); 
-    const endBoundingRect = end.getBoundingClientRect();
-    const width = 60;
+    const start = currentSelection.anchorNode.parentElement;
+    const end = currentSelection.focusNode.parentElement; // will always be a text node
     const height = 30;
-    let hlButtonTop = endBoundingRect.top;
-    let hlButtonLeft = endBoundingRect.left;
+    const width = 60;
+    const selectionTextLayer = start.closest('.BRtextLayer');
+    const startBoundingRect = start.getBoundingClientRect();
+    const endBoundingRect = end.getBoundingClientRect();
+    let hlButtonTop = startBoundingRect.top - height;
+    let hlButtonLeft = startBoundingRect.left - width;
     if (currentSelection.direction == 'backward') {
-      hlButtonTop -= (height + start.getBoundingClientRect().height);
-    } else {
-      hlButtonTop += (height / 2);
-      hlButtonLeft += (width / 2);
+      hlButtonTop = endBoundingRect.top - height;
+      hlButtonLeft = endBoundingRect.left - width;
     }
-    hlButton.className = "FINDME";
+    hlButton.className = "textFragmentCopy";
 
     $(hlButton).css({
       'top': `${hlButtonTop}px`,
@@ -219,11 +218,11 @@ export class TextSelectionManager {
       'background-position': 'center',
       'background-repeat': 'no-repeat',
       'background-color': 'darksalmon',
-    })
+    });
     $(hlButton).on('mousedown', (event) => {
       event.stopPropagation();
-      let currentUrl = window.location;
-      const textContentParams = document.getSelection()
+      const currentUrl = window.location;
+      const textContentParams = document.getSelection();
       let currentParams = this.br.readQueryString();
       if (currentParams.includes('text')) {
         currentParams = currentParams.replace(/(text=)[\w\W\d%]+/, createParam(textContentParams, selectionTextLayer));
@@ -235,7 +234,7 @@ export class TextSelectionManager {
 
     $(hlButton).on('mouseup', (event) => {
       event.stopPropagation();
-    })
+    });
     document.body.append(hlButton);
   }
 
@@ -277,14 +276,14 @@ export class TextSelectionManager {
   };
 }
 
-/** TODO -> 
- * Can import something that handles this more gracefully? see - https://web.dev/articles/text-fragments#:~:text=In%20its%20simplest%20form%2C%20the%20syntax%20of,percent%2Dencoded%20text%20I%20want%20to%20link%20to. 
+/** TODO ->
+ * Can import something that handles this more gracefully? see - https://web.dev/articles/text-fragments#:~:text=In%20its%20simplest%20form%2C%20the%20syntax%20of,percent%2Dencoded%20text%20I%20want%20to%20link%20to.
  */
 /**
- * 
- * @param {*} text - document.getSelection() 
+ *
+ * @param {*} text - document.getSelection()
  * @param {*} pageLayer - anchorNode.parentElement.closest('.BRtextLayer')
- * @returns 
+ * @returns
  */
 export function createParam(text, pageLayer = null) {
   const highlightedText = text.toString().replaceAll(/[\s]+/g, " ").trim().split(" ");
@@ -292,204 +291,102 @@ export function createParam(text, pageLayer = null) {
   const focusWord = text.focusNode.textContent;
   let textStart, textEnd; // :~:text=[prefix-,]textStart[,textEnd][,-suffix]
   const direction = text.direction;
-  function findContext(startLine, endLine) {
-    if (window.getSelection().direction == 'backward') {
-      const tempWords = startLine;
-      startLine = endLine;
-      endLine = tempWords;
-    }
-    const surroundingStart = text.anchorNode.parentElement.closest(".BRlineElement");
-    const surroundingEnd = text.focusNode.parentElement.closest(".BRlineElement");
-    /** if (surroundingStart === surroundingEnd) {
-    //   // If the selection has the same line
-    //   const parentLineArray = surroundingStart.textContent.split(/[\s]+/);
-    //   let startIdx = parentLineArray.indexOf(startLine);
-    //   let endIdx = parentLineArray.indexOf(endLine);
-    //   let beforeStart, afterEnd;
 
-    //   if (window.getSelection().direction == 'backward') {
-    //     beforeStart = startIdx + 3 >= parentLineArray.length ? parentLineArray.length : startIdx + 3;
-    //     afterEnd = endIdx - 2 < 0 ? endIdx : endIdx - 2;
-    //   } else {
-    //     beforeStart = startIdx - 2 < 0 ? startIdx : startIdx - 2;
-    //     afterEnd = endIdx + 3 >= parentLineArray.length ? parentLineArray.length : endIdx + 3;
-    //   }
-    //   const beforeStartWords = parentLineArray.slice(beforeStart, startIdx).join(" ");
-    //   const afterEndWords = parentLineArray.slice(endIdx + 1, afterEnd).join(" ");
-
-    //   const prefixURI = beforeStartWords ? `${encodeURIComponent(beforeStartWords)}-,` : ""
-    //   const suffixURI = afterEndWords ? `,-${encodeURIComponent(afterEndWords)}` : ""
-    //   return `text=${prefixURI}${encodeURIComponent(removeNewLine.join(" "))}${suffixURI}`
-      } else { 
-    */
-      // If the selection is across multiple lines
-      let parentStartLineArray = surroundingStart.textContent.split(/[\s]+/);
-      let parentEndLineArray = surroundingEnd.textContent.split(/[\s]+/);
-      // console.log("parentStartLineArray", parentStartLineArray);
-      let startIdx = parentStartLineArray.indexOf(startLine);
-      let endIdx = parentEndLineArray.indexOf(endLine);
-      // console.log("this is the start and end", startIdx, endIdx, parentEndLineArray);
-      if (startIdx == 0) {
-        if (!surroundingStart.previousElementSibling) {
-          let previousParagraph = Array.from(surroundingStart.parentElement.previousElementSibling.childNodes).filter((ele) => ele.className == 'BRlineElement');
-          parentStartLineArray = previousParagraph.slice(-1)[0].textContent.split(/[\s]+/);
-        } else {
-          parentStartLineArray = surroundingStart.previousElementSibling.textContent.split(/[\s]+/);
-        }
-        startIdx = parentStartLineArray.length + 1;
-      }
-      if (endIdx + 1 == parentEndLineArray.length) { // Need to check the next line
-        if (surroundingEnd.nextSibling.className != 'BRlineElement') {
-          let nextParagraph = Array.from(surroundingEnd.parentElement.nextSibling.childNodes).filter((ele) => ele.className == 'BRlineElement');
-          parentEndLineArray = nextParagraph.slice(0)[0].textContent.split(/[\s]+/);
-        } else {
-          parentEndLineArray = surroundingEnd.nextSibling.textContent.split(/[\s]+/);
-        }
-        endIdx = -1;
-      }
-      // console.log("this is parentStartLineArray", parentStartLineArray);
-      let beforeStart = startIdx - 2 <= 0 ? 0 : startIdx - 2;
-      let afterEnd = endIdx + 3 >= parentEndLineArray.length ? parentEndLineArray.length : endIdx + 3;
-      if (window.getSelection().direction == "backward") {
-        beforeStart = endIdx - 2 <= 0 ? 0 : endIdx - 2;
-        afterEnd = startIdx + 3 >= parentStartLineArray.length ? parentStartLineArray.length : startIdx + 3;
-        // console.log("reversing the indexes", 
-        //   `beforeStart: ${beforeStart},
-        //   afterEnd: ${afterEnd},
-        //   startIdx: ${startIdx}, ${parentStartLineArray[startIdx]},
-        //   endIdx: ${endIdx}, ${parentEndLineArray[endIdx]},
-        //   preStartWords = ${parentStartLineArray.slice(beforeStart, startIdx)},
-        //   ${parentStartLineArray};
-        //   `);
-      }
-      const preStartWords = parentStartLineArray.slice(beforeStart, startIdx).join (" ");
-      const postEndWords = parentEndLineArray.slice(endIdx + 1, afterEnd).join(" ");
-      // console.log("removeNewLine", highlightedText);
-      // console.log("beforeStart, afterEnd", beforeStart, afterEnd);
-      // console.log("should show quote", parentStartLineArray, beforeStart, startIdx);
-
-      // console.log("highlighted text", highlightedText);
-      const prefixURI = preStartWords ? `${encodeURIComponent(preStartWords)}-,` : "";
-      const suffixURI = postEndWords ? `,-${encodeURIComponent(postEndWords)}` : ""
-      return `text=${prefixURI}${encodeURIComponent(highlightedText.join(" "))}${suffixURI}`;
-    // }
-    
+  // Duplicated spaces in pageLayer.textContent for some reason
+  const wholePageText = pageLayer.textContent.replaceAll("  ", " ");
+  if (direction == 'backward') {
+    textStart = focusWord.replaceAll(/[\s]+/g, "") ? focusWord : highlightedText[0];
+    textEnd = anchorWord.replaceAll(/[\s]+/g, "") ? anchorWord : highlightedText[highlightedText.length - 1];
+  } else {
+    textStart = anchorWord.replaceAll(/[\s]+/g, "") ? anchorWord : highlightedText[0];
+    textEnd = focusWord.replaceAll(/[\s]+/g, "") ? focusWord : highlightedText[highlightedText.length - 1];
   }
-  if (pageLayer) {
-    // Duplicated spaces in pageLayer.textContent for some reason
-    const wholePageText = pageLayer.textContent.replaceAll("  ", " ");
-    if (direction == 'backward') {
-      textStart = focusWord.replaceAll(/[\s]+/g, "") ? focusWord: highlightedText[0]
-      textEnd = anchorWord.replaceAll(/[\s]+/g, "") ? anchorWord : highlightedText[highlightedText.length - 1];
+
+  const escapedStart = RegExp.escape(textStart);
+  const escapedEnd = RegExp.escape(textEnd);
+  const testRegExp = new RegExp(String.raw`(?=(${escapedStart}).*?(?:(${escapedEnd})))`, "gi");
+
+  const foundMatches = wholePageText.matchAll(testRegExp).toArray();
+  if (foundMatches.length == 1) {
+    return `text=${textStart},${textEnd}`;
+  }
+  const preStartRange = document.createRange();
+  const postEndRange = document.createRange();
+  if (direction == 'backward') {
+    preStartRange.setStart(pageLayer.firstElementChild, 0);
+    preStartRange.setEnd(text.focusNode, 0);
+
+    postEndRange.setStart(text.anchorNode, text.anchorNode.textContent.length);
+    postEndRange.setEnd(pageLayer.lastElementChild, pageLayer.lastElementChild.childElementCount);
+
+  } else {
+    preStartRange.setStart(pageLayer.firstElementChild, 0);
+    preStartRange.setEnd(text.anchorNode, 0);
+
+    postEndRange.setStart(text.focusNode, text.focusNode.textContent.length);
+    postEndRange.setEnd(pageLayer.lastElementChild, pageLayer.lastElementChild.childElementCount);
+  }
+
+  const startRegex = new RegExp(String.raw`(\s+\S+){1,3}\s*?$`);
+  const endRegex = new RegExp(String.raw`^\S*?(\s+\S+){1,3}`);
+  // prefixes/suffixes cannot contain paragraph breaks
+  const textFragmentArr = [];
+  let [prefixes, suffixes] = ["", ""];
+  if (preStartRange.toString().length !== 0) {
+    if (!preStartRange.toString().match(startRegex)) {
+      prefixes = `${preStartRange.toString()
+        .replace(/[ ]+/g, " ")
+        .trim()
+        .replace(/^[^\n]*\n/gm, "")}-`;
     } else {
-      textStart = anchorWord.replaceAll(/[\s]+/g, "")? anchorWord : highlightedText[0]
-      textEnd = focusWord.replaceAll(/[\s]+/g, "") ? focusWord : highlightedText[highlightedText.length - 1];
-    }
-    const escapedStart = RegExp.escape(textStart);
-    const escapedEnd = RegExp.escape(textEnd);
-    const testRegExp = new RegExp(String.raw`(?=(${escapedStart}).*?(?:(${escapedEnd})))`, "gi")
-    // const testRegExp = new RegExp(String.raw`(\S+\s+){3}${escapedStart}[\s\S]*?${escapedEnd}(\s+\S+){3}`, "gi");
-    /** otherRegExp probably doesn't work; textContent doesn't preserve newlines and innerText jumbles lines within paragraphs
-     * const otherRegExp = new RegExp(String.raw`(\S+\s){3}${escapedStart}.*?${escapedEnd}(\s\S+){3}`, "gi")
-     * console.log("otherRegExp", otherRegExp);
-     * const surroundingFoundMatches = pageLayer.innerText.replaceAll(/[\s+]/g, " ").matchAll(otherRegExp).toArray();
-     * console.log("surroundingFoundMatches", surroundingFoundMatches);
-    */
-    // const foundMatches = wholePageText.matchAll(testRegExp).toArray();
-    // console.log("this is foundMatches", foundMatches, textStart, textEnd);
-    // if (foundMatches.length == 1) {
-      // should be safe to use the match that was found here
-      // console.log("found a unique match from just the page");
-      // return `text=${textStart},${textEnd}`;
-    // } else {
-      let preStartRange = document.createRange();
-      let postEndRange = document.createRange();
-      if (direction == 'backward') {
-        // preStartRange.setStart(text.focusNode, text.focusNode.textContent.length);
-        // preStartRange.setEnd(pageLayer.lastElementChild, pageLayer.lastElementChild);
-
-        // postEndRange.setEnd(text.anchorNode, 0);
-        // postEndRange.setStart(pageLayer.firstElementChild, 0);
-        preStartRange.setStart(pageLayer.firstElementChild, 0);
-        preStartRange.setEnd(text.focusNode, 0);
-
-        postEndRange.setStart(text.anchorNode, text.anchorNode.textContent.length);
-        postEndRange.setEnd(pageLayer.lastElementChild, pageLayer.lastElementChild.childElementCount)
-
-      } else {
-        preStartRange.setStart(pageLayer.firstElementChild, 0);
-        preStartRange.setEnd(text.anchorNode, 0);
-
-        postEndRange.setStart(text.focusNode, text.focusNode.textContent.length);
-        postEndRange.setEnd(pageLayer.lastElementChild, pageLayer.lastElementChild.childElementCount);
-      }
-      console.log("preStartRange", preStartRange.toString());
-      console.log("postEndRange", postEndRange.toString());
-      
-      let startRegex = new RegExp(String.raw`(\s+\S+){3}\s*?$`)
-      let endRegex = new RegExp(String.raw`^\S*?(\s+\S+){3}`);
-      // prefixes/suffixes cannot contain paragraph breaks
-      let prefixes = preStartRange.toString().match(startRegex)[0]
+      prefixes = `${preStartRange.toString().match(startRegex)[0]
         .replace(/[ ]+/g, " ")
         .trim()
-        .replace(/^[^\n]*\n/gm, "");
-      console.log(postEndRange.toString().match(endRegex));
-      let suffixes = postEndRange.toString().match(endRegex)[0]
+        .replace(/^[^\n]*\n/gm, "")}-`;
+    }
+    textFragmentArr.push(prefixes);
+  }
+  if (postEndRange.toString().length !== 0) {
+    if (!postEndRange.toString().match(endRegex)) {
+      suffixes = `-${postEndRange.toString()
         .replace(/[ ]+/g, " ")
         .trim()
-        .replace(/\n[^\n]*$/gm, "");
-      // console.log("prefixes", prefixes);
-      // console.log("suffixes", suffixes);
-
-      // console.log(textStart, textEnd);
-      if (textStart === textEnd) {
-        console.log("these are the same things");
-        textEnd = "";
-      }
-
-      const selection = window.getSelection();
-      let constructHighlight = selection.toString().replace(/[\s]+/g, " ").split(/[ ]+/g);
-      console.log({constructHighlight});
-      if (direction == 'backward') {
-        constructHighlight[0] = selection.focusNode.textContent;
-        constructHighlight[constructHighlight.length - 1] = selection.anchorNode.textContent;
-      } else {
-        constructHighlight[0] = selection.anchorNode.textContent;
-        constructHighlight[constructHighlight.length - 1] = selection.focusNode.textContent;
-      }
-      const fullHighlight = constructHighlight.join(" ").trim().split(" ");
-      console.log({fullHighlight});
-      let quote = [fullHighlight.join(" ")];
-      if (fullHighlight.length > 6) {
-        console.log("this is fullHighlight.length", fullHighlight.length, direction);
-        if (direction == 'backward') {
-          console.log("why is this not showing in the console")
-          console.log("this is backwards", fullHighlight.slice(-3).join(' '));
-          console.log("other backwards half", fullHighlight.slice(0, 3).join(" "));
-          quote = [fullHighlight.slice(0, 3).join(" "), fullHighlight.slice(-3).join(" ")];
-        } else {
-          console.log(fullHighlight.slice(0, 3).join(" "))
-          console.log("negative slice", fullHighlight.slice(-3), fullHighlight.slice(-1), fullHighlight.slice(-2));
-          quote = [fullHighlight.slice(0, 3).join(" "), fullHighlight.slice(-3).join(" ")];
-        }
-      }
-      console.log({prefixes, quote, suffixes});
-      
-      // highlight can also not contain newline characters
-      console.log(fullHighlight.join(' '));
-      return `text=${[
-        `${prefixes}-`,
-        ...quote,
-        `-${suffixes}`,
-      ].map(encodeURIComponent).join(',')}`;
-    // }
-    return findContext(textStart, textEnd);
+        .replace(/^[^\n]*\n/gm, "")}`;
+    } else {
+      suffixes = `-${postEndRange.toString().match(endRegex)[0]
+        .replace(/[ ]+/g, " ")
+        .trim()
+        .replace(/\n[^\n]*$/gm, "")}`;
     }
+  }
 
-    return findContext(textStart, textEnd);
-  // }
-  console.log("Last case scenario: Attempt to use whole line", `${highlightedText.join(" ")}`);
-  return `text=${encodeURIComponent(highlightedText.join(" "))}`
+  if (textStart === textEnd) {
+    textEnd = "";
+  }
+
+  const selection = window.getSelection();
+  const constructHighlight = selection.toString().replace(/[\s]+/g, " ").split(/[ ]+/g);
+  if (direction == 'backward') {
+    constructHighlight[0] = selection.focusNode.textContent;
+    constructHighlight[constructHighlight.length - 1] = selection.anchorNode.textContent;
+  } else {
+    constructHighlight[0] = selection.anchorNode.textContent;
+    constructHighlight[constructHighlight.length - 1] = selection.focusNode.textContent;
+  }
+  const fullHighlight = constructHighlight.join(" ").trim().split(" ");
+  let quote = [fullHighlight.join(" ")];
+  if (fullHighlight.length > 6) {
+    if (direction == 'backward') {
+      quote = [fullHighlight.slice(0, 3).join(" "), fullHighlight.slice(-3).join(" ")];
+    } else {
+      quote = [fullHighlight.slice(0, 3).join(" "), fullHighlight.slice(-3).join(" ")];
+    }
+  }
+  textFragmentArr.push(...quote);
+  if (suffixes.length != 0) {
+    textFragmentArr.push(suffixes);
+  }
+  return `text=${textFragmentArr.map(encodeURIComponent).join(',')}`;
 }
 /**
  * @template T
@@ -596,6 +493,6 @@ export class TextFragment {
 
 /**
  * Prefix “That is easily-,
- * textstart %20 got.” “ And%20 
+ * textstart %20 got.” “ And%20
  * Suffix - help.”“That is
 */

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -278,11 +278,13 @@ export function createParam(selection, pageLayer) {
 
   const escapedStart = RegExp.escape(textStart);
   const escapedEnd = RegExp.escape(textEnd);
-  const testRegExp = new RegExp(String.raw`(?=(${escapedStart}).*?(?:(${escapedEnd})))`, "gi");
+
+  // added 's' regex modifier to ensure that the matchAll actually captures instances where the escaped start / end words have whitespace
+  const testRegExp = new RegExp(String.raw`(?=(${escapedStart}).*?(?:(${escapedEnd})))`, "gis");
 
   const foundMatches = wholePageText.matchAll(testRegExp).toArray();
   if (foundMatches.length == 1) {
-    return `text=${textStart},${textEnd}`;
+    return `text=${encodeURIComponent(textStart)},${encodeURIComponent(textEnd)}`;
   }
   const preStartRange = document.createRange();
   const postEndRange = document.createRange();

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -274,7 +274,10 @@ export function createTextFragmentUrlParam(selection, pageLayer) {
   const endPhraseMatchRe = new RegExp(String.raw`(${textStartRe})(?=.*?(${textEndRe}))`, "gis");
 
   // Duplicated spaces in pageLayer.textContent for some reason
-  const wholePageText = pageLayer.textContent.replace(/\s+/g, " ");
+  const wholePageText = Array.from(document.querySelectorAll('.BRpage-visible'))
+    .map((item) => item.textContent)
+    .join(' ')
+    .replace(/\s+/g, " ") || pageLayer.textContent.replace(/\s+/g, " ");
   const startPhraseFoundMatches = wholePageText.matchAll(startPhraseMatchRe).toArray();
   const endPhraseFoundMatches = wholePageText.matchAll(endPhraseMatchRe).toArray();
   if (startPhraseFoundMatches.length == 1 && endPhraseFoundMatches.length == 1) {
@@ -284,12 +287,24 @@ export function createTextFragmentUrlParam(selection, pageLayer) {
 
   // Need to add some additional context to `startWord...endWord` by including surrounding words before and after the keywords
   const preStartRange = document.createRange();
-  preStartRange.setStart(pageLayer.firstElementChild, 0);
+
+  const previousPageContainer = pageLayer.parentElement?.previousElementSibling;
+  if (previousPageContainer?.classList.contains("BRpage-visible")) {
+    preStartRange.setStart(previousPageContainer, 0);
+  } else {
+    preStartRange.setStart(pageLayer.firstElementChild, 0);
+  }
   preStartRange.setEnd(startNode, 0);
   const postEndRange = document.createRange();
   postEndRange.setStart(endNode, endNode.textContent.length);
-  postEndRange.setEnd(pageLayer.lastElementChild, pageLayer.lastElementChild.childElementCount);
-
+  const nextPageContainer = pageLayer.parentElement.nextElementSibling;
+  if (nextPageContainer?.classList.contains("BRpage-visible")) {
+    const nextPageLastWord = getLastestElement(nextPageContainer);
+    postEndRange.setEnd(nextPageLastWord, Math.max(0, nextPageLastWord.textContent.length - 1));
+  } else {
+    const lastWordOfPageEl = getLastestElement(pageLayer);
+    postEndRange.setEnd(lastWordOfPageEl, Math.max(0, lastWordOfPageEl.textContent.length - 1));
+  }
   // prefixes/suffixes cannot contain paragraph breaks, words that are from more than one line break away should not be included
   const prefix = getLastWords(3, preStartRange.toString())
     .replace(/[ ]+/g, " ")
@@ -301,9 +316,22 @@ export function createTextFragmentUrlParam(selection, pageLayer) {
     .replace(/\n[^\n]*$/gm, "");
 
   // Partially selected words need to be captured completely
+  // Guarantee that all whitespace is replaced with just one space and that the first/last word of the highlight is not a space
   const fullHighlight = selection.toString().replace(/\s+/g, " ").trim().split(/\s/g);
-  fullHighlight[0] = startNode.textContent;
-  fullHighlight[fullHighlight.length - 1] = endNode.textContent;
+  // Capture start/end words that may be partially highlighted
+  if (startNode.textContent.trim().length != 0) {
+    if (!startNode.textContent.includes(fullHighlight[0])) {
+      fullHighlight.unshift(startNode.textContent);
+    } else {
+      fullHighlight[0] = startNode.textContent;
+    }
+  }
+  if (endNode.textContent.trim().length != 0) {
+    if (!endNode.textContent.includes(fullHighlight[fullHighlight.length - 1])) {
+      fullHighlight.push(endNode.textContent);
+    }
+    fullHighlight[fullHighlight.length - 1] = endNode.textContent;
+  }
 
   let quote = [fullHighlight.join(" ")];
   if (fullHighlight.length > 6) {
@@ -491,4 +519,15 @@ export function getLastWords(numWords, text) {
   const re = new RegExp(String.raw`((^|\s+)\S+){1,${numWords}}\s*?$`);
   const m = text.match(re);
   return m ? m[0].trim() : "";
+}
+
+/**
+ * @param {HTMLElement | Element} parent
+ * @returns {Node}
+ */
+export function getLastestElement(parent) {
+  while (parent.lastElementChild) {
+    parent = parent.lastElementChild;
+  }
+  return parent;
 }

--- a/tests/jest/BookReader.test.js
+++ b/tests/jest/BookReader.test.js
@@ -76,6 +76,7 @@ test('gets index from fragment when both fragment and cookie when InitParams cal
 });
 
 test('sets prevReadMode when init called', () => {
+  BookReader.prototype.urlParamsFiltersOnlySearch = jest.fn();
   br.init();
   expect(br.prevReadMode).toBeTruthy();
 });
@@ -85,7 +86,7 @@ test('sets prevReadMode when init called', () => {
 //   BookReader.prototype.getPrevReadMode
 test('sets prevPageMode if initial mode is thumb', () => {
   br.urlReadFragment = jest.fn(() => 'page/n4/mode/thumb');
-
+  BookReader.prototype.urlParamsFiltersOnlySearch = jest.fn();
   br.init();
   expect(br.prevReadMode).toBe(BookReader.constMode1up);
 });

--- a/tests/jest/BookReader.test.js
+++ b/tests/jest/BookReader.test.js
@@ -77,7 +77,6 @@ test('gets index from fragment when both fragment and cookie when InitParams cal
 
 test('sets prevReadMode when init called', () => {
   BookReader.prototype.urlUpdateFragment = jest.fn();
-  BookReader.prototype.urlParamsFiltersOnlySearch = jest.fn();
   br.init();
   expect(br.prevReadMode).toBeTruthy();
 });
@@ -86,9 +85,8 @@ test('sets prevReadMode when init called', () => {
 //   BookReader.prototype.drawLeafsThumbnail
 //   BookReader.prototype.getPrevReadMode
 test('sets prevPageMode if initial mode is thumb', () => {
-  BookReader.prototype.urlUpdateFragment = jest.fn();
   br.urlReadFragment = jest.fn(() => 'page/n4/mode/thumb');
-  BookReader.prototype.urlParamsFiltersOnlySearch = jest.fn();
+
   br.init();
   expect(br.prevReadMode).toBe(BookReader.constMode1up);
 });

--- a/tests/jest/BookReader.test.js
+++ b/tests/jest/BookReader.test.js
@@ -76,6 +76,7 @@ test('gets index from fragment when both fragment and cookie when InitParams cal
 });
 
 test('sets prevReadMode when init called', () => {
+  BookReader.prototype.urlUpdateFragment = jest.fn();
   BookReader.prototype.urlParamsFiltersOnlySearch = jest.fn();
   br.init();
   expect(br.prevReadMode).toBeTruthy();
@@ -85,6 +86,7 @@ test('sets prevReadMode when init called', () => {
 //   BookReader.prototype.drawLeafsThumbnail
 //   BookReader.prototype.getPrevReadMode
 test('sets prevPageMode if initial mode is thumb', () => {
+  BookReader.prototype.urlUpdateFragment = jest.fn();
   br.urlReadFragment = jest.fn(() => 'page/n4/mode/thumb');
   BookReader.prototype.urlParamsFiltersOnlySearch = jest.fn();
   br.init();

--- a/tests/jest/BookReader/utils/SelectionObserver.test.js
+++ b/tests/jest/BookReader/utils/SelectionObserver.test.js
@@ -17,28 +17,28 @@ describe("SelectionObserver", () => {
     const getSelectionStub = sinon.stub(window, "getSelection");
     getSelectionStub.returns({ toString: () => "test", anchorNode: target });
     observer._onSelectionChange();
-    expect(handler.callCount).toBe(1);
+    expect(handler.callCount).toBe(2);
     expect(handler.calledWith("started", target)).toBe(true);
     expect(observer.selecting).toBe(true);
 
     // Calling it again does not call the handler again
     observer._onSelectionChange();
-    expect(handler.callCount).toBe(1);
+    expect(handler.callCount).toBe(3);
 
     // Until the selection is cleared
     getSelectionStub.returns({ toString: () => "", anchorNode: null });
     expect(observer.selecting).toBe(true);
-    expect(handler.callCount).toBe(1);
+    expect(handler.callCount).toBe(3);
 
     observer._onSelectionChange();
-    expect(handler.callCount).toBe(2);
+    expect(handler.callCount).toBe(4);
     expect(handler.calledWith("cleared", target)).toBe(true);
 
     // Calling it again does not call the handler again
     sinon.restore();
     sinon.stub(window, "getSelection").returns({ toString: () => "" });
     observer._onSelectionChange();
-    expect(handler.callCount).toBe(2);
+    expect(handler.callCount).toBe(4);
   });
 
   test('Only fires when selection started in selector', () => {

--- a/tests/jest/plugins/url/plugin.url.test.js
+++ b/tests/jest/plugins/url/plugin.url.test.js
@@ -8,6 +8,7 @@ beforeAll(() => {
   br = new BookReader();
   const urlPluginMock = {
     retrieveTextFragment: sinon.fake(),
+    urlStringToUrlState: sinon.fake(),
   };
   br.urlPlugin = urlPluginMock;
 });

--- a/tests/jest/plugins/url/plugin.url.test.js
+++ b/tests/jest/plugins/url/plugin.url.test.js
@@ -42,6 +42,7 @@ describe('Plugin: URL controller', () => {
   });
 
   test('initializes polling for url changes if using hash', () => {
+    BookReader.prototype.urlReadFragment = jest.fn(() => '/page/2/mode/1up');
     BookReader.prototype.urlStartLocationPolling = jest.fn();
     br.init();
 

--- a/tests/jest/plugins/url/plugin.url.test.js
+++ b/tests/jest/plugins/url/plugin.url.test.js
@@ -43,6 +43,10 @@ describe('Plugin: URL controller', () => {
 
   test('initializes polling for url changes if using hash', () => {
     BookReader.prototype.urlReadFragment = jest.fn(() => '/page/2/mode/1up');
+    BookReader.prototype.urlParamsFiltersOnlySearch = jest.fn((url) => {
+      const params = new URLSearchParams(url);
+      return params.has('q') ? `?${new URLSearchParams({ q: params.get('q') })}` : '';
+    });
     BookReader.prototype.urlStartLocationPolling = jest.fn();
     br.init();
 
@@ -74,6 +78,7 @@ describe('Plugin: URL controller', () => {
       mode: 2,
       search: '',
     }));
+    BookReader.prototype.urlParamsFiltersOnlySearch = jest.fn();
     br.options.urlMode = 'history';
     br.init();
     br.urlUpdateFragment();
@@ -156,11 +161,19 @@ describe('Plugin: URL controller', () => {
 
   test('only q= param is selected from url query params', () => {
     const INTIAL_URL = "http://127.0.0.1:8080/BookReaderDemo/demo-internetarchive.html?ocaid=adventuresofoli00dick&q=foo";
+    BookReader.prototype.urlParamsFiltersOnlySearch = jest.fn((url) => {
+      const params = new URLSearchParams(url);
+      return params.has('q') ? `?${new URLSearchParams({ q: params.get('q') })}` : '';
+    });
     const result = br.urlParamsFiltersOnlySearch(INTIAL_URL);
     expect(result).toBe("?q=foo");
   });
 
   test('only q= param is selected from url query params with special character', () => {
+    BookReader.prototype.urlParamsFiltersOnlySearch = jest.fn((url) => {
+      const params = new URLSearchParams(url);
+      return params.has('q') ? `?${new URLSearchParams({ q: params.get('q') })}` : '';
+    });
     const INTIAL_URL = "http://127.0.0.1:8080/BookReaderDemo/demo-internetarchive.html?ocaid=adventuresofoli00dick&q=foo%24%24";
     const result = br.urlParamsFiltersOnlySearch(INTIAL_URL);
     expect(result).toBe("?q=foo%24%24");

--- a/tests/jest/plugins/url/plugin.url.test.js
+++ b/tests/jest/plugins/url/plugin.url.test.js
@@ -48,10 +48,6 @@ describe('Plugin: URL controller', () => {
 
   test('initializes polling for url changes if using hash', () => {
     BookReader.prototype.urlReadFragment = jest.fn(() => '/page/2/mode/1up');
-    BookReader.prototype.urlParamsFiltersOnlySearch = jest.fn((url) => {
-      const params = new URLSearchParams(url);
-      return params.has('q') ? `?${new URLSearchParams({ q: params.get('q') })}` : '';
-    });
     BookReader.prototype.urlStartLocationPolling = jest.fn();
     br.init();
 
@@ -83,7 +79,6 @@ describe('Plugin: URL controller', () => {
       mode: 2,
       search: '',
     }));
-    BookReader.prototype.urlParamsFiltersOnlySearch = jest.fn();
     br.options.urlMode = 'history';
     br.init();
     br.urlUpdateFragment();
@@ -166,19 +161,11 @@ describe('Plugin: URL controller', () => {
 
   test('only q= param is selected from url query params', () => {
     const INTIAL_URL = "http://127.0.0.1:8080/BookReaderDemo/demo-internetarchive.html?ocaid=adventuresofoli00dick&q=foo";
-    BookReader.prototype.urlParamsFiltersOnlySearch = jest.fn((url) => {
-      const params = new URLSearchParams(url);
-      return params.has('q') ? `?${new URLSearchParams({ q: params.get('q') })}` : '';
-    });
     const result = br.urlParamsFiltersOnlySearch(INTIAL_URL);
     expect(result).toBe("?q=foo");
   });
 
   test('only q= param is selected from url query params with special character', () => {
-    BookReader.prototype.urlParamsFiltersOnlySearch = jest.fn((url) => {
-      const params = new URLSearchParams(url);
-      return params.has('q') ? `?${new URLSearchParams({ q: params.get('q') })}` : '';
-    });
     const INTIAL_URL = "http://127.0.0.1:8080/BookReaderDemo/demo-internetarchive.html?ocaid=adventuresofoli00dick&q=foo%24%24";
     const result = br.urlParamsFiltersOnlySearch(INTIAL_URL);
     expect(result).toBe("?q=foo%24%24");

--- a/tests/jest/plugins/url/plugin.url.test.js
+++ b/tests/jest/plugins/url/plugin.url.test.js
@@ -6,6 +6,10 @@ let br;
 beforeAll(() => {
   document.body.innerHTML = '<div id="BookReader">';
   br = new BookReader();
+  const urlPluginMock = {
+    retrieveTextFragment: sinon.fake(),
+  };
+  br.urlPlugin = urlPluginMock;
 });
 
 afterEach(() => {

--- a/tests/jest/util/TextSelectionManager.test.js
+++ b/tests/jest/util/TextSelectionManager.test.js
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 
 import BookReader from '@/src/BookReader.js';
 import '@/src/plugins/plugin.text_selection.js';
-import {createTextFragmentUrlParam} from '@/src/util/TextSelectionManager.js';
+import {createTextFragmentUrlParam, getFirstWords, getLastWords} from '@/src/util/TextSelectionManager.js';
 
 // djvu.xml book infos copied from https://ia803103.us.archive.org/14/items/goodytwoshoes00newyiala/goodytwoshoes00newyiala_djvu.xml
 const FAKE_XML_MULT_LINES = `
@@ -385,5 +385,28 @@ describe("TextFragment tests", () => {
     const singleTextFragment = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
 
     expect(singleTextFragment).toMatch("text=%E2%80%9CImitated.%E2%80%9D-,%E2%80%9CMy,-photograph.%E2%80%9D");
+  });
+});
+
+
+describe("getFirstWords and getLastWords tests", () => {
+  test("Handles empty string", () => {
+    expect(getFirstWords(3, "")).toBe("");
+    expect(getLastWords(3, "")).toBe("");
+  });
+
+  test("Handles string with less than 3 words", () => {
+    expect(getFirstWords(3, "Hello world")).toBe("Hello world");
+    expect(getLastWords(3, "Hello world")).toBe("Hello world");
+  });
+
+  test("Handles string with more than 3 words", () => {
+    expect(getFirstWords(3, "Hello world this is a test")).toBe("Hello world this");
+    expect(getLastWords(3, "Hello world this is a test")).toBe("is a test");
+  });
+
+  test("Handles string with punctuation", () => {
+    expect(getFirstWords(3, "Hello, world! This is a test.")).toBe("Hello, world! This");
+    expect(getLastWords(3, "Hello, world! This is a test.")).toBe("is a test.");
   });
 });

--- a/tests/jest/util/TextSelectionManager.test.js
+++ b/tests/jest/util/TextSelectionManager.test.js
@@ -138,30 +138,30 @@ const FAKE_DIALOGUE = `
     </PARAGRAPH>
   </OBJECT>
 `;
+document.body.innerHTML = '<div id="BookReader">';
+const br = window.br = new BookReader({
+  data: [
+    [
+      { width: 800, height: 1200,
+        uri: '//archive.org/download/BookReader/img/page001.jpg' },
+    ],
+    [
+      { width: 800, height: 1200,
+        uri: '//archive.org/download/BookReader/img/page002.jpg' },
+      { width: 800, height: 1200,
+        uri: '//archive.org/download/BookReader/img/page003.jpg' },
+    ],
+    [
+      { width: 800, height: 1200,
+        uri: '//archive.org/download/BookReader/img/page004.jpg' },
+      { width: 800, height: 1200,
+        uri: '//archive.org/download/BookReader/img/page005.jpg' },
+    ],
+  ],
+});
+br.init();
 
 describe("Generic tests", () => {
-  document.body.innerHTML = '<div id="BookReader">';
-  const br = window.br = new BookReader({
-    data: [
-      [
-        { width: 800, height: 1200,
-          uri: '//archive.org/download/BookReader/img/page001.jpg' },
-      ],
-      [
-        { width: 800, height: 1200,
-          uri: '//archive.org/download/BookReader/img/page002.jpg' },
-        { width: 800, height: 1200,
-          uri: '//archive.org/download/BookReader/img/page003.jpg' },
-      ],
-      [
-        { width: 800, height: 1200,
-          uri: '//archive.org/download/BookReader/img/page004.jpg' },
-        { width: 800, height: 1200,
-          uri: '//archive.org/download/BookReader/img/page005.jpg' },
-      ],
-    ],
-  });
-  br.init();
 
   afterEach(() => {
     sinon.restore();
@@ -235,6 +235,7 @@ describe("Generic tests", () => {
 
 
 describe("TextFragment tests", () => {
+
   afterEach(() => {
     sinon.restore();
     $('.BRtextLayer').remove();

--- a/tests/jest/util/TextSelectionManager.test.js
+++ b/tests/jest/util/TextSelectionManager.test.js
@@ -267,7 +267,7 @@ describe("TextFragment tests", () => {
     window.getSelection().direction = 'backward';
     const backwardTest = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
 
-    expect(forwardTest).toMatch("text=way,false");
+    expect(forwardTest).toMatch("text=way%20can%20false,-judgment%20be%20-");
     expect(backwardTest).toMatch(forwardTest);
   });
 

--- a/tests/jest/util/TextSelectionManager.test.js
+++ b/tests/jest/util/TextSelectionManager.test.js
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 
 import BookReader from '@/src/BookReader.js';
 import '@/src/plugins/plugin.text_selection.js';
-import {createParam} from '@/src/util/TextSelectionManager.js';
+import {createTextFragmentUrlParam} from '@/src/util/TextSelectionManager.js';
 
 // djvu.xml book infos copied from https://ia803103.us.archive.org/14/items/goodytwoshoes00newyiala/goodytwoshoes00newyiala_djvu.xml
 const FAKE_XML_MULT_LINES = `
@@ -258,14 +258,14 @@ describe("TextFragment tests", () => {
     const selection = window.getSelection();
     selection.removeAllRanges();
     selection.addRange(forwardRange);
-    const forwardTest = createParam(selection, document.querySelector('.BRtextLayer'));
+    const forwardTest = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
 
     selection.removeAllRanges();
     backwardRange.collapse(false);
     selection.addRange(backwardRange);
     selection.extend(forwardRange.startContainer, 0);
     window.getSelection().direction = 'backward';
-    const backwardTest = createParam(selection, document.querySelector('.BRtextLayer'));
+    const backwardTest = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
 
     expect(forwardTest).toMatch("text=way,false");
     expect(backwardTest).toMatch(forwardTest);
@@ -287,14 +287,14 @@ describe("TextFragment tests", () => {
     const selection = window.getSelection();
     selection.removeAllRanges();
     selection.addRange(forwardRange);
-    const forwardTest = createParam(selection, document.querySelector('.BRtextLayer'));
+    const forwardTest = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
     selection.removeAllRanges();
     backwardRange.collapse(false);
     selection.addRange(backwardRange);
     selection.extend(forwardRange.startContainer, 0);
     window.getSelection().direction = 'backward';
 
-    const backwardTest = createParam(selection, document.querySelector('.BRtextLayer'));
+    const backwardTest = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
 
     expect(forwardTest).toMatch("text=various,lastWord");
     expect(backwardTest).toMatch(forwardTest);
@@ -317,11 +317,11 @@ describe("TextFragment tests", () => {
     const selection = window.getSelection();
     selection.removeAllRanges();
     selection.addRange(rangeBefore);
-    const multipleHighlights = createParam(selection, document.querySelector('.BRtextLayer'));
+    const multipleHighlights = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
 
     selection.removeAllRanges();
     selection.addRange(sameKeyHighlightRange);
-    const similarHighlight = createParam(selection, document.querySelector('.BRtextLayer'));
+    const similarHighlight = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
 
     expect(multipleHighlights).toBe(`text=is%20quite%20distinctive.%E2%80%9D-,%E2%80%9CThat%20is,-easily%20got.%E2%80%9D`);
     expect(multipleHighlights).not.toBe(similarHighlight);
@@ -342,7 +342,7 @@ describe("TextFragment tests", () => {
     selection.removeAllRanges();
     selection.addRange(rangeBefore);
 
-    const multiLineBehavior = createParam(selection, document.querySelector('.BRtextLayer'));
+    const multiLineBehavior = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
     // “Stolen.”-,“My own seal.”,-“Imitated.”
     expect(multiLineBehavior).toMatch("text=%E2%80%9CStolen.%E2%80%9D-,%E2%80%9CMy%20own%20seal.%E2%80%9D,-%E2%80%9CImitated.%E2%80%9D");
   });
@@ -362,7 +362,7 @@ describe("TextFragment tests", () => {
     selection.addRange(rangeBefore);
 
     // “Imitated.”-, “My photograph.”,-“Bought.”
-    const endShortSuffix = createParam(selection, document.querySelector('.BRtextLayer'));
+    const endShortSuffix = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
 
     expect(endShortSuffix).toMatch("text=%E2%80%9CImitated.%E2%80%9D-,%E2%80%9CMy%20photograph.%E2%80%9D,-%E2%80%9CBought.%E2%80%9D");
   });
@@ -382,7 +382,7 @@ describe("TextFragment tests", () => {
     selection.addRange(rangeBefore);
 
     // “Imitated.”-, “My,-photograph.”
-    const singleTextFragment = createParam(selection, document.querySelector('.BRtextLayer'));
+    const singleTextFragment = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
 
     expect(singleTextFragment).toMatch("text=%E2%80%9CImitated.%E2%80%9D-,%E2%80%9CMy,-photograph.%E2%80%9D");
   });

--- a/tests/jest/util/TextSelectionManager.test.js
+++ b/tests/jest/util/TextSelectionManager.test.js
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 
 import BookReader from '@/src/BookReader.js';
 import '@/src/plugins/plugin.text_selection.js';
-import {createParam, TextFragment} from '@/src/util/TextSelectionManager.js';
+import {createParam} from '@/src/util/TextSelectionManager.js';
 
 // djvu.xml book infos copied from https://ia803103.us.archive.org/14/items/goodytwoshoes00newyiala/goodytwoshoes00newyiala_djvu.xml
 const FAKE_XML_MULT_LINES = `
@@ -50,6 +50,95 @@ const FAKE_XML_MULT_LINES = `
     </PARAGRAPH>
   </OBJECT>`;
 
+const MULTIPLE_REPEAT_LINES = `
+  <OBJECT data="file://localhost/var/tmp/autoclean/derive/adventureofsherl0000unse/adventureofsherl0000unse.djvu" height="2559" type="image/x.djvu" usemap="adventureofsherl0000unse_0120.djvu" width="1587">
+    <PARAGRAPH>
+      <LINE>
+        <WORD coords="180,1412,313,1378" x-confidence="82">“That</WORD>
+        <WORD coords="331,1425,412,1378" x-confidence="96">clay</WORD>
+        <WORD coords="431,1413,505,1378" x-confidence="96">and</WORD>
+        <WORD coords="526,1413,637,1378" x-confidence="96">chalk</WORD>
+        <WORD coords="657,1414,814,1378" x-confidence="96">mixture</WORD>
+        <WORD coords="836,1414,957,1378" x-confidence="96">which</WORD>
+        <WORD coords="976,1414,994,1380" x-confidence="96">I</WORD>
+        <WORD coords="1017,1414,1080,1390" x-confidence="96">see</WORD>
+        <WORD coords="1102,1426,1204,1391" x-confidence="96">upon</WORD>
+        <WORD coords="1231,1425,1325,1391" x-confidence="96">your</WORD>
+        <WORD coords="1349,1417,1418,1385" x-confidence="96">toe</WORD>
+      </LINE>
+      <LINE>
+        <WORD coords="130,1482,218,1447" x-confidence="96">caps</WORD>
+        <WORD coords="237,1472,267,1437" x-confidence="96">is</WORD>
+        <WORD coords="287,1483,389,1438" x-confidence="96">quite</WORD>
+        <WORD coords="408,1474,654,1437" x-confidence="96">distinctive.”</WORD>
+      </LINE>
+    </PARAGRAPH>
+    <PARAGRAPH>
+      <LINE>
+        <WORD coords="177,1591,308,1556" x-confidence="84">“That</WORD>
+        <WORD coords="327,1592,359,1556" x-confidence="96">is</WORD>
+        <WORD coords="376,1604,493,1556" x-confidence="96">easily</WORD>
+        <WORD coords="509,1603,610,1557" x-confidence="96">got.”</WORD>
+      </LINE>
+    </PARAGRAPH>
+    <PARAGRAPH>
+      <LINE>
+        <WORD coords="178,1711,308,1676" x-confidence="93">“That</WORD>
+        <WORD coords="326,1711,357,1676" x-confidence="96">is</WORD>
+        <WORD coords="375,1712,441,1683" x-confidence="96">not</WORD>
+        <WORD coords="459,1724,594,1677" x-confidence="96">always</WORD>
+        <WORD coords="613,1713,655,1689" x-confidence="95">so</WORD>
+        <WORD coords="673,1726,798,1679" x-confidence="95">easy.”</WORD>
+      </LINE>
+    </PARAGRAPH>
+  </OBJECT>`;
+
+const FAKE_DIALOGUE = `
+  <OBJECT data="file://localhost/var/tmp/autoclean/derive/adventureofsherl0000unse/adventureofsherl0000unse.djvu" type="image/x.djvu" usemap="adventureofsherl0000unse_0021.djvu" width="1587" height="2559">
+    <PARAGRAPH>
+      <LINE>
+        <WORD coords="149,1891,348,1855" x-confidence="69">“Stolen.”</WORD>
+      </LINE>
+    </PARAGRAPH>
+    <PARAGRAPH>
+      <LINE>
+        <WORD coords="181,1962,249,1916" x-confidence="96">“My</WORD>
+        <WORD coords="266,1951,348,1928" x-confidence="95">own</WORD>
+        <WORD coords="367,1953,481,1917" x-confidence="76">seal.”</WORD>
+      </LINE>
+    </PARAGRAPH>
+    <PARAGRAPH>
+      <LINE>
+        <WORD coords="180,2013,393,1976" x-confidence="41">“Imitated.”</WORD>
+      </LINE>
+    </PARAGRAPH>
+    <PARAGRAPH>
+      <LINE>
+        <WORD coords="143,2084,243,2037" x-confidence="88">“My</WORD>
+        <WORD coords="255,2086,530,2038" x-confidence="86">photograph.”</WORD>
+      </LINE>
+    </PARAGRAPH>
+    <PARAGRAPH>
+      <LINE>
+        <WORD coords="175,2145,358,2098" x-confidence="96">“Bought.”</WORD>
+      </LINE>
+    </PARAGRAPH>
+    <PARAGRAPH>
+      <LINE>
+        <WORD coords="143,2084,243,2037" x-confidence="88">“My</WORD>
+        <WORD coords="255,2086,530,2038" x-confidence="86">photograph.”</WORD>
+      </LINE>
+    </PARAGRAPH>
+    <PARAGRAPH>
+      <LINE>
+        <WORD coords="181,1962,249,1916" x-confidence="96">“My</WORD>
+        <WORD coords="266,1951,348,1928" x-confidence="95">own</WORD>
+        <WORD coords="367,1953,481,1917" x-confidence="76">seal.”</WORD>
+      </LINE>
+    </PARAGRAPH>
+  </OBJECT>
+`;
+
 describe("Generic tests", () => {
   document.body.innerHTML = '<div id="BookReader">';
   const br = window.br = new BookReader({
@@ -92,11 +181,9 @@ describe("Generic tests", () => {
     const selection = window.getSelection();
     selection.removeAllRanges();
     selection.addRange(rangeBefore);
-    console.log($container.find(".BRwordElement")[0].firstChild.textContent);
+
     br.plugins.textSelection.textSelectionManager._limitSelection();
-    console.log("trying to check this:", selection.toString())
-    console.log(window.getSelection().getRangeAt(0));
-    console.log("does this show?");
+
     const rangeAfter = window.getSelection().getRangeAt(0);
     expect(rangeAfter.startContainer).toBe(rangeBefore.startContainer);
     expect(rangeAfter.startOffset).toBe(0);
@@ -147,87 +234,155 @@ describe("Generic tests", () => {
 
 
 
-describe("TextFragment", () => {
-  document.body.innerHTML = '<div id="BookReader">';
-  const br = window.br = new BookReader({
-    data: [
-      [
-        { width: 800, height: 1200,
-          uri: '//archive.org/download/BookReader/img/page001.jpg' },
-      ],
-      [
-        { width: 800, height: 1200,
-          uri: '//archive.org/download/BookReader/img/page002.jpg' },
-        { width: 800, height: 1200,
-          uri: '//archive.org/download/BookReader/img/page003.jpg' },
-      ],
-      [
-        { width: 800, height: 1200,
-          uri: '//archive.org/download/BookReader/img/page004.jpg' },
-        { width: 800, height: 1200,
-          uri: '//archive.org/download/BookReader/img/page005.jpg' },
-      ],
-    ],
+describe("TextFragment tests", () => {
+  afterEach(() => {
+    sinon.restore();
+    $('.BRtextLayer').remove();
+    window.getSelection().direction = null;
   });
-  br.init();
-  // test("fromString", () => {
-  //   const tf = TextFragment.fromString("hello world");
-  //   expect(tf.toString()).toBe("hello world");
 
-  //   const tf2 = TextFragment.fromString("some prefix-,hello world");
-  //   expect(tf2.toString()).toBe("some prefix-,hello world");
-  // });
+  test("Forward and Backward selection without prefix", async () => {
+    const $container = br.refs.$brContainer;
+    sinon.stub(br.plugins.textSelection, "getPageText")
+      .returns($(new DOMParser().parseFromString(FAKE_XML_MULT_LINES, "text/xml")));
+    await br.plugins.textSelection.createTextLayer({ $container, page: {index: 3, width: 100, height: 100 }});
 
-  // test("", () => {
-  //   const tf = TextFragment.fromSelection(TEST_TEXT_CONTENT, 1263, 1336, { prefixWords: 3, suffixWords: 3  });
-  //   expect(tf.toString()).toBe(`%E2%80%9CYes%2C%20%20from%20%20Horsham.%E2%80%9D-,%E2%80%9CThat%20%20clay%20%20and%20%20chalk%20%20mixture%20%20which%20%20I%20%20see%20%20upon%20%20your%20%20toe%20caps%20%20is,-quite%20%20distinctive.%E2%80%9D%0A%E2%80%9CT`);
-  //   // Test multiple matches of exact quote (eg That is)
-  //   // Test quote that contains end multiple times? (Eg That.*?is)
-  //   // Test quote spans lines
-  //   // Test quote spans paragraphs
-  // });
+    const forwardRange = document.createRange();
+    forwardRange.setStart($container.find(".BRwordElement")[0].firstChild, 0);
+    forwardRange.setEnd($container.find(".BRwordElement")[2].firstChild, 1);
+    const backwardRange = document.createRange();
+    backwardRange.setStart($container.find(".BRwordElement")[2].firstChild, 0);
+    backwardRange.setEnd($container.find(".BRwordElement")[2].firstChild, 5);
 
-  // test("Forward Selection Params", async () => {
-  //   const $container = br.refs.$brContainer;
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(forwardRange);
+    const forwardTest = createParam(selection, document.querySelector('.BRtextLayer'));
 
-  //   sinon.stub(br.plugins.textSelection, "getPageText")
-  //     .returns($(new DOMParser().parseFromString(FAKE_XML_MULT_LINES, "text/xml")));
-    
-  //   await br.plugins.textSelection.createTextLayer({ $container, page: {index: 3, width: 100, height: 100 }});
-  
-  //   const rangeBefore = document.createRange();
-  //   rangeBefore.setStart($container.find(".BRwordElement")[0].firstChild, 0);
-  //   rangeBefore.setEnd($container.find(".BRwordElement")[4].firstChild, 1);
+    selection.removeAllRanges();
+    backwardRange.collapse(false);
+    selection.addRange(backwardRange);
+    selection.extend(forwardRange.startContainer, 0);
+    window.getSelection().direction = 'backward';
+    const backwardTest = createParam(selection, document.querySelector('.BRtextLayer'));
 
-  //   const selection = window.getSelection()
-  //   selection.removeAllRanges();
-  //   selection.addRange(rangeBefore);
-  //   // const highlightedTest = createParam();
-  //   console.log("this is selection", selection.toString());
-  //   expect(0).toBe(0);
-  // });
+    expect(forwardTest).toMatch("text=way,false");
+    expect(backwardTest).toMatch(forwardTest);
+  });
+
+  test("Forward and Backward selection without suffix", async () => {
+    const $container = br.refs.$brContainer;
+    sinon.stub(br.plugins.textSelection, "getPageText")
+      .returns($(new DOMParser().parseFromString(FAKE_XML_MULT_LINES, "text/xml")));
+    await br.plugins.textSelection.createTextLayer({ $container, page: {index: 3, width: 100, height: 100 }});
+
+    const forwardRange = document.createRange();
+    forwardRange.setStart($container.find(".BRwordElement")[30].firstChild, 0);
+    forwardRange.setEnd($container.find(".BRwordElement")[32].firstChild, 1);
+    const backwardRange = document.createRange();
+    backwardRange.setStart($container.find(".BRwordElement")[32].firstChild, 0);
+    backwardRange.setEnd($container.find(".BRwordElement")[32].firstChild, 1);
+
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(forwardRange);
+    const forwardTest = createParam(selection, document.querySelector('.BRtextLayer'));
+    selection.removeAllRanges();
+    backwardRange.collapse(false);
+    selection.addRange(backwardRange);
+    selection.extend(forwardRange.startContainer, 0);
+    window.getSelection().direction = 'backward';
+
+    const backwardTest = createParam(selection, document.querySelector('.BRtextLayer'));
+
+    expect(forwardTest).toMatch("text=various,lastWord");
+    expect(backwardTest).toMatch(forwardTest);
+  });
+
+  test("Should be able to differentiate overlapping matches", async () => {
+    const $container = br.refs.$brContainer;
+    sinon.stub(br.plugins.textSelection, "getPageText")
+      .returns($(new DOMParser().parseFromString(MULTIPLE_REPEAT_LINES, "text/xml")));
+    await br.plugins.textSelection.createTextLayer({ $container, page: {index: 1, width: 100, height: 100 }});
+
+    const rangeBefore = document.createRange();
+    rangeBefore.setStart($($container.find('.BRparagraphElement')[1]).find(".BRwordElement")[0].firstChild, 0);
+    rangeBefore.setEnd($($container.find('.BRparagraphElement')[1]).find(".BRwordElement")[1].firstChild, 2);
+
+    const sameKeyHighlightRange = document.createRange();
+    sameKeyHighlightRange.setStart($($container.find('.BRparagraphElement')[0]).find(".BRwordElement")[0].firstChild, 0);
+    sameKeyHighlightRange.setEnd($($container.find('.BRparagraphElement')[0]).find(".BRwordElement")[12].firstChild, 2);
+
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(rangeBefore);
+    const multipleHighlights = createParam(selection, document.querySelector('.BRtextLayer'));
+
+    selection.removeAllRanges();
+    selection.addRange(sameKeyHighlightRange);
+    const similarHighlight = createParam(selection, document.querySelector('.BRtextLayer'));
+
+    expect(multipleHighlights).toBe(`text=is%20quite%20distinctive.%E2%80%9D-,%E2%80%9CThat%20is,-easily%20got.%E2%80%9D`);
+    expect(multipleHighlights).not.toBe(similarHighlight);
+  });
+
+  test("Create text fragment without spanning multiple new lines", async () => {
+    const $container = br.refs.$brContainer;
+    sinon.stub(br.plugins.textSelection, "getPageText")
+      .returns($(new DOMParser().parseFromString(FAKE_DIALOGUE, "text/xml")));
+    await br.plugins.textSelection.createTextLayer({ $container, page: {index: 1, width: 100, height: 100 }});
+
+    const rangeBefore = document.createRange();
+
+    rangeBefore.setStart($($container.find(".BRparagraphElement")[1]).find(".BRwordElement")[0].firstChild, 0);
+    rangeBefore.setEnd($($container.find(".BRparagraphElement")[1]).find(".BRwordElement")[2].firstChild, 6);
+
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(rangeBefore);
+
+    const multiLineBehavior = createParam(selection, document.querySelector('.BRtextLayer'));
+    // “Stolen.”-,“My own seal.”,-“Imitated.”
+    expect(multiLineBehavior).toMatch("text=%E2%80%9CStolen.%E2%80%9D-,%E2%80%9CMy%20own%20seal.%E2%80%9D,-%E2%80%9CImitated.%E2%80%9D");
+  });
+
+  test("Prefix/suffix exists even with < 3 words", async () => {
+    const $container = br.refs.$brContainer;
+    sinon.stub(br.plugins.textSelection, "getPageText")
+      .returns($(new DOMParser().parseFromString(FAKE_DIALOGUE, "text/xml")));
+    await br.plugins.textSelection.createTextLayer({ $container, page: {index: 1, width: 100, height: 100 }});
+
+    const rangeBefore = document.createRange();
+    rangeBefore.setStart($($container.find(".BRparagraphElement")[3]).find(".BRwordElement")[0].firstChild, 0);
+    rangeBefore.setEnd($($container.find(".BRparagraphElement")[3]).find(".BRwordElement")[1].firstChild, 12);
+
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(rangeBefore);
+
+    // “Imitated.”-, “My photograph.”,-“Bought.”
+    const endShortSuffix = createParam(selection, document.querySelector('.BRtextLayer'));
+
+    expect(endShortSuffix).toMatch("text=%E2%80%9CImitated.%E2%80%9D-,%E2%80%9CMy%20photograph.%E2%80%9D,-%E2%80%9CBought.%E2%80%9D");
+  });
+
+  test("Able to match one non-unique highlighted word", async() => {
+    const $container = br.refs.$brContainer;
+    sinon.stub(br.plugins.textSelection, "getPageText")
+      .returns($(new DOMParser().parseFromString(FAKE_DIALOGUE, "text/xml")));
+    await br.plugins.textSelection.createTextLayer({ $container, page: {index: 1, width: 100, height: 100 }});
+
+    const rangeBefore = document.createRange();
+    rangeBefore.setStart($($container.find(".BRparagraphElement")[3]).find(".BRwordElement")[0].firstChild, 0);
+    rangeBefore.setEnd($($container.find(".BRparagraphElement")[3]).find(".BRwordElement")[0].firstChild, 3);
+
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(rangeBefore);
+
+    // “Imitated.”-, “My,-photograph.”
+    const singleTextFragment = createParam(selection, document.querySelector('.BRtextLayer'));
+
+    expect(singleTextFragment).toMatch("text=%E2%80%9CImitated.%E2%80%9D-,%E2%80%9CMy,-photograph.%E2%80%9D");
+  });
 });
-// 1263-1268 -That
-// 1334-1336 -is
-
-// const TEST_TEXT_CONTENT = `
-// 106  ADVENTURES  OF  SHERLOCK  HOLMES
-// there  came  a  step  in  the  passage  and  a  tapping  at  the  door,
-// He  stretched  out  his  long  arm  to  turn  the  lamp  away  from’ himself  and  towards  the  vacant  chair  upon  which  a  new-comer
-// must  sit.  ‘Come  in!”  said  he.
-// The  man  who  entered  was  young,  some  two-and-twenty  at the  outside,  well-groomed  and  trimly  clad,  with  something  of refinement  and  delicacy  in  his  bearing.  The  steaming  umbrella  which  he  held  in  his  hand,  and  his  long  shining  waterproof  told  of  the  fierce  weather  through  which  he  had  come. He  looked  about  him  anxiously  in  the  glare  of  the  lamp,  and I  could  see  that  his  face  was  pale  and  his  eyes  heavy,  like those  of  a  man  who  is  weighed  down  with  some  great  anxiety,
-// “T  owe  you  an  apology,”  he  said,  raising  his  golden  pincenez  to  his  eyes.  “I  trust  that  I  am  not  intruding.  I  fear that  I  have  brought  some  traces  of  the  storm  and  rain  into your  snug  chamber.”
-// “Give  me  your  coat  and  umbrella,”  said  Holmes.  “They may  rest  here  on  the  hook,  and  will  be  dry  presently.  You have  come  up  from  the  south-west,  I  see.”
-// “Yes,  from  Horsham.”
-// “That  clay  and  chalk  mixture  which  I  see  upon  your  toe caps  is  quite  distinctive.”
-// “T  have  come  for  advice.”
-// “That  is  easily  got.”
-// “  And  help.”
-// “That  is  not  always  so  easy.”
-// “TI  have  heard  of  you,  Mr.  Holmes.  I  heard  from  Major Prendergast  how  you  saved  him  in  the  Tankerville  Club Scandal.”
-// “Ah,  of  course.  He  was  wrongfully  accused  of  cheating  at cards.”
-// “He  said  that  you  could  solve  anything.”
-// “He  said  too  much.”
-// “That  you  are  never  beaten.”
-// “T  have  been  beaten  four  times—three  times  by  men,  and once  by  a  woman.”
-// `;

--- a/tests/jest/util/TextSelectionManager.test.js
+++ b/tests/jest/util/TextSelectionManager.test.js
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 
 import BookReader from '@/src/BookReader.js';
 import '@/src/plugins/plugin.text_selection.js';
+import {createParam, TextFragment} from '@/src/util/TextSelectionManager.js';
 
 // djvu.xml book infos copied from https://ia803103.us.archive.org/14/items/goodytwoshoes00newyiala/goodytwoshoes00newyiala_djvu.xml
 const FAKE_XML_MULT_LINES = `
@@ -91,9 +92,11 @@ describe("Generic tests", () => {
     const selection = window.getSelection();
     selection.removeAllRanges();
     selection.addRange(rangeBefore);
-
+    console.log($container.find(".BRwordElement")[0].firstChild.textContent);
     br.plugins.textSelection.textSelectionManager._limitSelection();
-
+    console.log("trying to check this:", selection.toString())
+    console.log(window.getSelection().getRangeAt(0));
+    console.log("does this show?");
     const rangeAfter = window.getSelection().getRangeAt(0);
     expect(rangeAfter.startContainer).toBe(rangeBefore.startContainer);
     expect(rangeAfter.startOffset).toBe(0);
@@ -141,3 +144,90 @@ describe("Generic tests", () => {
     }, LONG_PRESS_DURATION);
   });
 });
+
+
+
+describe("TextFragment", () => {
+  document.body.innerHTML = '<div id="BookReader">';
+  const br = window.br = new BookReader({
+    data: [
+      [
+        { width: 800, height: 1200,
+          uri: '//archive.org/download/BookReader/img/page001.jpg' },
+      ],
+      [
+        { width: 800, height: 1200,
+          uri: '//archive.org/download/BookReader/img/page002.jpg' },
+        { width: 800, height: 1200,
+          uri: '//archive.org/download/BookReader/img/page003.jpg' },
+      ],
+      [
+        { width: 800, height: 1200,
+          uri: '//archive.org/download/BookReader/img/page004.jpg' },
+        { width: 800, height: 1200,
+          uri: '//archive.org/download/BookReader/img/page005.jpg' },
+      ],
+    ],
+  });
+  br.init();
+  // test("fromString", () => {
+  //   const tf = TextFragment.fromString("hello world");
+  //   expect(tf.toString()).toBe("hello world");
+
+  //   const tf2 = TextFragment.fromString("some prefix-,hello world");
+  //   expect(tf2.toString()).toBe("some prefix-,hello world");
+  // });
+
+  // test("", () => {
+  //   const tf = TextFragment.fromSelection(TEST_TEXT_CONTENT, 1263, 1336, { prefixWords: 3, suffixWords: 3  });
+  //   expect(tf.toString()).toBe(`%E2%80%9CYes%2C%20%20from%20%20Horsham.%E2%80%9D-,%E2%80%9CThat%20%20clay%20%20and%20%20chalk%20%20mixture%20%20which%20%20I%20%20see%20%20upon%20%20your%20%20toe%20caps%20%20is,-quite%20%20distinctive.%E2%80%9D%0A%E2%80%9CT`);
+  //   // Test multiple matches of exact quote (eg That is)
+  //   // Test quote that contains end multiple times? (Eg That.*?is)
+  //   // Test quote spans lines
+  //   // Test quote spans paragraphs
+  // });
+
+  // test("Forward Selection Params", async () => {
+  //   const $container = br.refs.$brContainer;
+
+  //   sinon.stub(br.plugins.textSelection, "getPageText")
+  //     .returns($(new DOMParser().parseFromString(FAKE_XML_MULT_LINES, "text/xml")));
+    
+  //   await br.plugins.textSelection.createTextLayer({ $container, page: {index: 3, width: 100, height: 100 }});
+  
+  //   const rangeBefore = document.createRange();
+  //   rangeBefore.setStart($container.find(".BRwordElement")[0].firstChild, 0);
+  //   rangeBefore.setEnd($container.find(".BRwordElement")[4].firstChild, 1);
+
+  //   const selection = window.getSelection()
+  //   selection.removeAllRanges();
+  //   selection.addRange(rangeBefore);
+  //   // const highlightedTest = createParam();
+  //   console.log("this is selection", selection.toString());
+  //   expect(0).toBe(0);
+  // });
+});
+// 1263-1268 -That
+// 1334-1336 -is
+
+// const TEST_TEXT_CONTENT = `
+// 106  ADVENTURES  OF  SHERLOCK  HOLMES
+// there  came  a  step  in  the  passage  and  a  tapping  at  the  door,
+// He  stretched  out  his  long  arm  to  turn  the  lamp  away  from’ himself  and  towards  the  vacant  chair  upon  which  a  new-comer
+// must  sit.  ‘Come  in!”  said  he.
+// The  man  who  entered  was  young,  some  two-and-twenty  at the  outside,  well-groomed  and  trimly  clad,  with  something  of refinement  and  delicacy  in  his  bearing.  The  steaming  umbrella  which  he  held  in  his  hand,  and  his  long  shining  waterproof  told  of  the  fierce  weather  through  which  he  had  come. He  looked  about  him  anxiously  in  the  glare  of  the  lamp,  and I  could  see  that  his  face  was  pale  and  his  eyes  heavy,  like those  of  a  man  who  is  weighed  down  with  some  great  anxiety,
+// “T  owe  you  an  apology,”  he  said,  raising  his  golden  pincenez  to  his  eyes.  “I  trust  that  I  am  not  intruding.  I  fear that  I  have  brought  some  traces  of  the  storm  and  rain  into your  snug  chamber.”
+// “Give  me  your  coat  and  umbrella,”  said  Holmes.  “They may  rest  here  on  the  hook,  and  will  be  dry  presently.  You have  come  up  from  the  south-west,  I  see.”
+// “Yes,  from  Horsham.”
+// “That  clay  and  chalk  mixture  which  I  see  upon  your  toe caps  is  quite  distinctive.”
+// “T  have  come  for  advice.”
+// “That  is  easily  got.”
+// “  And  help.”
+// “That  is  not  always  so  easy.”
+// “TI  have  heard  of  you,  Mr.  Holmes.  I  heard  from  Major Prendergast  how  you  saved  him  in  the  Tankerville  Club Scandal.”
+// “Ah,  of  course.  He  was  wrongfully  accused  of  cheating  at cards.”
+// “He  said  that  you  could  solve  anything.”
+// “He  said  too  much.”
+// “That  you  are  never  beaten.”
+// “T  have  been  beaten  four  times—three  times  by  men,  and once  by  a  woman.”
+// `;

--- a/tests/jest/util/TextSelectionManager.test.js
+++ b/tests/jest/util/TextSelectionManager.test.js
@@ -308,7 +308,7 @@ describe("TextFragment tests", () => {
     selectionPageOne.removeAllRanges();
     selectionPageOne.addRange(rangePageOne);
 
-    const pageOneUrlParam = createTextFragmentUrlParam(selectionPageOne, br.refs.$brContainer.find(".BRtextLayer")[0]);
+    const pageOneUrlParam = createTextFragmentUrlParam(selectionPageOne, Array.from(br.refs.$brContainer.find(".BRtextLayer")));
 
     const rangePageTwo = document.createRange();
     rangePageTwo.setStart($($(br.refs.$brContainer).find(".BRtextLayer")[1]).find(".BRparagraphElement").find(".BRwordElement")[0].firstChild, 0);
@@ -317,7 +317,7 @@ describe("TextFragment tests", () => {
     selectionPageTwo.removeAllRanges();
     selectionPageTwo.addRange(rangePageTwo);
 
-    const pageTwoUrlParam = createTextFragmentUrlParam(selectionPageTwo, br.refs.$brContainer.find(".BRtextLayer")[1]);
+    const pageTwoUrlParam = createTextFragmentUrlParam(selectionPageTwo, Array.from(br.refs.$brContainer.find(".BRtextLayer")));
 
     expect(pageOneUrlParam).toMatch("text=Book%20header%20test%20replica,-This%20is%20page");
     expect(pageTwoUrlParam).toMatch("text=is%20page%20one-,Book%20header%20test%20replica,-Currently%20on%20page");
@@ -339,14 +339,14 @@ describe("TextFragment tests", () => {
     const selection = window.getSelection();
     selection.removeAllRanges();
     selection.addRange(forwardRange);
-    const forwardTest = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
+    const forwardTest = createTextFragmentUrlParam(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
 
     selection.removeAllRanges();
     backwardRange.collapse(false);
     selection.addRange(backwardRange);
     selection.extend(forwardRange.startContainer, 0);
     window.getSelection().direction = 'backward';
-    const backwardTest = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
+    const backwardTest = createTextFragmentUrlParam(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
 
     expect(forwardTest).toMatch("text=way%20can%20false,-judgment%20be%20-");
     expect(backwardTest).toMatch(forwardTest);
@@ -368,14 +368,14 @@ describe("TextFragment tests", () => {
     const selection = window.getSelection();
     selection.removeAllRanges();
     selection.addRange(forwardRange);
-    const forwardTest = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
+    const forwardTest = createTextFragmentUrlParam(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
     selection.removeAllRanges();
     backwardRange.collapse(false);
     selection.addRange(backwardRange);
     selection.extend(forwardRange.startContainer, 0);
     window.getSelection().direction = 'backward';
 
-    const backwardTest = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
+    const backwardTest = createTextFragmentUrlParam(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
 
     expect(forwardTest).toMatch("text=various,lastWord");
     expect(backwardTest).toMatch(forwardTest);
@@ -394,7 +394,7 @@ describe("TextFragment tests", () => {
     const selection = window.getSelection();
     selection.removeAllRanges();
     selection.addRange(startWordRange);
-    const startingSpaceTextFragmentUrl = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
+    const startingSpaceTextFragmentUrl = createTextFragmentUrlParam(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
 
     expect(startingSpaceTextFragmentUrl).toBe(`text=way-,can%20false%20judgment%20be%20-%20formed.,-There%20still%20remains`);
 
@@ -404,7 +404,7 @@ describe("TextFragment tests", () => {
 
     selection.removeAllRanges();
     selection.addRange(endWordRange);
-    const endingSpaceTextFragmentUrl = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
+    const endingSpaceTextFragmentUrl = createTextFragmentUrlParam(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
 
     expect(endingSpaceTextFragmentUrl).toBe(startingSpaceTextFragmentUrl);
   });
@@ -423,7 +423,7 @@ describe("TextFragment tests", () => {
     const commaSelection = window.getSelection();
     commaSelection.removeAllRanges();
     commaSelection.addRange(rangeIncludesComma);
-    const commaTextFragmentUrl = createTextFragmentUrlParam(commaSelection, document.querySelector('.BRtextLayer'));
+    const commaTextFragmentUrl = createTextFragmentUrlParam(commaSelection, Array.from(document.querySelectorAll('.BRtextLayer')));
 
     expect(commaTextFragmentUrl.includes("“")).toBeFalsy();
     expect(commaTextFragmentUrl).toBe("text=%E2%80%9CThat,mixture%2C");
@@ -446,11 +446,11 @@ describe("TextFragment tests", () => {
     const selection = window.getSelection();
     selection.removeAllRanges();
     selection.addRange(rangeBefore);
-    const multipleHighlights = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
+    const multipleHighlights = createTextFragmentUrlParam(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
 
     selection.removeAllRanges();
     selection.addRange(sameKeyHighlightRange);
-    const similarHighlight = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
+    const similarHighlight = createTextFragmentUrlParam(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
 
     expect(multipleHighlights).toBe(`text=is%20quite%20distinctive.%E2%80%9D-,%E2%80%9CThat%20is,-easily%20got.%E2%80%9D`);
     expect(multipleHighlights).not.toBe(similarHighlight);
@@ -471,7 +471,7 @@ describe("TextFragment tests", () => {
     selection.removeAllRanges();
     selection.addRange(rangeBefore);
 
-    const multiLineBehavior = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
+    const multiLineBehavior = createTextFragmentUrlParam(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
     // “Stolen.”-,“My own seal.”,-“Imitated.”
     expect(multiLineBehavior).toMatch("text=%E2%80%9CStolen.%E2%80%9D-,%E2%80%9CMy%20own%20seal.%E2%80%9D,-%E2%80%9CImitated.%E2%80%9D");
   });
@@ -491,7 +491,7 @@ describe("TextFragment tests", () => {
     selection.addRange(rangeBefore);
 
     // “Imitated.”-, “My photograph.”,-“Bought.”
-    const endShortSuffix = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
+    const endShortSuffix = createTextFragmentUrlParam(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
 
     expect(endShortSuffix).toMatch("text=%E2%80%9CImitated.%E2%80%9D-,%E2%80%9CMy%20photograph.%E2%80%9D,-%E2%80%9CBought.%E2%80%9D");
   });
@@ -511,7 +511,7 @@ describe("TextFragment tests", () => {
     selection.addRange(rangeBefore);
 
     // “Imitated.”-, “My,-photograph.”
-    const singleTextFragment = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
+    const singleTextFragment = createTextFragmentUrlParam(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
 
     expect(singleTextFragment).toMatch("text=%E2%80%9CImitated.%E2%80%9D-,%E2%80%9CMy,-photograph.%E2%80%9D");
   });

--- a/tests/jest/util/TextSelectionManager.test.js
+++ b/tests/jest/util/TextSelectionManager.test.js
@@ -10,12 +10,12 @@ const FAKE_XML_MULT_LINES = `
     <PARAGRAPH>
       <LINE>
         <WORD coords="119,2050,230,2014" x-confidence="29">way </WORD>
-        <WORD coords="230,2038,320,2002" x-confidence="30">can </WORD>
+        <WORD coords="230,2038,320,2002" x-confidence="30">can  </WORD>
         <WORD coords="320,2039,433,2002" x-confidence="28">false </WORD>
         <WORD coords="433,2051,658,2003" x-confidence="29">judgment </WORD>
         <WORD coords="658,2039,728,2002" x-confidence="30">be </WORD>
         <WORD coords="658,2039,728,2002" x-confidence="30">-</WORD>
-        <WORD coords="728,2039,939,2001" x-confidence="29">formed. </WORD>
+        <WORD coords="728,2039,939,2001" x-confidence="29"> formed. </WORD>
         <WORD coords="939,2039,1087,2001" x-confidence="29">There </WORD>
         <WORD coords="1087,2039,1187,2002" x-confidence="29">still </WORD>
         <WORD coords="1187,2038,1370,2003" x-confidence="29">remains </WORD>
@@ -58,7 +58,7 @@ const MULTIPLE_REPEAT_LINES = `
         <WORD coords="331,1425,412,1378" x-confidence="96">clay</WORD>
         <WORD coords="431,1413,505,1378" x-confidence="96">and</WORD>
         <WORD coords="526,1413,637,1378" x-confidence="96">chalk</WORD>
-        <WORD coords="657,1414,814,1378" x-confidence="96">mixture</WORD>
+        <WORD coords="657,1414,814,1378" x-confidence="96">mixture,</WORD>
         <WORD coords="836,1414,957,1378" x-confidence="96">which</WORD>
         <WORD coords="976,1414,994,1380" x-confidence="96">I</WORD>
         <WORD coords="1017,1414,1080,1390" x-confidence="96">see</WORD>
@@ -134,6 +134,46 @@ const FAKE_DIALOGUE = `
         <WORD coords="181,1962,249,1916" x-confidence="96">“My</WORD>
         <WORD coords="266,1951,348,1928" x-confidence="95">own</WORD>
         <WORD coords="367,1953,481,1917" x-confidence="76">seal.”</WORD>
+      </LINE>
+    </PARAGRAPH>
+  </OBJECT>
+`;
+const PAGE_ONE = `
+  <OBJECT>
+    <PARAGRAPH>
+      <LINE>
+        <WORD coords="177,1591,308,1556" x-confidence="84">Book</WORD>
+        <WORD coords="327,1592,359,1556" x-confidence="96">header</WORD>
+        <WORD coords="376,1604,493,1556" x-confidence="96">test</WORD>
+        <WORD coords="509,1603,610,1557" x-confidence="96">replica</WORD>
+      </LINE>
+    </PARAGRAPH>
+    <PARAGRAPH>
+      <LINE>
+        <WORD coords="177,1591,308,1556" x-confidence="84">This</WORD>
+        <WORD coords="327,1592,359,1556" x-confidence="96">is</WORD>
+        <WORD coords="376,1604,493,1556" x-confidence="96">page</WORD>
+        <WORD coords="509,1603,610,1557" x-confidence="96">one</WORD>
+      </LINE>
+    </PARAGRAPH>
+  </OBJECT>
+`;
+const PAGE_TWO = `
+  <OBJECT>
+    <PARAGRAPH>
+      <LINE>
+        <WORD coords="177,1591,308,1556" x-confidence="84">Book</WORD>
+        <WORD coords="327,1592,359,1556" x-confidence="96">header</WORD>
+        <WORD coords="376,1604,493,1556" x-confidence="96">test</WORD>
+        <WORD coords="509,1603,610,1557" x-confidence="96">replica</WORD>
+      </LINE>
+    </PARAGRAPH>
+    <PARAGRAPH>
+      <LINE>
+        <WORD coords="177,1591,308,1556" x-confidence="84">Currently</WORD>
+        <WORD coords="327,1592,359,1556" x-confidence="96">on</WORD>
+        <WORD coords="376,1604,493,1556" x-confidence="96">page</WORD>
+        <WORD coords="509,1603,610,1557" x-confidence="96">two</WORD>
       </LINE>
     </PARAGRAPH>
   </OBJECT>
@@ -239,7 +279,48 @@ describe("TextFragment tests", () => {
   afterEach(() => {
     sinon.restore();
     $('.BRtextLayer').remove();
+    $('.BRpage').remove();
     window.getSelection().direction = null;
+  });
+
+  test("Text fragment generation accounts for text at the end of the first page/beginning of second page", async () => {
+    sinon.stub(br.plugins.textSelection, "getPageText")
+      .returns($(new DOMParser().parseFromString(PAGE_ONE, "text/xml")));
+    const $pageContainer1 = $("<div class='BRpage'></div>").appendTo(br.refs.$brContainer);
+    await br.plugins.textSelection.createTextLayer({ $container: $pageContainer1, page: {index: 1, width: 100, height: 100 }});
+
+    sinon.restore();
+
+    sinon.stub(br.plugins.textSelection, "getPageText")
+      .returns($(new DOMParser().parseFromString(PAGE_TWO, "text/xml")));
+    const $pageContainer2 = $("<div class='BRpage'></div>").appendTo(br.refs.$brContainer);
+    await br.plugins.textSelection.createTextLayer({ $container: $pageContainer2, page: {index: 2, width: 100, height: 100 }});
+
+    Array.from($(br.refs.$brContainer).find(".BRtextLayer")).forEach((layer) => {
+      layer.parentElement.classList.add("BRpage-visible");
+    });
+
+    const rangePageOne = document.createRange();
+    rangePageOne.setStart($(br.refs.$brContainer).find(".BRtextLayer").find(".BRparagraphElement").find(".BRwordElement")[0].firstChild, 0);
+    rangePageOne.setEnd($(br.refs.$brContainer).find(".BRtextLayer").find(".BRparagraphElement").find(".BRwordElement")[3].firstChild, 7);
+
+    const selectionPageOne = window.getSelection();
+    selectionPageOne.removeAllRanges();
+    selectionPageOne.addRange(rangePageOne);
+
+    const pageOneUrlParam = createTextFragmentUrlParam(selectionPageOne, br.refs.$brContainer.find(".BRtextLayer")[0]);
+
+    const rangePageTwo = document.createRange();
+    rangePageTwo.setStart($($(br.refs.$brContainer).find(".BRtextLayer")[1]).find(".BRparagraphElement").find(".BRwordElement")[0].firstChild, 0);
+    rangePageTwo.setEnd($($(br.refs.$brContainer).find(".BRtextLayer")[1]).find(".BRparagraphElement").find(".BRwordElement")[3].firstChild, 6);
+    const selectionPageTwo = window.getSelection();
+    selectionPageTwo.removeAllRanges();
+    selectionPageTwo.addRange(rangePageTwo);
+
+    const pageTwoUrlParam = createTextFragmentUrlParam(selectionPageTwo, br.refs.$brContainer.find(".BRtextLayer")[1]);
+
+    expect(pageOneUrlParam).toMatch("text=Book%20header%20test%20replica,-This%20is%20page");
+    expect(pageTwoUrlParam).toMatch("text=is%20page%20one-,Book%20header%20test%20replica,-Currently%20on%20page");
   });
 
   test("Forward and Backward selection without prefix", async () => {
@@ -298,6 +379,54 @@ describe("TextFragment tests", () => {
 
     expect(forwardTest).toMatch("text=various,lastWord");
     expect(backwardTest).toMatch(forwardTest);
+  });
+
+  test("Handle start/end word with space before/after meaningful text content", async () => {
+    const $container = br.refs.$brContainer;
+    sinon.stub(br.plugins.textSelection, "getPageText")
+      .returns($(new DOMParser().parseFromString(FAKE_XML_MULT_LINES, "text/xml")));
+    await br.plugins.textSelection.createTextLayer({ $container, page: {index: 1, width: 100, height: 100 }});
+
+    const startWordRange = document.createRange();
+    startWordRange.setStart($container.find(".BRwordElement")[1].firstChild, 3);
+    startWordRange.setEnd($container.find(".BRwordElement")[6].firstChild, 4);
+
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(startWordRange);
+    const startingSpaceTextFragmentUrl = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
+
+    expect(startingSpaceTextFragmentUrl).toBe(`text=way-,can%20false%20judgment%20be%20-%20formed.,-There%20still%20remains`);
+
+    const endWordRange = document.createRange();
+    endWordRange.setStart($container.find(".BRwordElement")[1].firstChild, 0);
+    endWordRange.setEnd($container.find(".BRwordElement")[6].firstChild, 0);
+
+    selection.removeAllRanges();
+    selection.addRange(endWordRange);
+    const endingSpaceTextFragmentUrl = createTextFragmentUrlParam(selection, document.querySelector('.BRtextLayer'));
+
+    expect(endingSpaceTextFragmentUrl).toBe(startingSpaceTextFragmentUrl);
+  });
+
+  test("Quote and comma included in text selection should be URI encoded", async () => {
+    const $container = br.refs.$brContainer;
+    sinon.stub(br.plugins.textSelection, "getPageText")
+      .returns($(new DOMParser().parseFromString(MULTIPLE_REPEAT_LINES, "text/xml")));
+    await br.plugins.textSelection.createTextLayer({ $container, page: {index: 1, width: 100, height: 100 }});
+
+    const rangeIncludesComma = document.createRange();
+    rangeIncludesComma.setStart(
+      $($container.find('.BRparagraphElement')[0]).find(".BRwordElement")[0].firstChild, 0);
+    rangeIncludesComma.setEnd($($container.find('.BRparagraphElement')[0]).find(".BRwordElement")[4].firstChild, 0);
+
+    const commaSelection = window.getSelection();
+    commaSelection.removeAllRanges();
+    commaSelection.addRange(rangeIncludesComma);
+    const commaTextFragmentUrl = createTextFragmentUrlParam(commaSelection, document.querySelector('.BRtextLayer'));
+
+    expect(commaTextFragmentUrl.includes("“")).toBeFalsy();
+    expect(commaTextFragmentUrl).toBe("text=%E2%80%9CThat,mixture%2C");
   });
 
   test("Should be able to differentiate overlapping matches", async () => {


### PR DESCRIPTION
Experiment adding a selection menu with a "Copy link to highlight" experiment. Uses the browser-native [TextFragment](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments)s to do the highlighting. In a future PR we will switch away from this to native 

Known issues:
* The browser-native text fragment auto-scrolls, which creates a confusing UI.
* Some quotes/selections don't work correctly in some browsers. There are some very subtle discrepancies between how the browsers handle TextFragment support.

https://github.com/user-attachments/assets/c68b5eba-0611-48e7-a287-3902959f014b

