### PR TITLE
Fix hash mode to preserve URL pathname

### DIFF
--- a/src/plugins/url/UrlPlugin.js
+++ b/src/plugins/url/UrlPlugin.js
@@ -151,7 +151,9 @@ export class UrlPlugin {
     }
 
     if (this.urlMode == 'hash') {
-      window.location.replace('#' + concatenatedPath);
+      // Use location.hash instead of location.replace('#...') to preserve
+      // the current pathname in SPA contexts.
+      window.location.hash = concatenatedPath;
     }
     this.oldLocationHash = urlStrPath;
   }

--- a/src/plugins/url/plugin.url.js
+++ b/src/plugins/url/plugin.url.js
@@ -206,7 +206,10 @@ BookReader.prototype.urlUpdateFragment = function() {
     } else if (this.textFragmentPage && extractedPage != this.textFragmentPage) {
       textFragment = '';
     }
-    window.location.replace('#' + newFragment + newQueryStringSearch + textFragment);
+    // Use location.hash instead of location.replace('#...') to preserve
+    // the current pathname. location.replace('#foo') is a relative URL
+    // that can wipe the path in SPA contexts.
+    window.location.hash = newFragment + newQueryStringSearch + textFragment;
     this.oldLocationHash = newFragment + newQueryStringSearch + textFragment;
   }
 };


### PR DESCRIPTION
## Summary
- Replace `window.location.replace('#fragment')` with `window.location.hash = fragment`
- Applied to both `plugin.url.js` and `UrlPlugin.js`

## Problem
When `urlMode` is `'hash'`, BookReader calls `window.location.replace('#page/n5/mode/2up')`. This is a relative URL navigation that replaces the **entire URL** — not just the hash. In SPA contexts, this wipes the route path:

```
Before: /labs/details/goody
After:  /#page/n5/mode/2up     ← path gone!
```

`window.location.hash = ...` only modifies the hash fragment and always preserves the existing pathname.

## Test plan
- [ ] Verify hash mode URL updates work on `archive.org/details/*` pages
- [ ] Verify page navigation updates the hash fragment without changing the pathname
- [ ] Verify the URL is correctly restored on page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)