### PR TITLE
Add exports field for granular imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,14 @@
     "access": "public"
   },
   "module": "src/ia-bookreader/ia-bookreader.js",
+  "exports": {
+    ".": "./src/ia-bookreader/ia-bookreader.js",
+    "./core": "./src/BookReader.js",
+    "./jquery": "./src/jquery-wrapper.js",
+    "./plugins/*": "./src/plugins/*",
+    "./styles": "./BookReader/BookReader.css",
+    "./BookReader/*": "./BookReader/*"
+  },
   "keywords": [
     "online",
     "bookreader",


### PR DESCRIPTION
## Summary
Add an `exports` field to package.json enabling consumers to import specific parts of BookReader:

```js
import '@internetarchive/bookreader'               // full shell (unchanged)
import '@internetarchive/bookreader/core'           // BookReader class only
import '@internetarchive/bookreader/jquery'          // jQuery wrapper
import '@internetarchive/bookreader/plugins/search/plugin.search.js'  // individual plugin
import '@internetarchive/bookreader/styles'          // BookReader.css
```

## Problem
Currently, the only entry point is the full ia-bookreader shell. Consumers who want to use BookReader core with a custom shell, or who need to import jQuery/plugins separately for loading order control, have to use deep path imports that aren't guaranteed by the package contract.

## Test plan
- [ ] Verify `import '@internetarchive/bookreader'` still works (default entry)
- [ ] Verify `import '@internetarchive/bookreader/core'` imports BookReader class
- [ ] Verify `import '@internetarchive/bookreader/jquery'` sets up jQuery globals

🤖 Generated with [Claude Code](https://claude.com/claude-code)