### PR TITLE
Add min-release-age setting to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-exact=true
+min-release-age=14  # days


### PR DESCRIPTION
Note this might require updating to a newer version of npm that supports this -- 11.10.0.