### PR TITLE
Small Copy Link to Highlight fixes

### DIFF
--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -149,6 +149,7 @@
   display: none;
   border-radius: 20px;
   background-color: #333;
+  color: white;
   color-scheme: dark;
   padding: 2px;
   overflow: hidden;

--- a/src/plugins/plugin.experiments.js
+++ b/src/plugins/plugin.experiments.js
@@ -52,8 +52,11 @@ export class ExperimentsPlugin extends BookReaderPlugin {
     /** Where the state of this plugin is saved in localStorage */
     localStorageKey: 'BrExperiments',
 
-    /** The experiments that should be shown in the experiments panel */
-    enabledExperiments: ['translate', 'copyLinkToHighlight'],
+    /** @type {ExperimentName[]} The experiments that should be shown in the experiments panel */
+    availableExperiments: ['translate', 'copyLinkToHighlight'],
+
+    /** @type {ExperimentName[]} The experiments that should be automatically enabled for all users */
+    autoEnabledExperiments: [],
   }
 
   /** @type {ExperimentModel[]} */
@@ -160,7 +163,14 @@ export class ExperimentsPlugin extends BookReaderPlugin {
       if (experiment.icon) {
         experiment.icon = experiment.buildAssetPath(experiment.icon);
       }
+
       experiment.br = this.br;
+
+      // Enable any experiments that should be automatically enabled
+      if (!experiment.enabled && this.options.autoEnabledExperiments.includes(experiment.name)) {
+        experiment.enabled = true;
+        await experiment.enable({ manual: false });
+      }
     }
 
     this._loadExperimentStates();
