### PR TITLE
Mode2UpLit: skip page-flip when a text selection is active

### DIFF
--- a/src/BookReader/Mode2UpLit.js
+++ b/src/BookReader/Mode2UpLit.js
@@ -676,6 +676,15 @@ export class Mode2UpLit extends LitElement {
 
     if (ev.which != 1) return;
 
+    // Don't flip the page if the user is completing a text-selection
+    // drag. The page-flip handler runs on `mouseup`, so releasing the
+    // mouse at the end of a selection would otherwise trigger
+    // `br.left()` / `br.right()` and clobber the selection. The text
+    // selection plugin's own mouseup handler stops propagation when the
+    // mouseup lands on a word, but not when it lands in blank space
+    // between words or on the page margin.
+    if (window.getSelection?.()?.toString().trim()) return;
+
     const $page = $(ev.target).closest('.BRpagecontainer');
     if (!$page.length) return;
     if ($page.data('side') == 'L') {


### PR DESCRIPTION
## Summary

`Mode2UpLit.handlePageClick` unconditionally flips the page on any left-click `mouseup` inside a `.BRpagecontainer`. When a user drags across text to select it, releasing the mouse at the end of the selection fires `mouseup` and triggers the page-flip, clobbering the selection.

## Reproduction

1. Open any text item with OCR in 2up mode (e.g. `archive.org/details/goody`).
2. Drag across a few words to select them.
3. Release the mouse anywhere except directly on a `.BRwordElement` or `.BRspace` — e.g. on blank space between words or on the page margin.
4. The page flips and the selection is cleared.

## Why the text_selection plugin doesn't catch it

The text_selection plugin attaches a `mouseup.textSelectPluginHandler` to the text layer that calls `event.stopPropagation()`, which works — but only when the `mouseup` target is inside the text layer. If the drag ends on blank space or the page image, the plugin's handler doesn't fire and the event bubbles up to `.br-mode-2up__book`'s `@mouseup=${handlePageClick}`.

## Fix

Check `window.getSelection().toString().trim()` at the top of `handlePageClick` and bail if it has content. A single early-return — no new event listeners, no timing dependencies.

```js
handlePageClick = (ev) => {
  if (ev.which == 3 && this.br.protected) return false;
  if (ev.which != 1) return;
  if (window.getSelection?.()?.toString().trim()) return;  // ← new
  // …existing flip logic
}
```

## Verification

Offshoot works around this in https://git.archive.org/www/offshoot/-/merge_requests/1049 by attaching a capture-phase `mouseup` listener on the BookReader root container that calls `stopPropagation` when a selection is active. Upstream-fixing it here lets offshoot drop that workaround entirely.

Manually verified on offshoot's review app: selection now survives the mouseup in every case — on-word, between-word, on-margin, crossing-page-boundary.

## Risk

Low. The check fires only when there's an actual non-whitespace selection, which is unambiguously a selection-drag. No effect on tap-to-flip behavior (tap has no selection at mouseup time).
