### PR TITLE
Fix height propagation through ia-bookreader shell

### DIFF
--- a/src/ia-bookreader/ia-bookreader.js
+++ b/src/ia-bookreader/ia-bookreader.js
@@ -607,10 +607,15 @@ export class IaBookReader extends LitElement {
         min-height: unset;
       }
 
-      div[slot="header"],
+      div[slot="header"] {
+        display: flex;
+        width: 100%;
+      }
+
       div[slot="main"] {
         display: flex;
         width: 100%;
+        height: 100%;
       }
 
       slot {
@@ -621,7 +626,7 @@ export class IaBookReader extends LitElement {
       slot,
       slot > * {
         display: block;
-        height: inherit;
+        height: 100%;
         width: inherit;
       }
       .placeholder {


### PR DESCRIPTION
## Summary
- Add `height: 100%` to `div[slot="main"]` in ia-bookreader styles
- Change `slot > *` from `height: inherit` to `height: 100%`

## Problem
The height chain through the ia-bookreader shadow DOM slot chain breaks:

```
iaux-item-navigator (height: 100% via --br-height) 
  → div[slot="main"] (display: flex, NO HEIGHT ← breaks here)
    → slot > * (height: inherit → resolves to 0)
      → book-navigator (height: inherit → 0)
        → #BookReader (0 height → pages render at 0px)
```

BookReader measures its container during `init()`. When the container has 0 height, page images don't render. Consumers currently work around this by injecting CSS into ia-bookreader's shadow root.

## Test plan
- [ ] Verify BookReader pages render at full height in the ia-bookreader shell
- [ ] Verify fullscreen mode still works correctly
- [ ] Verify the shell layout doesn't break on existing archive.org pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)