### PR TITLE
Fix 2 TOC rendering bugs

### DIFF
--- a/src/plugins/plugin.chapters.js
+++ b/src/plugins/plugin.chapters.js
@@ -94,9 +94,10 @@ export class ChaptersPlugin extends BookReaderPlugin {
       this._tocEntries = rawTableOfContents
         .map(rawTOCEntry => (Object.assign({}, rawTOCEntry, {
           pageIndex: (
-            typeof(rawTOCEntry.leaf) == 'number' ? this.br.book.leafNumToIndex(rawTOCEntry.leaf) :
-              rawTOCEntry.pagenum ? this.br.book.getPageIndex(rawTOCEntry.pagenum) :
-                undefined
+            typeof rawTOCEntry.page_index === 'number' ? rawTOCEntry.page_index :
+              typeof(rawTOCEntry.leaf) == 'number' ? this.br.book.leafNumToIndex(rawTOCEntry.leaf) :
+                rawTOCEntry.pagenum ? this.br.book.getPageIndex(rawTOCEntry.pagenum) :
+                  undefined
           ),
         })));
       this._render();

--- a/src/plugins/plugin.chapters.js
+++ b/src/plugins/plugin.chapters.js
@@ -6,6 +6,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 import '@internetarchive/icon-toc/icon-toc.js';
 import { BookReaderPlugin } from "../BookReaderPlugin.js";
 import { applyVariables } from "../util/strings.js";
+import { promisifyEvent } from "../BookReader/utils.js";
 /** @typedef {import('@/src/BookReader/BookModel.js').PageIndex} PageIndex */
 /** @typedef {import('@/src/BookReader/BookModel.js').PageString} PageString */
 /** @typedef {import('@/src/BookReader/BookModel.js').LeafNum} LeafNum */
@@ -100,6 +101,9 @@ export class ChaptersPlugin extends BookReaderPlugin {
                   undefined
           ),
         })));
+      if (!this.br.shell) {
+        await promisifyEvent(window, 'BookReader:PostInit');
+      }
       this._render();
       this.br.bind(BookReader.eventNames.pageChanged, () => this._updateCurrent());
     }

--- a/tests/jest/plugins/plugin.chapters.test.js
+++ b/tests/jest/plugins/plugin.chapters.test.js
@@ -95,6 +95,7 @@ describe("ChaptersPlugin", () => {
     test("renders if valid TOC on open library", async () => {
       const fakeBR = {
         options: { vars: {} },
+        shell: {},
         bind: sinon.stub(),
       };
       const p = new ChaptersPlugin(fakeBR);
@@ -113,6 +114,7 @@ describe("ChaptersPlugin", () => {
         options: {
           table_of_contents: deepCopy(SAMPLE_TOC_UNDEF),
         },
+        shell: {},
         bind: sinon.stub(),
       };
       const p = new ChaptersPlugin(fakeBR);
@@ -131,6 +133,7 @@ describe("ChaptersPlugin", () => {
         options: {
           table_of_contents,
         },
+        shell: {},
         bind: sinon.stub(),
         book: {
           leafNumToIndex: (leaf) => leaf + 1,


### PR DESCRIPTION
1. Fix issue where the TOC render function was called too early for TOC's specified directly in the BR manifest

Testing: 
- [Before fails](https://ia-bookreader.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=sim_ans_1990-09_13_1#page/n5/mode/2up) / [after succeeds](https://deploy-preview-1543--ia-bookreader.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=sim_ans_1990-09_13_1#page/n5/mode/2up) (ignore the blank pages)
- [No regression on normal TOCs](https://deploy-preview-1543--ia-bookreader.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=adventureofsherl0000unse).

2. Add support for specifying `page_index` directly in the toc entry to handle cases where the `pagenum` does not resolve to page.
- Can't really test this easily until the petabox-side changes are merged but seems low risk. No regressions either.