### PR TITLE
Fix Navbar responsive controls for shadow DOM hosts

### DIFF
--- a/src/BookReader/Navbar/Navbar.js
+++ b/src/BookReader/Navbar/Navbar.js
@@ -217,16 +217,25 @@ export class Navbar {
    * NOTE: `this.minimumControls`, `this.maximumControls`, and .BRnavMobile switch on resize
    */
   showMobileControls() {
+    // Scope queries to the navbar's own jQuery-wrapped root instead of
+    // `document`. `document.querySelector` can't cross shadow DOM
+    // boundaries, so when BookReader is hosted inside a shadow tree
+    // (e.g. offshoot's details-page), every lookup here returns null
+    // and no `.hide` toggling happens — leaving both the mobile-only
+    // viewmode button and the three desktop view-mode buttons visible
+    // at the same time.
+    //
+    // `this.$nav` is built from a fragment with two top-level sibling
+    // divs (.BRnavMobile + .BRnavMain), so `.filter()` (not `.find()`)
+    // is required for the outer classes.
+    const $main = this.$nav?.filter('.BRnavMain');
     this.minimumControls.forEach((control) => {
-      const element = document.querySelector(`.BRnavMain .controls .${control}`);
-      if (element) element.classList.remove('hide');
+      $main?.find(`.controls .${control}`).removeClass('hide');
     });
     this.maximumControls.forEach((control) => {
-      const element = document.querySelector(`.BRnavMain .controls .${control}`);
-      if (element) element.classList.add('hide');
+      $main?.find(`.controls .${control}`).addClass('hide');
     });
-    const mobileNav = document.querySelector(`.BRnavMobile`);
-    if (mobileNav) mobileNav.classList.remove('hide');
+    this.$nav?.filter('.BRnavMobile').removeClass('hide');
   }
 
   /**
@@ -234,16 +243,14 @@ export class Navbar {
    * NOTE: `this.minimumControls`, `this.maximumControls`, and .BRnavMobile switch on resize
    */
   showDesktopControls() {
+    const $main = this.$nav?.filter('.BRnavMain');
     this.maximumControls.forEach((control) => {
-      const element = document.querySelector(`.BRnavMain .controls .${control}`);
-      if (element) element.classList.remove('hide');
+      $main?.find(`.controls .${control}`).removeClass('hide');
     });
     this.minimumControls.forEach((control) => {
-      const element = document.querySelector(`.BRnavMain .controls .${control}`);
-      if (element) element.classList.add('hide');
+      $main?.find(`.controls .${control}`).addClass('hide');
     });
-    const mobileNav = document.querySelector(`.BRnavMobile`);
-    if (mobileNav) mobileNav.classList.add('hide');
+    this.$nav?.filter('.BRnavMobile').addClass('hide');
   }
 
   /**


### PR DESCRIPTION
## Summary

Fix `Navbar.showMobileControls` / `showDesktopControls` to work when BookReader is hosted inside a shadow-DOM ancestor (e.g. archive.org's offshoot details page, or any web-component host).

## Problem

Both methods use `document.querySelector` to find the view-mode buttons and the mobile-nav wrapper:

```js
showDesktopControls() {
  this.maximumControls.forEach((control) => {
    const element = document.querySelector(`.BRnavMain .controls .${control}`);
    if (element) element.classList.remove('hide');
  });
  // ...
  const mobileNav = document.querySelector(`.BRnavMobile`);
  if (mobileNav) mobileNav.classList.add('hide');
}
```

`document.querySelector` can't cross shadow DOM boundaries. When BookReader renders inside a shadow-scoped ancestor, every lookup returns null, no `.hide` class is ever toggled, and both sets of controls render simultaneously — the mobile-only `viewmode` button shows next to the three desktop view-mode buttons (`onepg`, `twopg`, `thumb`), producing a **duplicate thumbnail icon** in the navbar at desktop widths.

## Fix

Scope the queries to `this.$nav` (the navbar's own jQuery-wrapped root element) instead of `document`. `$nav` is built from a fragment containing two top-level sibling divs (`.BRnavMobile` + `.BRnavMain`), so:

- `.find('.controls .${name}')` scoped inside `.filter('.BRnavMain')` for the inner control buttons
- `.filter('.BRnavMobile')` for the outer mobile nav (not `.find('.BRnavMobile')`, which is descendants-only and would silently miss the top-level sibling)

This makes both methods shadow-DOM-agnostic while preserving identical behavior in the light-DOM case.

## Verification

- Unit-verified offshoot-side in https://git.archive.org/www/offshoot/-/merge_requests/1049 — a live regression test constructs a jQuery-wrapped navbar fragment, invokes `showDesktopControls` / `showMobileControls`, and asserts the expected `.hide` class transitions.
- Manually verified in offshoot's review app: duplicate thumbnail icon disappears at desktop widths; mobile nav still toggles correctly on resize.

## Risk

Low. The jQuery `.filter()` / `.find()` chain produces the same DOM set that the `document.querySelector` versions were reaching in the document-case, and the method surface is unchanged.

Related: addresses the same class of shadow-DOM bug as #1520.
