### PR TITLE
Add support for quote start/end to Copy Link to Highlight

### DIFF
--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -790,80 +790,62 @@ function replaceWhitespace(string) {
 }
 
 /**
- * Finds ordered, non-overlapping quote matches within a range and returns a Range for each.
- * @param {String[]} quotes - Ordered quote parts to find
+ * Finds all regex matches within a range and returns their ranges.
+ * @param {RegExp} regex
  * @param {Range} range - the range to search in
  * @param {Node[]} textNodes - visible text nodes within the range
- * @returns {Range[] | undefined} Ranges for each quote part, or undefined if no full ordered match is found
- *
- * Adapted from
- * https://github.com/GoogleChromeLabs/text-fragments-polyfill/blob/abc6ed408b3f20e91d9cbda9977748459f5e3877/src/text-fragment-utils.js#L765
+ * @param {{ normalize?: function(string): string }} [options]
+ * @returns {Range[] | undefined} Range for each match, or undefined if no matches are found
  */
-export function findRangesForQuotes(quotes, range, textNodes) {
-  if (!quotes.length) return undefined;
+export function findRangeForRegExp(regex, range, textNodes, { normalize = (s) => s } = {}) {
+  if (!textNodes.length) return undefined;
 
   const startOffset = textNodes[0] === range.startContainer ?
     range.startOffset :
     0;
-  const normalizedWholePageString = replaceWhitespace(range.toString());
-  const normalizedQuotes = quotes.map(replaceWhitespace);
-  const normalizedStartOffset = replaceWhitespace(textNodes[0].textContent.slice(0, startOffset)).length;
+  const normalizedWholePageString = normalize(range.toString());
+  const normalizedStartOffset = normalize(textNodes[0].textContent.slice(0, startOffset)).length;
+  const matchRegex = new RegExp(regex.source, regex.flags.includes('g') ? regex.flags : `${regex.flags}g`);
 
-  let searchStart = 0;
-  while (searchStart < normalizedWholePageString.length) {
-    let partSearchStart = searchStart;
-    const foundRanges = [];
-    let matchedAllQuotes = true;
+  const matches = Array.from(normalizedWholePageString.matchAll(matchRegex));
+  const resultRanges = matches.map((match) => {
+    const start = getBoundaryPointAtIndex(
+      normalizedStartOffset + match.index,
+      textNodes,
+      false,
+      { normalize },
+    );
+    const end = getBoundaryPointAtIndex(
+      normalizedStartOffset + match.index + match[0].length,
+      textNodes,
+      true,
+      { normalize },
+    );
 
-    for (const normalizedQuote of normalizedQuotes) {
-      const matchedIndex = normalizedWholePageString.indexOf(normalizedQuote, partSearchStart);
-      if (matchedIndex === -1) {
-        matchedAllQuotes = false;
-        break;
-      }
-
-      const start = getBoundaryPointAtIndex(
-        normalizedStartOffset + matchedIndex,
-        textNodes,
-        false,
-      );
-      const end = getBoundaryPointAtIndex(
-        normalizedStartOffset + matchedIndex + normalizedQuote.length,
-        textNodes,
-        true,
-      );
-
-      if (start == null || end == null) {
-        matchedAllQuotes = false;
-        break;
-      }
-
-      const foundRange = new Range();
-      foundRange.setStart(start.node, 0);
-      foundRange.setEnd(end.node, 1);
-      foundRanges.push(foundRange);
-      partSearchStart = matchedIndex + normalizedQuote.length;
+    if (!start || !end) {
+      console.warn("Could not find boundary points for regex match, skipping this match", {match, start, end});
+      return undefined;
     }
 
-    if (matchedAllQuotes) {
-      return foundRanges;
-    }
+    const foundRange = new Range();
+    foundRange.setStart(start.node, 0);
+    foundRange.setEnd(end.node, 1);
+    return foundRange;
+  });
 
-    const firstMatchedIndex = normalizedWholePageString.indexOf(normalizedQuotes[0], searchStart);
-    if (firstMatchedIndex === -1) return undefined;
-    searchStart = firstMatchedIndex + 1;
-  }
-  return undefined;
+  const definedRanges = resultRanges.filter((matchRange) => !!matchRange);
+  if (!definedRanges?.length) return undefined;
+  return definedRanges;
 }
-
 
 /**
  * Uses the index that matches the quote string and normalizes the string contents to find the correct node
  * @param {Number} index
  * @param {Node[]} nodes
  * @param {boolean} isEnd
+ * @param {{ normalize?: function(string): string }} [options]
  */
-export function getBoundaryPointAtIndex(index, nodes, isEnd) {
+export function getBoundaryPointAtIndex(index, nodes, isEnd, { normalize = (s) => s } = {}) {
   let counted = 0;
   let normalizedData;
   for (let i = 0; i < nodes.length; i++) {
@@ -872,7 +854,7 @@ export function getBoundaryPointAtIndex(index, nodes, isEnd) {
       // Treat the lineElement as a space for now, will check if the previous node was hyphenated or another lineElement later
       normalizedData = ' ';
     } else {
-      if (!normalizedData) normalizedData = replaceWhitespace(node.textContent);
+      if (!normalizedData) normalizedData = normalize(node.textContent);
     }
     let nodeEnd = counted + normalizedData.length;
     if (isEnd) nodeEnd += 1;
@@ -885,8 +867,8 @@ export function getBoundaryPointAtIndex(index, nodes, isEnd) {
         normalizedData.substring(normalizedOffset);
 
       let candidateSubstring = isEnd ?
-        replaceWhitespace(node.textContent.substring(0, normalizedOffset)) :
-        replaceWhitespace(node.textContent.substring(normalizedOffset));
+        normalize(node.textContent.substring(0, normalizedOffset)) :
+        normalize(node.textContent.substring(normalizedOffset));
 
       const direction = (isEnd ? -1 : 1) * (targetSubstring.length > candidateSubstring.length ? -1 : 1);
       while (denormalizedOffset >= 0 &&
@@ -928,57 +910,53 @@ export function getBoundaryPointAtIndex(index, nodes, isEnd) {
  * https://github.com/GoogleChromeLabs/text-fragments-polyfill/blob/main/src/text-fragment-utils.js#L743
  *
  * @param {HTMLElement} textLayer
- * @param {BookReaderTextFragment} quote
+ * @param {BookReaderTextFragment} textFragment
  * @param {string | null} cssClassName optional css class to add to the highlight span element
  */
-export function renderHighlight(textLayer, quote, cssClassName = null) {
+export function renderHighlight(textLayer, textFragment, cssClassName = null) {
   // Create a range that encompasses the entire text content
   const firstPageNode = getFirstMostNode(textLayer);
   const lastPageNode = getLastMostNode(textLayer);
   const wholePageRange = new Range();
   wholePageRange.setStart(firstPageNode, 0);
   wholePageRange.setEnd(lastPageNode, lastPageNode.textContent.length);
-
-  const quoteParts = quote.quote ? [quote.quote] : [quote.quoteStart, quote.quoteEnd];
-  const broadQuoteParts = quote.quote
-    ? [replaceWhitespace([quote.prefix, quote.quote, quote.suffix].filter(Boolean).join(' '))]
-    : [
-      replaceWhitespace([quote.prefix, quote.quoteStart].filter(Boolean).join(' ')),
-      replaceWhitespace([quote.quoteEnd, quote.suffix].filter(Boolean).join(' ')),
-    ];
-
-  if (!quoteParts.length) {
-    console.warn('Could not render text fragment: missing quote or quoteStart/quoteEnd');
-    return;
-  }
+  const normalize = replaceWhitespace;
 
   // Retrieve the text nodes and relevant whitespace elements
   // Need to keep the BRlineElement nodes in between to keep the index count consistent, remove first BRlineElement since text starts from the first real text node
   const pageWordNodes = Array.from(textLayer.querySelectorAll('.BRwordElement, .BRspace, br, .BRlineElement'));
   pageWordNodes.splice(0, 1);
 
-  const broadRanges = findRangesForQuotes(broadQuoteParts, wholePageRange, pageWordNodes);
-  if (!broadRanges?.length) {
+  const broadRanges = findRangeForRegExp(
+    textFragment.toRegExp({ normalize, context: true }),
+    wholePageRange,
+    pageWordNodes,
+    { normalize },
+  );
+  if (!broadRanges) {
     console.warn("Could not find quote with context in page");
     return;
   }
-  const broadRange = getBoundingRange(broadRanges);
 
   const broadRangeWordNodes = [];
-  for (const el of walkBetweenNodes(broadRange?.startContainer, broadRange?.endContainer)) {
+  for (const el of walkBetweenNodes(broadRanges[0].startContainer, broadRanges[0].endContainer)) {
     if (el.classList?.contains('BRwordElement') || el.classList?.contains('BRspace') || el.classList?.contains('BRlineElement')) {
       broadRangeWordNodes.push(el);
     }
   }
 
   // At which point the quote should now be unambiguous!
-  const exactRanges = findRangesForQuotes(quoteParts, broadRange, broadRangeWordNodes);
-  if (!exactRanges?.length) {
+  const exactRanges = findRangeForRegExp(
+    textFragment.toRegExp({ normalize, context: false }),
+    broadRanges[0],
+    broadRangeWordNodes,
+    { normalize },
+  );
+  if (!exactRanges) {
     throw new Error("Could not find quote in page");
   }
-  const exactRange = getBoundingRange(exactRanges);
-  const startTextNode = getFirstMostNode(exactRange.startContainer);
-  const endTextNode = getFirstMostNode(exactRange.endContainer);
+  const startTextNode = getFirstMostNode(exactRanges[0].startContainer);
+  const endTextNode = getFirstMostNode(exactRanges[0].endContainer);
 
   // markRange requires the range to start and end within text nodes
   const exactRangeTextNodes = new Range();
@@ -995,7 +973,7 @@ export function renderHighlight(textLayer, quote, cssClassName = null) {
     const mark = document.createElement("mark");
     mark.classList.add("BRhighlight");
     if (cssClassName) mark.classList.add(cssClassName);
-    if (quote.uuid) mark.classList.add(quote.uuid);
+    if (textFragment.uuid) mark.classList.add(textFragment.uuid);
     return mark;
   });
 }
@@ -1089,18 +1067,6 @@ function retrieveUUID(ele) {
     return findUUID[0];
   }
   return null;
-}
-
-/**
- * @param {Range[]} ranges
- * @returns {Range}
- */
-function getBoundingRange(ranges) {
-  const boundingRange = new Range();
-  boundingRange.setStart(ranges[0].startContainer, ranges[0].startOffset);
-  const lastRange = ranges[ranges.length - 1];
-  boundingRange.setEnd(lastRange.endContainer, lastRange.endOffset);
-  return boundingRange;
 }
 
 /**
@@ -1256,6 +1222,30 @@ export class BookReaderTextFragment {
       str += `,-${encodeURIComponent(this.suffix)}`;
     }
     return str;
+  }
+
+  /**
+   * Build a regex that matches this quote payload.
+   * @param {{ normalize?: function(string): string, context?: boolean }} [options]
+   * @returns {RegExp}
+   */
+  toRegExp({ normalize = (s) => s, context = false } = {}) {
+    /** @type {[String] | [String, String]} */
+    const quotes = this.quote ? [this.quote] : [this.quoteStart, this.quoteEnd];
+
+    if (context) {
+      if (this.prefix) quotes[0] = this.prefix + ' ' + quotes[0];
+      if (this.suffix) quotes[quotes.length - 1] = quotes[quotes.length - 1] + ' ' + this.suffix;
+    }
+
+    if (quotes.length === 1) {
+      return new RegExp(RegExp.escape(normalize(quotes[0])), 'g');
+    } else {
+      return new RegExp(
+        RegExp.escape(normalize(quotes[0])) + '[\\s\\S]*?' + RegExp.escape(normalize(quotes[1])),
+        'g',
+      );
+    }
   }
 
   toJSON() {

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -7,6 +7,8 @@ import '@internetarchive/icon-share';
 import '@internetarchive/icon-edit-pencil/icon-edit-pencil.js';
 
 const BR_HIGHLIGHTS_LOCAL_STORAGE_KEY = "BRhighlightStorage";
+const MAX_FULL_QUOTE_URL_CHARS = 80;
+const TRUNCATED_QUOTE_WORD_COUNT = 3;
 
 export class TextSelectionManager {
   options = {
@@ -788,41 +790,68 @@ function replaceWhitespace(string) {
 }
 
 /**
- * Checks if quote matches the text content and existing range, then identifies the start and end nodes that contain the quote string.
- * @param {String} quote - The text to find
+ * Finds ordered, non-overlapping quote matches within a range and returns a Range for each.
+ * @param {String[]} quotes - Ordered quote parts to find
  * @param {Range} range - the range to search in
  * @param {Node[]} textNodes - visible text nodes within the range
- * @returns {Range | undefined} Range that encompasses the quote, or undefined if no match is found
+ * @returns {Range[] | undefined} Ranges for each quote part, or undefined if no full ordered match is found
  *
- * Lightly adapted from
+ * Adapted from
  * https://github.com/GoogleChromeLabs/text-fragments-polyfill/blob/abc6ed408b3f20e91d9cbda9977748459f5e3877/src/text-fragment-utils.js#L765
  */
-export function findRangeForQuote(quote, range, textNodes) {
+export function findRangesForQuotes(quotes, range, textNodes) {
+  if (!quotes.length) return undefined;
+
   const startOffset = textNodes[0] === range.startContainer ?
     range.startOffset :
     0;
   const normalizedWholePageString = replaceWhitespace(range.toString());
-  const normalizedQuote = replaceWhitespace(quote);
+  const normalizedQuotes = quotes.map(replaceWhitespace);
+  const normalizedStartOffset = replaceWhitespace(textNodes[0].textContent.slice(0, startOffset)).length;
+
   let searchStart = 0;
-  let start;
-  let end;
   while (searchStart < normalizedWholePageString.length) {
-    const matchedIndex = normalizedWholePageString.indexOf(normalizedQuote, searchStart);
-    if (matchedIndex === -1) return undefined;
-    const normalizedStartOffset = replaceWhitespace(textNodes[0].textContent.slice(0, startOffset)).length;
-    start = getBoundaryPointAtIndex(
-      normalizedStartOffset + matchedIndex,
-      textNodes, false);
-    end = getBoundaryPointAtIndex(
-      normalizedStartOffset + matchedIndex + normalizedQuote.length,
-      textNodes, true);
-    if (start != null && end != null) {
+    let partSearchStart = searchStart;
+    const foundRanges = [];
+    let matchedAllQuotes = true;
+
+    for (const normalizedQuote of normalizedQuotes) {
+      const matchedIndex = normalizedWholePageString.indexOf(normalizedQuote, partSearchStart);
+      if (matchedIndex === -1) {
+        matchedAllQuotes = false;
+        break;
+      }
+
+      const start = getBoundaryPointAtIndex(
+        normalizedStartOffset + matchedIndex,
+        textNodes,
+        false,
+      );
+      const end = getBoundaryPointAtIndex(
+        normalizedStartOffset + matchedIndex + normalizedQuote.length,
+        textNodes,
+        true,
+      );
+
+      if (start == null || end == null) {
+        matchedAllQuotes = false;
+        break;
+      }
+
       const foundRange = new Range();
       foundRange.setStart(start.node, 0);
       foundRange.setEnd(end.node, 1);
-      return foundRange;
+      foundRanges.push(foundRange);
+      partSearchStart = matchedIndex + normalizedQuote.length;
     }
-    searchStart = matchedIndex + 1;
+
+    if (matchedAllQuotes) {
+      return foundRanges;
+    }
+
+    const firstMatchedIndex = normalizedWholePageString.indexOf(normalizedQuotes[0], searchStart);
+    if (firstMatchedIndex === -1) return undefined;
+    searchStart = firstMatchedIndex + 1;
   }
   return undefined;
 }
@@ -910,26 +939,30 @@ export function renderHighlight(textLayer, quote, cssClassName = null) {
   wholePageRange.setStart(firstPageNode, 0);
   wholePageRange.setEnd(lastPageNode, lastPageNode.textContent.length);
 
-  // Convert the whole page range into a normalized string, get the index of where the stored string matches the quote
-  const convertedString = replaceWhitespace(wholePageRange.toString());
-  const convertedQuote = replaceWhitespace(quote.quote);
-  const foundStringIndex = convertedString.indexOf(convertedQuote);
-  if (foundStringIndex == -1) {
-    console.warn("Could not find quote in page:", quote.quote);
+  const quoteParts = quote.quote ? [quote.quote] : [quote.quoteStart, quote.quoteEnd];
+  const broadQuoteParts = quote.quote
+    ? [replaceWhitespace([quote.prefix, quote.quote, quote.suffix].filter(Boolean).join(' '))]
+    : [
+      replaceWhitespace([quote.prefix, quote.quoteStart].filter(Boolean).join(' ')),
+      replaceWhitespace([quote.quoteEnd, quote.suffix].filter(Boolean).join(' ')),
+    ];
+
+  if (!quoteParts.length) {
+    console.warn('Could not render text fragment: missing quote or quoteStart/quoteEnd');
     return;
   }
-  const fullContext = [quote.prefix, quote.quote, quote.suffix].join(" ");
-  const convertedFullContext = replaceWhitespace(fullContext);
 
   // Retrieve the text nodes and relevant whitespace elements
   // Need to keep the BRlineElement nodes in between to keep the index count consistent, remove first BRlineElement since text starts from the first real text node
   const pageWordNodes = Array.from(textLayer.querySelectorAll('.BRwordElement, .BRspace, br, .BRlineElement'));
   pageWordNodes.splice(0, 1);
-  const broadRange = findRangeForQuote(convertedFullContext, wholePageRange, pageWordNodes);
-  if (!broadRange) {
-    console.warn("Could not find quote with context in page, falling back to finding quote without context:", quote.quote);
+
+  const broadRanges = findRangesForQuotes(broadQuoteParts, wholePageRange, pageWordNodes);
+  if (!broadRanges?.length) {
+    console.warn("Could not find quote with context in page");
     return;
   }
+  const broadRange = getBoundingRange(broadRanges);
 
   const broadRangeWordNodes = [];
   for (const el of walkBetweenNodes(broadRange?.startContainer, broadRange?.endContainer)) {
@@ -939,10 +972,11 @@ export function renderHighlight(textLayer, quote, cssClassName = null) {
   }
 
   // At which point the quote should now be unambiguous!
-  const exactRange = findRangeForQuote(quote.quote, broadRange, broadRangeWordNodes);
-  if (!exactRange) {
+  const exactRanges = findRangesForQuotes(quoteParts, broadRange, broadRangeWordNodes);
+  if (!exactRanges?.length) {
     throw new Error("Could not find quote in page");
   }
+  const exactRange = getBoundingRange(exactRanges);
   const startTextNode = getFirstMostNode(exactRange.startContainer);
   const endTextNode = getFirstMostNode(exactRange.endContainer);
 
@@ -1058,28 +1092,47 @@ function retrieveUUID(ele) {
 }
 
 /**
+ * @param {Range[]} ranges
+ * @returns {Range}
+ */
+function getBoundingRange(ranges) {
+  const boundingRange = new Range();
+  boundingRange.setStart(ranges[0].startContainer, ranges[0].startOffset);
+  const lastRange = ranges[ranges.length - 1];
+  boundingRange.setEnd(lastRange.endContainer, lastRange.endOffset);
+  return boundingRange;
+}
+
+/**
  * An extension of the fields defined by the browser-native TextFragment;
  * See https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments
  *
  * Text fragment string format: `pageNumber:prefix-,quote,-suffix`
+ * Or for long quotes: `pageNumber:prefix-,quoteStart,quoteEnd,-suffix`
  * Note the ':' and ',' separators must not be encoded, but
- * the pageNumber, prefix, quote, and suffix text can be encoded.
+ * the pageNumber, prefix, quote/quoteStart/quoteEnd, and suffix text can be encoded.
  */
 export class BookReaderTextFragment {
   /**
    * @param {object} params
    * @param {string | null}params.prefix
-   * @param {string} params.quote
+   * @param {string | null} [params.quote]
+   * @param {string | null} [params.quoteStart]
+   * @param {string | null} [params.quoteEnd]
    * @param {string | null} params.suffix
    * @param {string | null} params.pageNumber Page number; e.g. asserted page number or the n-prefixed page index
    * @param {number} params.pageIndex Page index; e.g. zero-based index of the page
    * @param {string | null} [params.uuid] UUID for the text fragment if it has one
    */
-  constructor({ prefix, quote, suffix, pageNumber, pageIndex, uuid }) {
+  constructor({ prefix, quote, quoteStart, quoteEnd, suffix, pageNumber, pageIndex, uuid }) {
     /** @type {string|null} */
     this.prefix = prefix;
-    /** @type {string} */
-    this.quote = quote;
+    /** @type {string | null} */
+    this.quote = quote ?? null;
+    /** @type {string | null} */
+    this.quoteStart = quoteStart ?? null;
+    /** @type {string | null} */
+    this.quoteEnd = quoteEnd ?? null;
     /** @type {string|null} */
     this.suffix = suffix;
     /** @type {string|null} Page number; e.g. asserted page number or the n-prefixed page index */
@@ -1108,14 +1161,40 @@ export class BookReaderTextFragment {
     }
     const pageNumber = match[1] ? decodeURIComponent(match[1]) : null;
     const prefix = match[2] ? decodeURIComponent(match[2]) : null;
-    const quote = decodeURIComponent(match[3]);
+    const quoteRegion = match[3] || '';
+    const quoteParts = quoteRegion.split(',');
+    let quote = null;
+    let quoteStart = null;
+    let quoteEnd = null;
+
+    if (quoteParts.length === 1) {
+      quote = decodeURIComponent(quoteParts[0]);
+    } else if (quoteParts.length === 2) {
+      quoteStart = decodeURIComponent(quoteParts[0]);
+      quoteEnd = decodeURIComponent(quoteParts[1]);
+    } else {
+      throw new Error(`Invalid text fragment quote format: ${str}`);
+    }
+
     const suffix = match[4] ? decodeURIComponent(match[4]) : null;
     const pageIndex = pageNumber ? book.getPageIndex(pageNumber) : fallbackPageIndex;
     if (typeof pageIndex !== 'number') {
       throw new Error(`Could not determine page index for text fragment with page number ${pageNumber}`);
     }
 
-    return new BookReaderTextFragment({ prefix, quote, suffix, pageNumber, pageIndex });
+    if (!quote && (!quoteStart || !quoteEnd)) {
+      throw new Error(`Invalid text fragment quote format: ${str}`);
+    }
+
+    return new BookReaderTextFragment({
+      prefix,
+      quote,
+      quoteStart,
+      quoteEnd,
+      suffix,
+      pageNumber,
+      pageIndex,
+    });
   }
 
   /**
@@ -1137,8 +1216,9 @@ export class BookReaderTextFragment {
   /**
    * Outputs a url-safe string serialization of the text fragment, that's a variation of the standard
    * browser TextFragment format to include page information: `pageNumber:prefix-,quote,-suffix`
+  * If quote text is long enough, it is serialized as `quoteStart,quoteEnd`.
     * Note the ':' and ',' separators must not and are not encoded, but
-    * the pageNumber, prefix, quote, and suffix text are encoded.
+   * the pageNumber, prefix, quote/quoteStart/quoteEnd, and suffix text are encoded.
    * @returns {string}
    */
   toUrlString() {
@@ -1148,7 +1228,30 @@ export class BookReaderTextFragment {
     if (this.prefix) {
       str += `${encodeURIComponent(this.prefix)}-,`;
     }
-    str += encodeURIComponent(this.quote);
+
+    const quote = this.quote?.trim() || null;
+    let shortenedQuoteParts = null;
+    if (quote && quote.length > MAX_FULL_QUOTE_URL_CHARS) {
+      const words = quote.match(/\S+/g) || [];
+      if (words.length >= TRUNCATED_QUOTE_WORD_COUNT * 2) {
+        const quoteStart = getFirstWords(TRUNCATED_QUOTE_WORD_COUNT, quote);
+        const quoteEnd = getLastWords(TRUNCATED_QUOTE_WORD_COUNT, quote);
+        if (quoteStart && quoteEnd) {
+          shortenedQuoteParts = { quoteStart, quoteEnd };
+        }
+      }
+    }
+
+    if (quote && !shortenedQuoteParts) {
+      str += encodeURIComponent(quote);
+    } else if (shortenedQuoteParts) {
+      str += `${encodeURIComponent(shortenedQuoteParts.quoteStart)},${encodeURIComponent(shortenedQuoteParts.quoteEnd)}`;
+    } else if (this.quoteStart && this.quoteEnd) {
+      str += `${encodeURIComponent(this.quoteStart)},${encodeURIComponent(this.quoteEnd)}`;
+    } else {
+      throw new Error('Text fragment requires either a quote or quoteStart/quoteEnd');
+    }
+
     if (this.suffix) {
       str += `,-${encodeURIComponent(this.suffix)}`;
     }
@@ -1159,6 +1262,8 @@ export class BookReaderTextFragment {
     return {
       prefix: this.prefix,
       quote: this.quote,
+      quoteStart: this.quoteStart,
+      quoteEnd: this.quoteEnd,
       suffix: this.suffix,
       pageNumber: this.pageNumber,
       pageIndex: this.pageIndex,
@@ -1209,6 +1314,7 @@ export class BookReaderTextFragment {
       .replace(/[ ]+/g, " ")
       .trim()
       .replace(/\n[^\n]*$/gm, "");
+
 
     // Guarantee that all whitespace is replaced with just one space and that the first/last word of the highlight is not a space
     const quote = fullQuoteRange.toString().replace(/\s+/g, " ").trim();

--- a/tests/jest/util/TextSelectionManager.test.js
+++ b/tests/jest/util/TextSelectionManager.test.js
@@ -4,6 +4,7 @@ import BookReader from '@/src/BookReader.js';
 import '@/src/plugins/plugin.text_selection.js';
 import {
   BookReaderTextFragment,
+  findRangesForQuotes,
   getFirstWords,
   getLastWords,
   walkBetweenNodes,
@@ -581,6 +582,86 @@ describe('BookReaderTextFragment.fromString', () => {
     expect(() => BookReaderTextFragment.fromString('missing:quote', book, 3))
       .toThrow('Could not determine page index for text fragment with page number missing');
   });
+
+  test('parses quoteStart/quoteEnd quote region', () => {
+    const book = {
+      getPageIndex: sinon.stub().withArgs('12').returns(42),
+    };
+
+    const fragment = BookReaderTextFragment.fromString(
+      '12:before%20text-,The%20quick%20brown,the%20lazy%20dog,-after%20text',
+      book,
+      7,
+    );
+
+    expect(fragment.pageNumber).toBe('12');
+    expect(fragment.pageIndex).toBe(42);
+    expect(fragment.prefix).toBe('before text');
+    expect(fragment.quote).toBeNull();
+    expect(fragment.quoteStart).toBe('The quick brown');
+    expect(fragment.quoteEnd).toBe('the lazy dog');
+    expect(fragment.suffix).toBe('after text');
+  });
+
+  test('throws when quote region has more than one separator comma', () => {
+    const book = {
+      getPageIndex: sinon.stub().withArgs('12').returns(42),
+    };
+
+    expect(() => BookReaderTextFragment.fromString('12:a,b,c', book, 7))
+      .toThrow('Invalid text fragment quote format: 12:a,b,c');
+  });
+});
+
+describe('BookReaderTextFragment.toUrlString', () => {
+  test('serializes short quote as full quote', () => {
+    const fragment = new BookReaderTextFragment({
+      pageNumber: '12',
+      pageIndex: 5,
+      prefix: 'before text',
+      quote: 'short quote',
+      suffix: 'after text',
+    });
+
+    expect(fragment.toUrlString()).toBe('12:before%20text-,short%20quote,-after%20text');
+  });
+
+  test('serializes long quote as quoteStart/quoteEnd', () => {
+    const fragment = new BookReaderTextFragment({
+      pageNumber: '12',
+      pageIndex: 5,
+      prefix: 'before text',
+      quote: 'alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau',
+      suffix: 'after text',
+    });
+
+    expect(fragment.toUrlString()).toBe('12:before%20text-,alpha%20beta%20gamma,rho%20sigma%20tau,-after%20text');
+  });
+
+  test('serializes long quote with fewer than 6 words as full quote', () => {
+    const fragment = new BookReaderTextFragment({
+      pageNumber: '12',
+      pageIndex: 5,
+      prefix: 'before text',
+      quote: 'antidisestablishmentarianism supercalifragilisticexpialidocious pneumonoultramicroscopicsilicovolcanoconiosis hippopotomonstrosesquipedaliophobia floccinaucinihilipilification',
+      suffix: 'after text',
+    });
+
+    expect(fragment.toUrlString()).toBe('12:before%20text-,antidisestablishmentarianism%20supercalifragilisticexpialidocious%20pneumonoultramicroscopicsilicovolcanoconiosis%20hippopotomonstrosesquipedaliophobia%20floccinaucinihilipilification,-after%20text');
+  });
+
+  test('serializes explicit quoteStart/quoteEnd when quote is missing', () => {
+    const fragment = new BookReaderTextFragment({
+      pageNumber: '12',
+      pageIndex: 5,
+      prefix: null,
+      quoteStart: 'The quick brown',
+      quoteEnd: 'the lazy dog',
+      suffix: null,
+    });
+
+    expect(fragment.toUrlString()).toBe('12:The%20quick%20brown,the%20lazy%20dog');
+  });
 });
 
 
@@ -647,5 +728,38 @@ describe('walkBetweenNodes', () => {
     // Last word should be the end word
     expect(result[result.length - 1].parentElement).toBe(end);
     expect(result[result.length - 1].textContent).toBe('Suppose');
+  });
+});
+
+describe('findRangesForQuotes', () => {
+  afterEach(() => {
+    sinon.restore();
+    $('.BRtextLayer').remove();
+  });
+
+  test('returns ordered non-overlapping ranges for multiple quote parts', async () => {
+    const $container = $("<div class='BRpagecontainer' data-page-num='12' data-index='15'></div>").appendTo(br.refs.$brContainer);
+    sinon.stub(br.plugins.textSelection, 'getPageText')
+      .returns($(new DOMParser().parseFromString(FAKE_DIALOGUE, 'text/xml')));
+    await br.plugins.textSelection.createTextLayer({ $container, page: {index: 1, width: 100, height: 100 }});
+
+    const textLayer = $container.find('.BRtextLayer')[0];
+    const firstPageNode = textLayer;
+    const lastPageNode = textLayer;
+    const wholePageRange = new Range();
+    wholePageRange.setStart(firstPageNode, 0);
+    wholePageRange.setEnd(lastPageNode, lastPageNode.childNodes.length);
+    const textNodes = Array.from(textLayer.querySelectorAll('.BRwordElement, .BRspace, br, .BRlineElement'));
+    textNodes.splice(0, 1);
+
+    const ranges = findRangesForQuotes([
+      '“My own seal.”',
+      '“My photograph.”',
+    ], wholePageRange, textNodes);
+
+    expect(ranges).toHaveLength(2);
+    expect(ranges[0].toString().replace(/\s+/g, ' ').trim()).toBe('“My own seal.”');
+    expect(ranges[1].toString().replace(/\s+/g, ' ').trim()).toBe('“My photograph.”');
+    expect(ranges[0].compareBoundaryPoints(Range.END_TO_START, ranges[1])).toBeLessThanOrEqual(0);
   });
 });

--- a/tests/jest/util/TextSelectionManager.test.js
+++ b/tests/jest/util/TextSelectionManager.test.js
@@ -4,7 +4,7 @@ import BookReader from '@/src/BookReader.js';
 import '@/src/plugins/plugin.text_selection.js';
 import {
   BookReaderTextFragment,
-  findRangesForQuotes,
+  findRangeForRegExp,
   getFirstWords,
   getLastWords,
   walkBetweenNodes,
@@ -731,13 +731,33 @@ describe('walkBetweenNodes', () => {
   });
 });
 
-describe('findRangesForQuotes', () => {
+describe('BookReaderTextFragment.toRegExp and findRangeForRegExp', () => {
   afterEach(() => {
     sinon.restore();
     $('.BRtextLayer').remove();
   });
 
-  test('returns ordered non-overlapping ranges for multiple quote parts', async () => {
+  test('includes context text when requested', () => {
+    const quote = new BookReaderTextFragment({
+      prefix: 'Before',
+      quote: 'middle',
+      quoteStart: null,
+      quoteEnd: null,
+      suffix: 'After',
+      pageNumber: null,
+      pageIndex: 0,
+    });
+
+    const nonContextRegex = quote.toRegExp({ context: false });
+    const contextRegex = quote.toRegExp({ context: true });
+
+    expect(nonContextRegex.test('middle')).toBe(true);
+    expect(nonContextRegex.test('Before middle After')).toBe(true);
+    expect(contextRegex.test('Before middle After')).toBe(true);
+    expect(contextRegex.test('middle')).toBe(false);
+  });
+
+  test('finds single quote matches as ranges', async () => {
     const $container = $("<div class='BRpagecontainer' data-page-num='12' data-index='15'></div>").appendTo(br.refs.$brContainer);
     sinon.stub(br.plugins.textSelection, 'getPageText')
       .returns($(new DOMParser().parseFromString(FAKE_DIALOGUE, 'text/xml')));
@@ -752,14 +772,49 @@ describe('findRangesForQuotes', () => {
     const textNodes = Array.from(textLayer.querySelectorAll('.BRwordElement, .BRspace, br, .BRlineElement'));
     textNodes.splice(0, 1);
 
-    const ranges = findRangesForQuotes([
-      '“My own seal.”',
-      '“My photograph.”',
-    ], wholePageRange, textNodes);
+    const quoteStart = new BookReaderTextFragment({
+      prefix: null,
+      quote: '“My own seal.”',
+      quoteStart: null,
+      quoteEnd: null,
+      suffix: null,
+      pageNumber: null,
+      pageIndex: 0,
+    });
+    const quoteEnd = new BookReaderTextFragment({
+      prefix: null,
+      quote: '“My photograph.”',
+      quoteStart: null,
+      quoteEnd: null,
+      suffix: null,
+      pageNumber: null,
+      pageIndex: 0,
+    });
 
-    expect(ranges).toHaveLength(2);
-    expect(ranges[0].toString().replace(/\s+/g, ' ').trim()).toBe('“My own seal.”');
-    expect(ranges[1].toString().replace(/\s+/g, ' ').trim()).toBe('“My photograph.”');
-    expect(ranges[0].compareBoundaryPoints(Range.END_TO_START, ranges[1])).toBeLessThanOrEqual(0);
+    const range = findRangeForRegExp(
+      quoteStart.toRegExp({ normalize: (s) => s.replace(/\s+/g, ' ') }),
+      wholePageRange,
+      textNodes,
+      { normalize: (s) => s.replace(/\s+/g, ' ') },
+    );
+    const quoteStartRange = findRangeForRegExp(
+      quoteStart.toRegExp({ normalize: (s) => s.replace(/\s+/g, ' ') }),
+      wholePageRange,
+      textNodes,
+      { normalize: (s) => s.replace(/\s+/g, ' ') },
+    );
+    const quoteEndRange = findRangeForRegExp(
+      quoteEnd.toRegExp({ normalize: (s) => s.replace(/\s+/g, ' ') }),
+      wholePageRange,
+      textNodes,
+      { normalize: (s) => s.replace(/\s+/g, ' ') },
+    );
+
+    expect(range).toBeTruthy();
+    expect(quoteStartRange).toBeTruthy();
+    expect(quoteEndRange).toBeTruthy();
+    expect(range[0].toString().replace(/\s+/g, ' ').trim()).toBe('“My own seal.”');
+    expect(quoteStartRange[0].toString().replace(/\s+/g, ' ').trim()).toBe('“My own seal.”');
+    expect(quoteEndRange[0].toString().replace(/\s+/g, ' ').trim()).toBe('“My photograph.”');
   });
 });


### PR DESCRIPTION
Add support for including only the quote start and end in the url when using Copy Link to Highlight, instead of having very long URLs.

Eg https://deploy-preview-1553--ia-bookreader.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=theworksofplato01platiala&text=221:one%20of%20those.-,Socr.%20Neither%2C%20my,speak%20to%20you#page/220/mode/2up