### PR TITLE
Switch page display to be 0-indexed

### DIFF
--- a/src/BookReader/Navbar/Navbar.js
+++ b/src/BookReader/Navbar/Navbar.js
@@ -445,7 +445,7 @@ export class Navbar {
 
 /**
  * Renders the html for the page string
- * @param {number} index 0-indexed leaf position (0..numLeafs-1)
+ * @param {PageIndex} index 0-indexed page index (0..numLeafs-1)
  * @param {number} numLeafs total number of leaves
  * @param {number|string} pageNum
  * @param {*} pageType - Deprecated

--- a/src/BookReader/Navbar/Navbar.js
+++ b/src/BookReader/Navbar/Navbar.js
@@ -314,7 +314,7 @@ export class Navbar {
     const $sliders = this.$root.find('.BRpager').slider({
       animate: true,
       min: 0,
-      max: br.book.getNumLeafs() - 1,
+      max: Math.max(0, br.book.getNumLeafs() - 1),
       value: br.currentIndex(),
       range: "min",
     });
@@ -324,8 +324,8 @@ export class Navbar {
     $sliders.find('.ui-slider-handle').attr({
       'role': 'slider',
       'aria-label': 'Page navigation slider',
-      'aria-valuemin': 1,
-      'aria-valuemax': br.book.getNumLeafs(),
+      'aria-valuemin': 0,
+      'aria-valuemax': Math.max(0, br.book.getNumLeafs() - 1),
     });
 
     // Ignore up/down arrow keys and page up/down keys, since they're confusingly different
@@ -396,7 +396,6 @@ export class Navbar {
   */
   getNavPageNumString(index) {
     const { br } = this;
-    // Accessible index starts at 0 (alas) so we add 1 to make human
     const pageNum = br.book.getPageNum(index);
     const pageType = br.book.getPageProp(index, 'pageType');
     const numLeafs = br.book.getNumLeafs();
@@ -425,7 +424,7 @@ export class Navbar {
   updateNavPageNum(index) {
     this.$root.find('.BRcurrentpage').html(this.getNavPageNumString(index));
     this.$root.find('.ui-slider-handle').attr({
-      'aria-valuenow': index + 1,
+      'aria-valuenow': index,
       'aria-valuetext': this.getNavPageNumString(index),
     });
   }
@@ -446,19 +445,19 @@ export class Navbar {
 
 /**
  * Renders the html for the page string
- * @param {number} index
- * @param {number} numLeafs
+ * @param {number} index 0-indexed leaf position (0..numLeafs-1)
+ * @param {number} numLeafs total number of leaves
  * @param {number|string} pageNum
  * @param {*} pageType - Deprecated
  * @param {number} maxPageNum
- * @return {string}
+ * @return {string} e.g. "Page 14 (3/39)"
  */
 export function getNavPageNumHtml(index, numLeafs, pageNum, pageType, maxPageNum) {
   const pageIsAsserted = pageNum[0] != 'n';
-  const pageIndex = index + 1;
 
   if (!pageIsAsserted) {
     pageNum = '—';
   }
-  return `Page ${pageNum} (${pageIndex}/${numLeafs})`;
+  const lastIndex = Math.max(0, numLeafs - 1);
+  return `Page ${pageNum} (${index}/${lastIndex})`;
 }

--- a/tests/jest/BookReader/Navbar/Navbar.test.js
+++ b/tests/jest/BookReader/Navbar/Navbar.test.js
@@ -6,15 +6,27 @@ describe('getNavPageNumHtml', () => {
   const f = getNavPageNumHtml;
 
   test('handle n-prefixed page numbers', () => {
-    expect(f(3, 40, 'n3', '', 40)).toBe('Page — (4/40)');
+    expect(f(3, 40, 'n3', '', 40)).toBe('Page — (3/39)');
   });
 
   test('handle regular page numbers', () => {
-    expect(f(3, 40, '14', '', 40)).toBe('Page 14 (4/40)');
+    expect(f(3, 40, '14', '', 40)).toBe('Page 14 (3/39)');
   });
 
   test('handle no max page', () => {
-    expect(f(3, 40, '14', '', null)).toBe('Page 14 (4/40)');
+    expect(f(3, 40, '14', '', null)).toBe('Page 14 (3/39)');
+  });
+
+  test('first leaf renders as 0', () => {
+    expect(f(0, 40, '1', '', 40)).toBe('Page 1 (0/39)');
+  });
+
+  test('last leaf renders as numLeafs - 1', () => {
+    expect(f(39, 40, '40', '', 40)).toBe('Page 40 (39/39)');
+  });
+
+  test('zero-leaf book renders as 0/0', () => {
+    expect(f(0, 0, 'n0', '', null)).toBe('Page — (0/0)');
   });
 });
 


### PR DESCRIPTION
Per bk request, because it was causing confusion when the number in the UI was different from the n-number in the URL (eg `/page/n0`).