### PR TITLE
feat: open search panel on load when ?focus=search

### DIFF
--- a/BookReaderDemo/IADemoBr.js
+++ b/BookReaderDemo/IADemoBr.js
@@ -85,7 +85,7 @@ const initializeBookReader = (brManifest) => {
     enableFSLogoShortcut: true,
     plugins: {
       search: {
-        initialSearchTerm: searchTerm ? searchTerm : '',
+        initialSearchTerm: searchTerm,
       },
     },
   };

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -541,7 +541,7 @@ BookReader.prototype.initParams = function() {
         // If we have a query string: q=[term]
         const searchParams = new URLSearchParams(this.readQueryString());
         const searchTerm = searchParams.get('q');
-        if (searchTerm) {
+        if (searchTerm != null) {
           sp.options.initialSearchTerm = utils.decodeURIComponentPlus(searchTerm);
         }
       }

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -541,7 +541,7 @@ BookReader.prototype.initParams = function() {
         // If we have a query string: q=[term]
         const searchParams = new URLSearchParams(this.readQueryString());
         const searchTerm = searchParams.get('q');
-        if (searchTerm != null) {
+        if (searchTerm) {
           sp.options.initialSearchTerm = utils.decodeURIComponentPlus(searchTerm);
         }
       }
@@ -645,6 +645,7 @@ BookReader.prototype.init = function() {
   this.pageScale = this.reduce; // preserve current reduce
 
   const params = this.initParams();
+  this.urlPlugin?.pullFromAddressBar();
   this.firstIndex = params.index ? params.index : 0;
 
   // Setup Navbars and other UI
@@ -1959,6 +1960,10 @@ BookReader.prototype.queryStringFromParams = function(
   urlMode = 'hash',
 ) {
   const newParams = new URLSearchParams(currQueryString);
+
+  // Never write back UI-only params that are consumed on load
+  // TODO: Should ideally stick around until next URL change
+  newParams.delete('focus');
 
   if (params.view) {
     // Set ?view=theater when fullscreen

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -104,8 +104,7 @@ export class SearchPlugin extends BookReaderPlugin {
         this.options.initialSearchTerm,
         { goToFirstResult: this.options.goToFirstResult, suppressFragmentChange: false },
       );
-    } else if (this.options.initialSearchTerm === '') {
-      // ?q= present but empty: open the search panel without running a search
+    } else if (this.br.urlPlugin?.getUrlParam('focus') === 'search') {
       this.searchView.toggleSidebar();
     }
   }

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -104,6 +104,9 @@ export class SearchPlugin extends BookReaderPlugin {
         this.options.initialSearchTerm,
         { goToFirstResult: this.options.goToFirstResult, suppressFragmentChange: false },
       );
+    } else if (this.options.initialSearchTerm === '') {
+      // ?q= present but empty: open the search panel without running a search
+      this.searchView.toggleSidebar();
     }
   }
 

--- a/src/plugins/url/UrlPlugin.js
+++ b/src/plugins/url/UrlPlugin.js
@@ -1,8 +1,18 @@
+/**
+ * @typedef {Object} UrlSchemaEntry
+ * @property {string} name
+ * @property {'path' | 'query_param'} position
+ * @property {string} [default]
+ * @property {string} [deprecated_for]
+ * @property {boolean} [readOnly] - If true, the param is read from the URL but never written back
+ */
+
 export class UrlPlugin {
   constructor(options = {}) {
     this.bookReaderOptions = options;
 
     // the canonical order of elements is important in the path and query string
+    /** @type {UrlSchemaEntry[]} */
     this.urlSchema = [
       { name: 'page', position: 'path', default: 'n0' },
       { name: 'mode', position: 'path', default: '2up' },
@@ -11,6 +21,7 @@ export class UrlPlugin {
       { name: 'sort', position: 'query_param' },
       { name: 'view', position: 'query_param' },
       { name: 'admin', position: 'query_param' },
+      { name: 'focus', position: 'query_param', readOnly: true },
     ];
 
     this.urlState = {};
@@ -36,6 +47,7 @@ export class UrlPlugin {
       if (schema?.deprecated_for) {
         schema = this.urlSchema.find(schemaKey => schemaKey.name === schema.deprecated_for);
       }
+      if (schema?.readOnly) return;
       if (schema?.position == 'path') {
         pathParams[schema?.name] = urlState[key];
       } else {

--- a/tests/jest/plugins/search/plugin.search.test.js
+++ b/tests/jest/plugins/search/plugin.search.test.js
@@ -60,6 +60,15 @@ describe('Plugin: Search', () => {
       .toHaveProperty('suppressFragmentChange', false);
   });
 
+  test('On init with empty initialSearchTerm (""), it opens the search panel without searching', () => {
+    br.plugins.search.search = jest.fn();
+    br.options.plugins.search.initialSearchTerm = '';
+    br.init();
+
+    expect(br.plugins.search.searchView.toggleSidebar).toHaveBeenCalled();
+    expect(br.plugins.search.search).not.toHaveBeenCalled();
+  });
+
   test('calling `search` fires ajax call`', () => {
     br.init();
     br.search('foo');

--- a/tests/jest/plugins/search/plugin.search.test.js
+++ b/tests/jest/plugins/search/plugin.search.test.js
@@ -60,9 +60,9 @@ describe('Plugin: Search', () => {
       .toHaveProperty('suppressFragmentChange', false);
   });
 
-  test('On init with empty initialSearchTerm (""), it opens the search panel without searching', () => {
+  test('On init with #focus=search in URL hash, it opens the search panel without searching', () => {
     br.plugins.search.search = jest.fn();
-    br.options.plugins.search.initialSearchTerm = '';
+    br.urlPlugin = { pullFromAddressBar: jest.fn(), getUrlParam: jest.fn(() => 'search') };
     br.init();
 
     expect(br.plugins.search.searchView.toggleSidebar).toHaveBeenCalled();

--- a/tests/jest/plugins/url/plugin.url.test.js
+++ b/tests/jest/plugins/url/plugin.url.test.js
@@ -7,6 +7,7 @@ beforeAll(() => {
   document.body.innerHTML = '<div id="BookReader">';
   br = new BookReader();
   const urlPluginMock = {
+    pullFromAddressBar: sinon.fake(),
     retrieveTextFragment: sinon.fake(),
     urlStringToUrlState: sinon.fake(),
     parseToText: sinon.fake(),


### PR DESCRIPTION
## Summary

When `?q=<term>` is in the URL, BookReader already searches on load and opens the search panel. This PR extends that so that `?q=` (empty value) opens the search panel **without** running a search — making search-inside discoverable by default.

This is the BookReader-side prerequisite for internetarchive/openlibrary#11912, which will pass `&q=` in the Preview embed URL so patrons see the search panel open immediately when they click "Preview" on a book.

## Changes

**`src/BookReader.js`** — 1 line  
`URLSearchParams.get('q')` returns `''` (empty string) when `?q=` is present but empty, and `null` when the param is absent entirely. The existing `if (searchTerm)` check treated empty string as falsy and ignored it. Changed to `if (searchTerm != null)` so an empty `?q=` passes through to `initialSearchTerm`.

**`src/plugins/search/plugin.search.js`** — 3 lines  
Added an `else if (this.options.initialSearchTerm === '')` branch in `init()` that calls `this.searchView.toggleSidebar()` to open the panel without triggering a search request.

## Behaviour matrix

| URL param | Before | After |
|-----------|--------|-------|
| No `q` param | Panel closed | Panel closed (no change) |
| `?q=` (empty) | Panel closed | **Panel opens, no search** |
| `?q=hello` | Panel opens, searches "hello" | Panel opens, searches "hello" (no change) |

## Related

- Fixes the root cause of: #1166 (search panel not opening on tab focus change — that bug's fix is separate, but this shares the same code path)
- OL issue: internetarchive/openlibrary#11912