@@ -222,7 +232,7 @@ export class ExperimentsPlugin extends BookReaderPlugin {
       `,
       label: 'Experiments',
       component: html`<br-experiments-panel
-        .experiments="${this.allExperiments.filter(experiment => this.options.enabledExperiments.includes(experiment.name))}"
+        .experiments="${this.allExperiments.filter(experiment => this.options.availableExperiments.includes(experiment.name))}"
         @connected="${e => this._panel = e.target}"
         @toggle="${async e => {
         await this._toggleExperiment(e.detail.experiment, e.detail.enabled);

--- a/src/plugins/plugin.experiments.js
+++ b/src/plugins/plugin.experiments.js
@@ -52,10 +52,10 @@ export class ExperimentsPlugin extends BookReaderPlugin {
     /** Where the state of this plugin is saved in localStorage */
     localStorageKey: 'BrExperiments',
 
-    /** @type {ExperimentName[]} The experiments that should be shown in the experiments panel */
+    /** @type {ExperimentName[]} Experiments shown in the experiments panel */
     availableExperiments: ['translate', 'copyLinkToHighlight'],
 
-    /** @type {ExperimentName[]} The experiments that should be automatically enabled for all users */
+    /** @type {ExperimentName[]} Experiments enabled by default */
     autoEnabledExperiments: [],
   }
 

--- a/src/plugins/tts/plugin.tts.js
+++ b/src/plugins/tts/plugin.tts.js
@@ -2,11 +2,11 @@
 
 import FestivalTTSEngine from './FestivalTTSEngine.js';
 import WebTTSEngine from './WebTTSEngine.js';
-import { toISO6391, approximateWordCount } from './utils.js';
+import { toISO6391 } from './utils.js';
 import { en as tooltips } from './tooltip_dict.js';
 import { renderBoxesInPageContainerLayer } from '../../BookReader/PageContainer.js';
 import { BookReaderPlugin } from '../../BookReaderPlugin.js';
-import { applyVariables } from '../../util/strings.js';
+import { applyVariables, countWords } from '../../util/strings.js';
 /** @typedef {import('./PageChunk.js').default} PageChunk */
 /** @typedef {import("./AbstractTTSEngine.js").default} AbstractTTSEngine */
 
@@ -291,7 +291,7 @@ export class TtsPlugin extends BookReaderPlugin {
    * @param {PageChunk} chunk
    */
   sendChunkFinishedAnalyticsEvent(chunk) {
-    this.sendAnalyticsEvent('ChunkFinished-Words', approximateWordCount(chunk.text));
+    this.sendAnalyticsEvent('ChunkFinished-Words', countWords(chunk.text));
   }
 
   /**

--- a/src/plugins/tts/utils.js
+++ b/src/plugins/tts/utils.js
@@ -2,16 +2,6 @@
 import langs from 'iso-language-codes';
 
 /**
- * Use regex to approximate word count in a string
- * @param {string} text
- * @return {number}
- */
-export function approximateWordCount(text) {
-  const m = text.match(/\S+/g);
-  return m ? m.length : 0;
-}
-
-/**
  * Checks whether the current browser is on android
  * @param {string} [userAgent]
  * @return {boolean}

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -761,6 +761,15 @@ export function getLastWords(numWords, text) {
 }
 
 /**
+ * @param {string} text
+ */
+export function countWords(text) {
+  const re = /\S+/g;
+  const matches = text.match(re);
+  return matches ? matches.length : 0;
+}
+
+/**
  * @param {Node} parent
  * @returns {Node}
  */
@@ -1298,19 +1307,30 @@ export class BookReaderTextFragment {
     const lastWordOfPageEl = getLastMostNode(contextElements[contextElements.length - 1]);
     postEndRange.setEnd(lastWordOfPageEl, Math.max(0, lastWordOfPageEl.textContent.length - 1));
 
-    // prefixes/suffixes cannot contain paragraph breaks, words that are from more than one line break away should not be included
-    const prefix = getLastWords(3, preStartRange.toString())
-      .replace(/[ ]+/g, " ")
-      .trim()
-      .replace(/^[^\n]*\n/gm, "");
-    const suffix = getFirstWords(3, postEndRange.toString())
-      .replace(/[ ]+/g, " ")
-      .trim()
-      .replace(/\n[^\n]*$/gm, "");
+    const CONTEXT_WORD_COUNT = 3;
 
+    const preStartText = replaceWhitespace(preStartRange.toString());
+    let prefix = getLastWords(CONTEXT_WORD_COUNT, preStartText);
+    let prefixWords = countWords(prefix);
+
+    const postEndText = replaceWhitespace(postEndRange.toString());
+    let suffix = getFirstWords(CONTEXT_WORD_COUNT, postEndText);
+    let suffixWords = countWords(suffix);
+
+    if (prefixWords < CONTEXT_WORD_COUNT) {
+      // Ran out of words! To reduce the risk of ambiguity, try extending suffix
+      suffix = getFirstWords(2 * CONTEXT_WORD_COUNT - prefixWords, postEndText);
+      suffixWords = countWords(suffix);
+    }
+
+    if (suffixWords < CONTEXT_WORD_COUNT) {
+      // Ran out of words on the suffix side as well, try extending prefix
+      prefix = getLastWords(2 * CONTEXT_WORD_COUNT - suffixWords, preStartText);
+      prefixWords = countWords(prefix);
+    }
 
     // Guarantee that all whitespace is replaced with just one space and that the first/last word of the highlight is not a space
-    const quote = fullQuoteRange.toString().replace(/\s+/g, " ").trim();
+    const quote = replaceWhitespace(fullQuoteRange.toString()).trim();
     const pageContainerEl = startTextNode.parentElement.closest(".BRpagecontainer");
 
     return new BookReaderTextFragment({

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -557,8 +557,10 @@ class BRSelectMenu extends LitElement {
   async handleCopyLinkToHighlight(e) {
     e.preventDefault();
     const currentParams = this.br.readQueryString();
-    const currentSelection = window.getSelection();
-    const textFragment = BookReaderTextFragment.fromSelection(currentSelection, this.br.$('.BRpage-visible').toArray());
+    const currentSelection = /** @type {Selection} */ (window.getSelection());
+    const range = currentSelection.getRangeAt(0);
+    const textLayer = range.startContainer.parentElement.closest('.BRtextLayer');
+    const textFragment = BookReaderTextFragment.fromSelection(currentSelection, [textLayer]);
 
     // Note: Have to do a param construction to avoid url-encoding of commas in the text fragment param
     let linkToHighlightParams = currentParams;

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -560,7 +560,11 @@ class BRSelectMenu extends LitElement {
     const currentParams = this.br.readQueryString();
     const currentSelection = /** @type {Selection} */ (window.getSelection());
     const range = currentSelection.getRangeAt(0);
-    const textLayer = range.startContainer.parentElement.closest('.BRtextLayer');
+    const textLayer = this.getNodeTextLayer(range.startContainer);
+    if (!textLayer) {
+      console.warn("No text layer found for selection");
+      return;
+    }
     const textFragment = BookReaderTextFragment.fromSelection(currentSelection, [textLayer]);
 
     // Note: Have to do a param construction to avoid url-encoding of commas in the text fragment param
@@ -584,11 +588,11 @@ class BRSelectMenu extends LitElement {
   /**
    * Returns the closest BRtextLayer element on the page that contains the target node
    * @param {Node} node
-   * @returns {HTMLElement | null}
+   * @returns {Element | null}
    */
   getNodeTextLayer(node) {
-    if (!node) return;
-    const element = 'closest' in node ? node : node.parentElement;
+    if (!node) return null;
+    const element = node instanceof Element ? node : node.parentElement;
     return element?.closest('.BRtextLayer') ?? null;
   }
 
@@ -1277,7 +1281,7 @@ export class BookReaderTextFragment {
   /**
    * Builds a TextFragment string from a given text selection.
    * @param {Selection} selection currently selected text, eg `document.getSelection()`
-   * @param {HTMLElement[]} contextElements elements providing context for the selection
+   * @param {Element[]} contextElements elements providing context for the selection
    * @returns {BookReaderTextFragment}
    */
   static fromSelection(selection, contextElements) {

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -1,4 +1,5 @@
 // @ts-check
+import { countWords } from './strings.js';
 import { SelectionObserver } from "../BookReader/utils/SelectionObserver.js";
 import { html, LitElement } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
@@ -758,15 +759,6 @@ export function getLastWords(numWords, text) {
   const re = new RegExp(String.raw`((^|\s+)\S+){1,${numWords}}\s*?$`);
   const m = text.match(re);
   return m ? m[0].trim() : "";
-}
-
-/**
- * @param {string} text
- */
-export function countWords(text) {
-  const re = /\S+/g;
-  const matches = text.match(re);
-  return matches ? matches.length : 0;
 }
 
 /**

--- a/src/util/strings.js
+++ b/src/util/strings.js
@@ -6,6 +6,16 @@
  **/
 
 /**
+ * Count whitespace-delimited words in a string.
+ * @param {string} text
+ * @return {number}
+ */
+export function countWords(text) {
+  const matches = text.match(/\S+/g);
+  return matches ? matches.length : 0;
+}
+
+/**
  * @param {StringWithVars|String} template
  * @param { {[varName: string]: { toString: () => string} } } vars
  * @param { {[varName: string]: { toString: () => string} } } [overrides]

--- a/tests/jest/plugins/tts/utils.test.js
+++ b/tests/jest/plugins/tts/utils.test.js
@@ -1,37 +1,5 @@
 import * as utils from '@/src/plugins/tts/utils.js';
 
-describe('approximateWordCount', () => {
-  const { approximateWordCount } = utils;
-
-  test('Empties', () => {
-    expect(approximateWordCount('')).toBe(0);
-    expect(approximateWordCount('    ')).toBe(0);
-  });
-
-  test('Spaceless', () => {
-    expect(approximateWordCount('supercalifragilisticexpialidocious')).toBe(1);
-  });
-
-  test('Basic', () => {
-    expect(approximateWordCount('the quick brown fox jumped over the lazy dog')).toBe(9);
-    expect(approximateWordCount('to be or not to be that is the question')).toBe(10);
-  });
-
-  test('Spacing', () => {
-    expect(approximateWordCount('   the     quick brown   fox jumped over the lazy dog ')).toBe(9);
-  });
-
-  test('Punctuation not separate word (unless separate)', () => {
-    expect(approximateWordCount('the. quick brown. fox. jumped. over the. lazy dog.')).toBe(9);
-    expect(approximateWordCount(' . . . . . ')).toBe(5);
-  });
-
-  test('Realword examples', () => {
-    expect(approximateWordCount("Albert\u2019s cats had a .large blue dish of milk for breakfast.")).toBe(11);
-    expect(approximateWordCount("FARM FOLK O nce upon a time there was a sturdy little boy who lived in Belgium. Every morning after he milked the cows, he gave his cats a large blue dish of milk for breakfast.")).toBe(36);
-  });
-});
-
 describe('toISO6391', () => {
   const { toISO6391 } = utils;
 

--- a/tests/jest/util/TextSelectionManager.test.js
+++ b/tests/jest/util/TextSelectionManager.test.js
@@ -4,6 +4,7 @@ import BookReader from '@/src/BookReader.js';
 import '@/src/plugins/plugin.text_selection.js';
 import {
   BookReaderTextFragment,
+  countWords,
   findRangeForRegExp,
   getFirstWords,
   getLastWords,
@@ -403,7 +404,7 @@ describe("BookReaderTextFragment.fromSelection tests", () => {
     selection.removeAllRanges();
     selection.addRange(startWordRange);
     const startingSpaceTextFragmentUrl = BookReaderTextFragment.fromSelection(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
-    expect(startingSpaceTextFragmentUrl.toUrlString()).toBe(`12:way-,can%20false%20judgment%20be%20-%20formed.,-There%20still%20remains`);
+    expect(startingSpaceTextFragmentUrl.toUrlString()).toBe(`12:way-,can%20false%20judgment%20be%20-%20formed.,-There%20still%20remains%20another%20mode`);
 
     const endWordRange = document.createRange();
     endWordRange.setStart($container.find(".BRwordElement")[1].firstChild, 0);
@@ -413,7 +414,7 @@ describe("BookReaderTextFragment.fromSelection tests", () => {
     selection.addRange(endWordRange);
     const endingSpaceTextFragmentUrl = BookReaderTextFragment.fromSelection(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
 
-    expect(endingSpaceTextFragmentUrl.toUrlString()).toBe("12:way-,can%20false%20judgment%20be%20-,-formed.%20There%20still");
+    expect(endingSpaceTextFragmentUrl.toUrlString()).toBe("12:way-,can%20false%20judgment%20be%20-,-formed.%20There%20still%20remains%20another");
   });
 
   test("Handle range end node not text node", async () => {
@@ -475,7 +476,7 @@ describe("BookReaderTextFragment.fromSelection tests", () => {
     selection.addRange(sameKeyHighlightRange);
     const similarHighlight = BookReaderTextFragment.fromSelection(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
 
-    expect(multipleHighlights.toUrlString()).toBe(`12:is%20quite%20distinctive.%E2%80%9D-,%E2%80%9CThat%20is,-easily%20got.%E2%80%9D`);
+    expect(multipleHighlights.toUrlString()).toBe(`12:is%20quite%20distinctive.%E2%80%9D-,%E2%80%9CThat%20is,-easily%20got.%E2%80%9D%20%E2%80%9CThat`);
     expect(multipleHighlights.toUrlString()).not.toBe(similarHighlight.toUrlString());
   });
 
@@ -499,24 +500,24 @@ describe("BookReaderTextFragment.fromSelection tests", () => {
     expect(multiLineBehavior.toUrlString()).toMatch("12:%E2%80%9CStolen.%E2%80%9D-,%E2%80%9CMy%20own%20seal.%E2%80%9D,-%E2%80%9CImitated.%E2%80%9D");
   });
 
-  test("Prefix/suffix exists even with < 3 words", async () => {
+  test("Prefix extended when < 3 words for suffix", async () => {
     const $container = $("<div class='BRpagecontainer' data-page-num='12' data-index='15'></div>").appendTo(br.refs.$brContainer);
     sinon.stub(br.plugins.textSelection, "getPageText")
       .returns($(new DOMParser().parseFromString(FAKE_DIALOGUE, "text/xml")));
     await br.plugins.textSelection.createTextLayer({ $container, page: {index: 1, width: 100, height: 100 }});
 
     const rangeBefore = document.createRange();
-    rangeBefore.setStart($($container.find(".BRparagraphElement")[3]).find(".BRwordElement")[0].firstChild, 0);
-    rangeBefore.setEnd($($container.find(".BRparagraphElement")[3]).find(".BRwordElement")[1].firstChild, 12);
+    rangeBefore.setStart($($container.find(".BRparagraphElement")[6]).find(".BRwordElement")[0].firstChild, 0);
+    rangeBefore.setEnd($($container.find(".BRparagraphElement")[6]).find(".BRwordElement")[1].firstChild, 3);
 
     const selection = window.getSelection();
     selection.removeAllRanges();
     selection.addRange(rangeBefore);
 
-    // “Imitated.”-, “My photograph.”,-“Bought.”
+    // “My photograph.” “Bought.” “My photograph.”-,“My own,-seal.”
     const endShortSuffix = BookReaderTextFragment.fromSelection(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
 
-    expect(endShortSuffix.toUrlString()).toMatch("12:%E2%80%9CImitated.%E2%80%9D-,%E2%80%9CMy%20photograph.%E2%80%9D,-%E2%80%9CBought.%E2%80%9D");
+    expect(endShortSuffix.toUrlString()).toMatch("12:%E2%80%9CMy%20photograph.%E2%80%9D%20%E2%80%9CBought.%E2%80%9D%20%E2%80%9CMy%20photograph.%E2%80%9D-,%E2%80%9CMy%20own,-seal.%E2%80%9D");
   });
 
   test("Able to match one non-unique highlighted word", async() => {
@@ -533,10 +534,10 @@ describe("BookReaderTextFragment.fromSelection tests", () => {
     selection.removeAllRanges();
     selection.addRange(rangeBefore);
 
-    // “Imitated.”-, “My,-photograph.”
+    // own seal. “Imitated.”-, “My,-photograph.”
     const singleTextFragment = BookReaderTextFragment.fromSelection(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
 
-    expect(singleTextFragment.toUrlString()).toMatch("12:%E2%80%9CImitated.%E2%80%9D-,%E2%80%9CMy,-photograph.%E2%80%9D");
+    expect(singleTextFragment.toUrlString()).toMatch("12:own%20seal.%E2%80%9D%20%E2%80%9CImitated.%E2%80%9D-,%E2%80%9CMy,-photograph.%E2%80%9D%20%E2%80%9CBought.%E2%80%9D%20%E2%80%9CMy");
   });
 });
 
@@ -684,6 +685,21 @@ describe("getFirstWords and getLastWords tests", () => {
   test("Handles string with punctuation", () => {
     expect(getFirstWords(3, "Hello, world! This is a test.")).toBe("Hello, world! This");
     expect(getLastWords(3, "Hello, world! This is a test.")).toBe("is a test.");
+  });
+});
+
+describe("countWords tests", () => {
+  test("handles empty or whitespace-only strings", () => {
+    expect(countWords("")).toBe(0);
+    expect(countWords("   \n\t  ")).toBe(0);
+  });
+
+  test("counts words separated by irregular whitespace", () => {
+    expect(countWords("one\n\ntwo\t\tthree   four")).toBe(4);
+  });
+
+  test("counts words with punctuation as words", () => {
+    expect(countWords("Hello, world! This is a test.")).toBe(6);
   });
 });
 

--- a/tests/jest/util/TextSelectionManager.test.js
+++ b/tests/jest/util/TextSelectionManager.test.js
@@ -4,7 +4,6 @@ import BookReader from '@/src/BookReader.js';
 import '@/src/plugins/plugin.text_selection.js';
 import {
   BookReaderTextFragment,
-  countWords,
   findRangeForRegExp,
   getFirstWords,
   getLastWords,
@@ -687,22 +686,6 @@ describe("getFirstWords and getLastWords tests", () => {
     expect(getLastWords(3, "Hello, world! This is a test.")).toBe("is a test.");
   });
 });
-
-describe("countWords tests", () => {
-  test("handles empty or whitespace-only strings", () => {
-    expect(countWords("")).toBe(0);
-    expect(countWords("   \n\t  ")).toBe(0);
-  });
-
-  test("counts words separated by irregular whitespace", () => {
-    expect(countWords("one\n\ntwo\t\tthree   four")).toBe(4);
-  });
-
-  test("counts words with punctuation as words", () => {
-    expect(countWords("Hello, world! This is a test.")).toBe(6);
-  });
-});
-
 
 describe('walkBetweenNodes', () => {
   const tree = $(FAKE_XML_MULT_LINES);

--- a/tests/jest/util/strings.test.js
+++ b/tests/jest/util/strings.test.js
@@ -1,4 +1,35 @@
-import { APPLY_FILTERS, applyVariables } from '@/src/util/strings.js';
+import { APPLY_FILTERS, applyVariables, countWords } from '@/src/util/strings.js';
+
+describe('countWords', () => {
+  test('Empties', () => {
+    expect(countWords('')).toBe(0);
+    expect(countWords('    ')).toBe(0);
+    expect(countWords('   \n\t  ')).toBe(0);
+  });
+
+  test('Spaceless', () => {
+    expect(countWords('supercalifragilisticexpialidocious')).toBe(1);
+  });
+
+  test('Basic', () => {
+    expect(countWords('the quick brown fox jumped over the lazy dog')).toBe(9);
+    expect(countWords('to be or not to be that is the question')).toBe(10);
+  });
+
+  test('Spacing', () => {
+    expect(countWords('   the     quick brown   fox jumped over the lazy dog ')).toBe(9);
+  });
+
+  test('Punctuation not separate word (unless separate)', () => {
+    expect(countWords('the. quick brown. fox. jumped. over the. lazy dog.')).toBe(9);
+    expect(countWords(' . . . . . ')).toBe(5);
+  });
+
+  test('Realword examples', () => {
+    expect(countWords("Albert\u2019s cats had a .large blue dish of milk for breakfast.")).toBe(11);
+    expect(countWords("FARM FOLK O nce upon a time there was a sturdy little boy who lived in Belgium. Every morning after he milked the cows, he gave his cats a large blue dish of milk for breakfast.")).toBe(36);
+  });
+});
 
 describe('applyVariables', () => {
   test('null cases', () => {


### PR DESCRIPTION
* Fix CSS bug when deployed to archive.org resulting in select menu having black text on a black background
* Add a new experiment option to auto-enable an experiment as we roll this out to internal testing. Will be used on IA during the deploy
    * BREAKING CHANGE: the experiment plugin's `enabledExperiments` option is now renamed to `availableExperiments`
* Fix first/last lines of page not working with Copy Link to Highlight by only including the current selection's text layer when building context
* Allow for paragraph break/newlines in prefix/suffix, so we can have more context, and less likely to have an ambiguous fragment
* If at start/end of page, extend suffix/prefix respectively to try to always have 6 words of context
