### PR TITLE
Improve select menu positioning

### DIFF
--- a/BookReaderDemo/IADemoBr.js
+++ b/BookReaderDemo/IADemoBr.js
@@ -53,6 +53,7 @@ const modal = document.querySelector('modal-manager');
 iaBookReader.modal = modal;
 
 // Override options coming from IA
+BookReader.optionOverrides = BookReader.optionOverrides || {};
 BookReader.optionOverrides.imagesBaseURL = '/BookReader/images/';
 
 const initializeBookReader = (brManifest) => {

--- a/BookReaderDemo/demo-internetarchive.html
+++ b/BookReaderDemo/demo-internetarchive.html
@@ -228,6 +228,28 @@
       <br>
     </div>
   </section>
+  <details class="demo">
+    <summary>Browser details</summary>
+    <dl id="browser-details"></dl>
+  </details>
+  <script>
+    const details = {
+      'navigator.userAgent': navigator.userAgent,
+      'navigator.vendor': navigator.vendor,
+      'navigator.maxTouchPoints': navigator.maxTouchPoints,
+      'navigator.userAgentData.mobile': navigator.userAgentData?.mobile ?? '(unavailable)',
+      'navigator.userAgentData.platform': navigator.userAgentData?.platform ?? '(unavailable)',
+      'window.innerWidth': window.innerWidth,
+      'window.innerHeight': window.innerHeight,
+      'screen.width': screen.width,
+      'screen.height': screen.height,
+      'devicePixelRatio': window.devicePixelRatio,
+    };
+    const dl = document.querySelector('#browser-details');
+    for (const [key, value] of Object.entries(details)) {
+      dl.innerHTML += `<dt><code>${key}</code></dt><dd>${value}</dd>`;
+    }
+  </script>
   <div class="demo">
     <h3>Placeholder div to allow scrolling</h3>
   </div>

--- a/BookReaderDemo/immersion-1up.html
+++ b/BookReaderDemo/immersion-1up.html
@@ -37,6 +37,7 @@
 
 <script>
 // Override options coming from IA
+BookReader.optionOverrides = BookReader.optionOverrides || {};
 BookReader.optionOverrides.imagesBaseURL = '/BookReader/images/';
 BookReader.optionOverrides.urlMode = 'history';
 BookReader.optionOverrides.urlHistoryBasePath = `${window.location.pathname}/`;

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -852,6 +852,7 @@ BookReader.prototype.setupKeyListeners = function () {
 
     // Ignore if modifiers are active.
     if (e.getModifierState('Control') ||
+      e.getModifierState('Shift') ||
       e.getModifierState('Alt') ||
       e.getModifierState('Meta') ||
       e.getModifierState('Win') /* hack for IE */) {

--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -151,7 +151,7 @@ BookReader.defaultOptions = DEFAULT_OPTIONS;
  * @type {BookReaderOptions}
  * This is here, just in case you need to absolutely override an option.
  */
-BookReader.optionOverrides = {};
+BookReader.optionOverrides = BookReader.optionOverrides || {};
 
 /**
  * Setup

--- a/src/BookReader/utils/SelectionObserver.js
+++ b/src/BookReader/utils/SelectionObserver.js
@@ -4,8 +4,8 @@ export class SelectionObserver {
   startedInSelector = false;
   /** @type {HTMLElement} */
   target = null;
-  /** @type {string} */
-  lastKnownSelectionText = '';
+  /** @type {Node | null} */
+  lastKnownFocusNode = null;
 
   /**
    * @param {string} selector
@@ -37,17 +37,18 @@ export class SelectionObserver {
       if (!target) return;
       this.target = target;
       this.selecting = true;
-      this.lastKnownSelectionText = sel.toString();
+      this.lastKnownFocusNode = sel.focusNode;
       this.handler('started', this.target);
     }
 
-    if (this.selecting && sel.toString() !== this.lastKnownSelectionText) {
-      this.lastKnownSelectionText = sel.toString();
+    if (this.selecting && this.lastKnownFocusNode != sel.focusNode && sel.toString() && !sel.isCollapsed) {
+      this.lastKnownFocusNode = sel.focusNode;
       this.handler('changed', this.target);
     }
 
     if (this.selecting && (sel.isCollapsed || !sel.toString() || !$(sel.anchorNode).closest(this.selector)[0])) {
       this.selecting = false;
+      this.lastKnownFocusNode = null;
       this.handler('cleared', this.target);
     }
   };

--- a/src/BookReader/utils/SelectionObserver.js
+++ b/src/BookReader/utils/SelectionObserver.js
@@ -4,8 +4,8 @@ export class SelectionObserver {
   startedInSelector = false;
   /** @type {HTMLElement} */
   target = null;
-  /** @type {Node} */
-  lastKnownFocusNode = null;
+  /** @type {string} */
+  lastKnownSelectionText = '';
 
   /**
    * @param {string} selector
@@ -30,18 +30,19 @@ export class SelectionObserver {
 
   _onSelectionChange = () => {
     const sel = window.getSelection();
+    if (!sel) return;
 
     if (!this.selecting && sel.toString()) {
       const target = $(sel.anchorNode).closest(this.selector)[0];
       if (!target) return;
       this.target = target;
       this.selecting = true;
-      this.lastKnownFocusNode = sel.focusNode;
+      this.lastKnownSelectionText = sel.toString();
       this.handler('started', this.target);
     }
 
-    if (this.selecting && (this.lastKnownFocusNode != sel.focusNode || sel.toString() && !sel.isCollapsed)) {
-      this.lastKnownFocusNode = sel.focusNode;
+    if (this.selecting && sel.toString() !== this.lastKnownSelectionText) {
+      this.lastKnownSelectionText = sel.toString();
       this.handler('changed', this.target);
     }
 

--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -153,7 +153,12 @@
   color-scheme: dark;
   padding: 2px;
   overflow: hidden;
+  opacity: 1;
   transition: border-radius 0.2s, opacity 0.2s;
+
+  @starting-style {
+    opacity: 0;
+  }
 }
 .br-select-menu__root--scrolling {
   opacity: 0;

--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -176,6 +176,7 @@
   align-items: center;
   border-radius: 20px;
   font-family: inherit;
+  color: inherit;
   border: 0;
   transition: background-color 0.2s, border-radius 0.2s;
   cursor: pointer;

--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -153,7 +153,11 @@
   color-scheme: dark;
   padding: 2px;
   overflow: hidden;
-  transition: border-radius 0.2s;
+  transition: border-radius 0.2s, opacity 0.2s;
+}
+.br-select-menu__root--scrolling {
+  opacity: 0;
+  pointer-events: none;
 }
 .br-select-menu__root:hover {
   border-radius: 8px;
@@ -191,18 +195,23 @@
 }
 
 .br-select-menu__label {
-  width: 0px;
-  opacity: 0;
-  interpolate-size: allow-keywords;
-  transition: width 0.2s;
+  margin-left: 4px;
   font-size: 12px;
 }
 
-
-.br-select-menu__root:hover .br-select-menu__label {
-  width: auto;
-  margin-left: 4px;
-  opacity: 1;
+@media (hover: hover) {
+    .br-select-menu__label {
+        width: 0px;
+        margin-left: 0;
+        opacity: 0;
+        interpolate-size: allow-keywords;
+        transition: width 0.2s;
+    }
+    .br-select-menu__root:hover .br-select-menu__label {
+        width: auto;
+        margin-left: 4px;
+        opacity: 1;
+    }
 }
 
 .BRtextLayer .BRhighlight {

--- a/src/plugins/tts/WebTTSEngine.js
+++ b/src/plugins/tts/WebTTSEngine.js
@@ -1,6 +1,6 @@
 /* global br */
-import { isChrome, isFirefox } from '../../util/browserSniffing.js';
-import { isAndroid, DEBUG_READ_ALOUD } from './utils.js';
+import { isChrome, isFirefox, isAndroid } from '../../util/browserSniffing.js';
+import { DEBUG_READ_ALOUD } from './utils.js';
 import { promisifyEvent, sleep } from '../../BookReader/utils.js';
 import AbstractTTSEngine from './AbstractTTSEngine.js';
 /** @typedef {import("./AbstractTTSEngine.js").PageChunk} PageChunk */

--- a/src/plugins/tts/utils.js
+++ b/src/plugins/tts/utils.js
@@ -1,15 +1,6 @@
 // @ts-check
 import langs from 'iso-language-codes';
 
-/**
- * Checks whether the current browser is on android
- * @param {string} [userAgent]
- * @return {boolean}
- */
-export function isAndroid(userAgent = navigator.userAgent) {
-  return /android/i.test(userAgent);
-}
-
 /** @type {{[lang: string]: string}} */
 // Handle odd one-off language pairs that might show up over time
 const specialLangs =  {

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -57,15 +57,12 @@ export class TextSelectionManager {
         // Set a class on the page to avoid hiding it when zooming/etc
         this.br.refs.$br.find('.BRpagecontainer--hasSelection').removeClass('BRpagecontainer--hasSelection');
         $(window.getSelection().anchorNode).closest('.BRpagecontainer').addClass('BRpagecontainer--hasSelection');
-        this.showSelectMenu();
-
+        // Don't show while still doing selection
+        if (!this.mouseIsDown) this.showSelectMenu();
       }
 
       if (selectEvent == 'changed') {
-        // hide the button as user changes their selection
-        if (this.mouseIsDown) {
-          this.hideSelectMenu();
-        } else if (window.getSelection()?.toString()) {
+        if (!this.mouseIsDown && window.getSelection()?.toString()) {
           this.showSelectMenu();
         }
       }
@@ -167,7 +164,6 @@ export class TextSelectionManager {
     // blocking selection
     $(textLayer).on("mousedown.textSelectPluginHandler", (event) => {
       this.mouseIsDown = true;
-      this.hideSelectMenu();
       if ($(event.target).is(this.selectionElement.join(", "))) {
         event.stopPropagation();
       }
@@ -175,7 +171,6 @@ export class TextSelectionManager {
 
     $(textLayer).on("mouseup.textSelectPluginHandler", (event) => {
       this.mouseIsDown = false;
-      this.hideSelectMenu();
       textLayer.style.pointerEvents = "none";
       if (skipNextMouseup) {
         skipNextMouseup = false;
@@ -201,7 +196,6 @@ export class TextSelectionManager {
       if (event.which != 1) return;
       this.mouseIsDown = true;
       event.stopPropagation();
-      this.hideSelectMenu();
     });
 
     // Prevent page flip on click
@@ -778,7 +772,8 @@ class BRSelectMenu extends LitElement {
     this.clearNodesForRemoval();
   }
 
-  hide = () => {
+  hide() {
+    if (!this.open) return;
     this.style.display = 'none';
     this.open = false;
     window.removeEventListener('scroll', this._onScroll, { capture: true });

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -514,9 +514,11 @@ class BRSelectMenu extends LitElement {
   }
 
   renderCopyLinkToHighlightOption() {
+    // Mousedown needed to prevent selection from being cleared on iOS
     return html`
       <br-menu-option
         id="copy-link-option"
+        @mousedown=${/** @param {MouseEvent} e */ (e) => e.preventDefault()}
         @click=${this.handleCopyLinkToHighlight}
         icon="share"
         label="Copy Link to Highlight"

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -7,6 +7,7 @@ import { customElement, property, query } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import '@internetarchive/icon-share';
 import '@internetarchive/icon-edit-pencil/icon-edit-pencil.js';
+import { isIOS, isAndroid } from './browserSniffing.js';
 
 const BR_HIGHLIGHTS_LOCAL_STORAGE_KEY = "BRhighlightStorage";
 const MAX_FULL_QUOTE_URL_CHARS = 80;
@@ -736,16 +737,20 @@ class BRSelectMenu extends LitElement {
   }
 
   repositionToSelection() {
-    // This is larger than both the iOS and Android text select menu
-    const OS_BAR_H = 60;
-    const MARGIN = 10;
+    const SCREEN_MARGIN = 10;
     const currentSelection = /** @type {Selection} */ (window.getSelection());
     const range = currentSelection.getRangeAt(0);
     const selectionRect = range.getBoundingClientRect();
 
-    const hlButtonTop = (selectionRect.top < OS_BAR_H
+    const isMobile = isIOS() || isAndroid();
+    // Leave room for mobile teardrop selection handles
+    const SELECTION_PADDING = isAndroid() ? 25 : isIOS() ? 15 : 10;
+    // On mobile, avoid the native OS text-selection bar which appears near the top of the screen
+    const OS_BAR_H = isMobile ? 60 : 0;
+    const idealTop = (selectionRect.top < OS_BAR_H
       ? selectionRect.bottom + OS_BAR_H
-      : selectionRect.bottom + 20) + window.scrollY;
+      : selectionRect.bottom) + SELECTION_PADDING;
+    const top = Math.max(SCREEN_MARGIN, idealTop) + window.scrollY;
 
     const menuWidth = this.getBoundingClientRect().width;
     // Excludes scrollbars
@@ -753,9 +758,9 @@ class BRSelectMenu extends LitElement {
     const idealLeft = menuWidth > selectionRect.width
       ? selectionRect.left + selectionRect.width / 2 - menuWidth / 2
       : selectionRect.left;
-    const left = clamp(idealLeft, MARGIN, windowWidth - menuWidth - MARGIN) + window.scrollX;
+    const left = clamp(idealLeft, SCREEN_MARGIN, windowWidth - menuWidth - SCREEN_MARGIN) + window.scrollX;
 
-    this.style.top = `${hlButtonTop}px`;
+    this.style.top = `${top}px`;
     this.style.left = `${left}px`;
   }
 

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -507,7 +507,6 @@ class BRSelectMenu extends LitElement {
     this.setAttribute('role', 'menu');
     this.setAttribute('aria-label', 'Text selection actions');
     this.setAttribute('aria-orientation', 'vertical');
-    window.addEventListener('scroll', this._onScroll, { capture: true, passive: true });
   }
 
   /** @override */
@@ -771,6 +770,9 @@ class BRSelectMenu extends LitElement {
     this.style.position = 'absolute';
     this.style.display = 'block';
     this.open = true;
+    this.classList.remove('br-select-menu__root--scrolling');
+    window.removeEventListener('scroll', this._onScroll, { capture: true });
+    window.addEventListener('scroll', this._onScroll, { capture: true, passive: true });
     await this.updateComplete; // ensure Lit has rendered so getBoundingClientRect() returns real width
     this.repositionToSelection();
     this.clearNodesForRemoval();
@@ -779,6 +781,7 @@ class BRSelectMenu extends LitElement {
   hide = () => {
     this.style.display = 'none';
     this.open = false;
+    window.removeEventListener('scroll', this._onScroll, { capture: true });
     this.clearNodesForRemoval();
     return;
   }

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { countWords } from './strings.js';
 import { SelectionObserver } from "../BookReader/utils/SelectionObserver.js";
+import { clamp } from "../BookReader/utils.js";
 import { html, LitElement } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -221,7 +222,11 @@ export class TextSelectionManager {
       document.body.append(this.selectMenu);
     }
 
-    this.selectMenu.show();
+    if (this.selectMenu.open) {
+      this.selectMenu.repositionToSelection();
+    } else {
+      this.selectMenu.show();
+    }
   }
 
   hideSelectMenu() {
@@ -459,6 +464,9 @@ class BRSelectMenu extends LitElement {
   @query('#copy-link-option')
   copyLinkOption;
 
+  @property({type: Boolean, reflect: true})
+  open = false;
+
   @property({type: Boolean})
   copyLinkToHighlightEnabled = true;
 
@@ -479,12 +487,36 @@ class BRSelectMenu extends LitElement {
     return this;
   }
 
+  /** @type {number | null} */
+  _scrollTimeoutId = null;
+
+  _onScroll = () => {
+    this.classList.add('br-select-menu__root--scrolling');
+    if (this._scrollTimeoutId != null) clearTimeout(this._scrollTimeoutId);
+    this._scrollTimeoutId = window.setTimeout(() => {
+      this._scrollTimeoutId = null;
+      this.repositionToSelection();
+      this.classList.remove('br-select-menu__root--scrolling');
+    }, 150);
+  };
+
   /** @override */
   connectedCallback() {
     super.connectedCallback();
     this.setAttribute('role', 'menu');
     this.setAttribute('aria-label', 'Text selection actions');
     this.setAttribute('aria-orientation', 'vertical');
+    window.addEventListener('scroll', this._onScroll, { capture: true, passive: true });
+  }
+
+  /** @override */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener('scroll', this._onScroll, { capture: true });
+    if (this._scrollTimeoutId != null) {
+      clearTimeout(this._scrollTimeoutId);
+      this._scrollTimeoutId = null;
+    }
   }
 
   renderCopyLinkToHighlightOption() {
@@ -703,31 +735,45 @@ class BRSelectMenu extends LitElement {
     this.show();
   }
 
-  show() {
-    if (this.br.plugins.translate?.userToggleTranslate) return;
-    const currentSelection = window.getSelection();
-    const start = currentSelection.anchorNode.parentElement;
-    const end = currentSelection.focusNode.parentElement; // will always be a text node
-    const height = 30;
-    const width = 60;
-    const startBoundingRect = start.getBoundingClientRect();
-    const endBoundingRect = end.getBoundingClientRect();
-    let hlButtonTop = startBoundingRect.top - height;
-    let hlButtonLeft = startBoundingRect.left - width;
-    if (currentSelection.direction == 'backward') {
-      hlButtonTop = endBoundingRect.top - height;
-      hlButtonLeft = endBoundingRect.left - width;
-    }
+  repositionToSelection() {
+    // This is larger than both the iOS and Android text select menu
+    const OS_BAR_H = 60;
+    const MARGIN = 10;
+    const currentSelection = /** @type {Selection} */ (window.getSelection());
+    const range = currentSelection.getRangeAt(0);
+    const selectionRect = range.getBoundingClientRect();
+
+    const hlButtonTop = (selectionRect.top < OS_BAR_H
+      ? selectionRect.bottom + OS_BAR_H
+      : selectionRect.bottom + 20) + window.scrollY;
+
+    const menuWidth = this.getBoundingClientRect().width;
+    // Excludes scrollbars
+    const windowWidth = document.documentElement.clientWidth;
+    const idealLeft = menuWidth > selectionRect.width
+      ? selectionRect.left + selectionRect.width / 2 - menuWidth / 2
+      : selectionRect.left;
+    const left = clamp(idealLeft, MARGIN, windowWidth - menuWidth - MARGIN) + window.scrollX;
+
     this.style.top = `${hlButtonTop}px`;
-    this.style.left = `${hlButtonLeft}px`;
+    this.style.left = `${left}px`;
+  }
+
+  async show() {
+    if (this.br.plugins.translate?.userToggleTranslate) return;
+
     this.style.zIndex = '1';
     this.style.position = 'absolute';
     this.style.display = 'block';
+    this.open = true;
+    await this.updateComplete; // ensure Lit has rendered so getBoundingClientRect() returns real width
+    this.repositionToSelection();
     this.clearNodesForRemoval();
   }
 
   hide = () => {
     this.style.display = 'none';
+    this.open = false;
     this.clearNodesForRemoval();
     return;
   }

--- a/src/util/browserSniffing.js
+++ b/src/util/browserSniffing.js
@@ -52,6 +52,15 @@ export function isIOS() {
 }
 
 /**
+ * Checks whether the current browser is on android
+ * @param {string} [userAgent]
+ * @return {boolean}
+ */
+export function isAndroid(userAgent = navigator.userAgent) {
+  return /android/i.test(userAgent);
+}
+
+/**
  * Checks whether the current browser is Samsung Internet
  * https://stackoverflow.com/a/40684162/2317712
  * @param {string} [userAgent]

--- a/tests/jest/BookReader/utils/SelectionObserver.test.js
+++ b/tests/jest/BookReader/utils/SelectionObserver.test.js
@@ -15,7 +15,7 @@ describe("SelectionObserver", () => {
 
     // stub window.getSelection
     const getSelectionStub = sinon.stub(window, "getSelection");
-    getSelectionStub.returns({ toString: () => "test", anchorNode: target });
+    getSelectionStub.returns({ toString: () => "test", anchorNode: target, isCollapsed: false });
     observer._onSelectionChange();
     expect(handler.callCount).toBe(1);
     expect(handler.calledWith("started", target)).toBe(true);
@@ -26,19 +26,44 @@ describe("SelectionObserver", () => {
     expect(handler.callCount).toBe(1);
 
     // Until the selection is cleared
-    getSelectionStub.returns({ toString: () => "", anchorNode: null });
+    getSelectionStub.returns({ toString: () => "", anchorNode: null, isCollapsed: true });
     expect(observer.selecting).toBe(true);
-    expect(handler.callCount).toBe(1);
-
     observer._onSelectionChange();
-    expect(handler.callCount).toBe(3);
+    expect(handler.callCount).toBe(2);
+    expect(observer.selecting).toBe(false);
     expect(handler.calledWith("cleared", target)).toBe(true);
 
     // Calling it again does not call the handler again
-    sinon.restore();
-    sinon.stub(window, "getSelection").returns({ toString: () => "" });
+    getSelectionStub.returns({ toString: () => "", isCollapsed: true });
     observer._onSelectionChange();
-    expect(handler.callCount).toBe(3);
+    expect(handler.callCount).toBe(2);
+  });
+
+  test('Fires changed event when focusNode changes with same selection text', () => {
+    const handler = sinon.spy();
+    const observer = new SelectionObserver(".text-layer", handler);
+    const target = document.createElement("div");
+    target.classList.add("text-layer");
+
+    const focusNodeA = document.createElement("span");
+    const focusNodeB = document.createElement("span");
+
+    const getSelectionStub = sinon.stub(window, "getSelection");
+    getSelectionStub.returns(/** @type {any} */({ toString: () => "hello", anchorNode: target, focusNode: focusNodeA, isCollapsed: false }));
+    observer._onSelectionChange();
+    expect(handler.callCount).toBe(1);
+    expect(handler.calledWith("started", target)).toBe(true);
+
+    // Same text, but focusNode has changed — should fire 'changed'
+    getSelectionStub.returns(/** @type {any} */({ toString: () => "hello", anchorNode: target, focusNode: focusNodeB, isCollapsed: false }));
+    observer._onSelectionChange();
+    expect(handler.callCount).toBe(2);
+    expect(handler.calledWith("changed", target)).toBe(true);
+
+    // Calling again with the same focusNode should not fire again
+    getSelectionStub.returns(/** @type {any} */({ toString: () => "hello", anchorNode: target, focusNode: focusNodeB, isCollapsed: false }));
+    observer._onSelectionChange();
+    expect(handler.callCount).toBe(2);
   });
 
   test('Only fires when selection started in selector', () => {

--- a/tests/jest/BookReader/utils/SelectionObserver.test.js
+++ b/tests/jest/BookReader/utils/SelectionObserver.test.js
@@ -17,28 +17,28 @@ describe("SelectionObserver", () => {
     const getSelectionStub = sinon.stub(window, "getSelection");
     getSelectionStub.returns({ toString: () => "test", anchorNode: target });
     observer._onSelectionChange();
-    expect(handler.callCount).toBe(2);
+    expect(handler.callCount).toBe(1);
     expect(handler.calledWith("started", target)).toBe(true);
     expect(observer.selecting).toBe(true);
 
     // Calling it again does not call the handler again
     observer._onSelectionChange();
-    expect(handler.callCount).toBe(3);
+    expect(handler.callCount).toBe(1);
 
     // Until the selection is cleared
     getSelectionStub.returns({ toString: () => "", anchorNode: null });
     expect(observer.selecting).toBe(true);
-    expect(handler.callCount).toBe(3);
+    expect(handler.callCount).toBe(1);
 
     observer._onSelectionChange();
-    expect(handler.callCount).toBe(4);
+    expect(handler.callCount).toBe(3);
     expect(handler.calledWith("cleared", target)).toBe(true);
 
     // Calling it again does not call the handler again
     sinon.restore();
     sinon.stub(window, "getSelection").returns({ toString: () => "" });
     observer._onSelectionChange();
-    expect(handler.callCount).toBe(4);
+    expect(handler.callCount).toBe(3);
   });
 
   test('Only fires when selection started in selector', () => {

--- a/tests/jest/util/browserSniffing.test.js
+++ b/tests/jest/util/browserSniffing.test.js
@@ -1,62 +1,74 @@
 import {
-  isChrome, isEdge, isFirefox, isSafari,
+  isChrome, isEdge, isFirefox, isSafari, isAndroid,
 } from '@/src/util/browserSniffing.js';
 
 const TESTS = [
   {
+    name: 'Chrome on Android',
+    userAgent: 'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Mobile Safari/537.36',
+    vendor: 'Google Inc.',
+    matchingFns: [isAndroid, isChrome],
+  },
+  {
+    name: 'Samsung Internet on Android',
+    userAgent: 'Mozilla/5.0 (Linux; Android 13; SAMSUNG SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/21.0 Chrome/110.0.5481.154 Mobile Safari/537.36',
+    vendor: '',
+    matchingFns: [isAndroid],
+  },
+  {
     name: 'Firefox on Windows 10',
     userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0',
     vendor: '',
-    machingFn: isFirefox,
+    matchingFns: [isFirefox],
   },
   {
     name: 'Chrome on Windows 10',
     userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
     vendor: 'Google Inc.',
-    machingFn: isChrome,
+    matchingFns: [isChrome],
   },
   {
     name: 'Edge on Windows 10',
     userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; ServiceUI 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.18362',
     vendor: '',
-    machingFn: isEdge,
+    matchingFns: [isEdge],
   },
   {
     name: 'Edge on Windows 11',
     userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36 Edg/134.0.0.0',
     vendor: 'Google Inc.',
-    machingFn: isEdge,
+    matchingFns: [isEdge],
   },
   {
     name: 'IE11 on Windows 10',
     userAgent: 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; Touch; .NET4.0C; .NET4.0E; Tablet PC 2.0; Zoom 3.6.0; rv:11.0) like Gecko',
     vendor: '',
-    machingFn: null,
+    matchingFns: [],
   },
   {
     name: 'Chromium on Windows 10',
     userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3923.0 Safari/537.36',
     vendor: 'Google Inc.',
-    machingFn: isChrome,
+    matchingFns: [isChrome],
   },
   {
     name: 'Safari 12 on Mojave',
     userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Safari/605.1.15',
     vendor: 'Apple Computer, Inc.',
-    machingFn: isSafari,
+    matchingFns: [isSafari],
   },
   {
     name: 'Safari 10 on iPhone 7',
     userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1',
     vendor: 'Apple Computer, Inc.',
-    machingFn: isSafari,
+    matchingFns: [isSafari],
   },
 ];
 
-for (const fn of [isChrome, isEdge, isFirefox, isSafari]) {
+for (const fn of [isChrome, isEdge, isFirefox, isSafari, isAndroid]) {
   describe(fn.name, () => {
-    for (const { name, userAgent, vendor, machingFn } of TESTS) {
-      test(name, () => expect(fn(userAgent, vendor)).toBe(machingFn == fn));
+    for (const { name, userAgent, vendor, matchingFns } of TESTS) {
+      test(name, () => expect(fn(userAgent, vendor)).toBe(matchingFns.includes(fn)));
     }
   });
 }


### PR DESCRIPTION
Closes #1559

- Avoiding falling off left or right edge of screen
- Reserve room for OS-native menus on mobile
- Auto-expand when on touch screens, since they can't hover to see the label
- Fix iOS bug where button text was blue
- Fix keyboard bug where shift + left/right wouldn't expand the selection
- Fix issue with select menu flickering after dismissing selection and being frequently hidden/shown

Also an unrelated fix about optionOverrides that was preventing e2e tests from passing for some reason. Not sure if that was required or if it was just sporadic e2e failures.

QA: https://deploy-preview-1560--ia-bookreader.netlify.app/