### PR TITLE
Add resolveEl() for shadow DOM compatibility

### DIFF
--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -789,6 +789,24 @@ BookReader.prototype.unbind = function(name, callback) {
 };
 
 /**
+ * Resolves `this.el` to a DOM Element, whether it was provided as an
+ * Element reference or a CSS selector string.
+ *
+ * This is needed because some consumers (e.g. apps using shadow DOM)
+ * must pass a DOM element directly — `document.querySelector` cannot
+ * cross shadow boundaries. jQuery's `$()` already handles both forms,
+ * but code that calls `document.querySelector(br.el)` will fail when
+ * `el` is an Element or when the target is inside a shadow root.
+ *
+ * @returns {Element|null}
+ */
+BookReader.prototype.resolveEl = function() {
+  if (this.el instanceof Element) return this.el;
+  if (typeof this.el === 'string') return document.querySelector(this.el);
+  return null;
+};
+
+/**
  * Resizes based on the container width and height
  */
 BookReader.prototype.resize = function() {

--- a/src/ia-bookreader/ia-bookreader.js
+++ b/src/ia-bookreader/ia-bookreader.js
@@ -337,7 +337,7 @@ export class IaBookReader extends LitElement {
 
   /** gets element that houses the bookreader in light dom */
   get mainBRContainer() {
-    return document.querySelector(this.bookreader?.el);
+    return this.bookreader?.resolveEl?.() ?? document.querySelector(this.bookreader?.el);
   }
 
   get baseProviderConfig() {

--- a/src/plugins/search/view.js
+++ b/src/plugins/search/view.js
@@ -331,7 +331,8 @@ class SearchView {
     const modal = document.createElement('div');
     modal.classList.add('BRprogresspopup', 'search_modal');
     modal.innerHTML = messageHTML;
-    document.querySelector(this.br.el).append(modal);
+    const container = this.br.resolveEl?.() ?? document.querySelector(this.br.el);
+    container?.append(modal);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds `BookReader.prototype.resolveEl()` that handles `el` as either a DOM Element or CSS selector string
- Updates `mainBRContainer` getter in ia-bookreader to use `resolveEl()`
- Updates search plugin's `renderModalMessage` to use `resolveEl()`

## Problem
`document.querySelector(br.el)` fails when:
- `br.el` is a DOM Element (not a string) — throws `SyntaxError: '[object HTMLDivElement]' is not a valid selector`
- `br.el` is a selector like `#BookReader` but the target element is inside a shadow DOM tree — returns `null`

This is needed for integrating BookReader into apps that use shadow DOM (e.g. offshoot, which wraps the details page inside `app-root`'s shadow root).

## Test plan
- [ ] Verify BookReader initializes normally with `el: '#BookReader'` (string selector, light DOM)
- [ ] Verify BookReader initializes with `el: document.getElementById('BookReader')` (DOM element)
- [ ] Verify search modal renders correctly in both modes
- [ ] Verify `mainBRContainer` returns the correct element in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)