### PR TITLE
Fix sentry error from calling non-existent method

### DIFF
--- a/src/ia-bookreader/ia-bookreader.js
+++ b/src/ia-bookreader/ia-bookreader.js
@@ -302,8 +302,11 @@ export class IaBookReader extends LitElement {
       providers.bookmarks = new BookmarksProvider({
         ...this.baseProviderConfig,
         onProviderChange: (bookmarks) => {
-          const method = Object.keys(bookmarks).length ? 'add' : 'remove';
-          this[`${method}MenuShortcut`]('bookmarks');
+          if (Object.keys(bookmarks).length) {
+            this.addMenuShortcut('bookmarks');
+          } else {
+            this.removeMenuShortcut('bookmarks');
+          }
           this.updateMenuContents();
         },
       });
@@ -460,6 +463,14 @@ export class IaBookReader extends LitElement {
     }
 
     this.menuShortcuts.push(this.menuProviders[menuId]);
+    this._sortMenuShortcuts();
+  }
+
+  /**
+   * @param {string} menuId
+   */
+  removeMenuShortcut(menuId) {
+    this.menuShortcuts = this.menuShortcuts.filter((m) => m.id !== menuId);
     this._sortMenuShortcuts();
   }
 


### PR DESCRIPTION
Restore method removed in #1492 that was apparently being used!

Fixes https://sentry.archive.org/organizations/ia-ux/issues/624258/?environment=production&project=6&query=is%3Aunresolved&referrer=issue-stream&sort=freq

<img width="1092" height="196" alt="image" src="https://github.com/user-attachments/assets/2b04d070-10d7-4217-857b-9a41cf578c26" />
