### PR TITLE
Make Copy Link to Highlight links more reslient to url encoding

### DIFF
--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -41,7 +41,6 @@ import { ModeThumb } from './BookReader/ModeThumb.js';
 import { ImageCache } from './BookReader/ImageCache.js';
 import { PageContainer } from './BookReader/PageContainer.js';
 import { NAMED_REDUCE_SETS } from './BookReader/ReduceSet.js';
-import {BookReaderTextFragment} from './util/TextSelectionManager.js';
 
 /**
  * BookReader
@@ -1977,25 +1976,8 @@ BookReader.prototype.queryStringFromParams = function(
     newParams.set('q', params.search);
   }
 
-  /** @type {BookReaderTextFragment | null} */
-  let textFragmentParam = null;
-  // Need to pull out text separately to avoid the spaces becoming encoded as +, which
-  // the browser seems not to handle with the text fragment
-  if (newParams.get('text')) {
-    newParams.delete('text');
-    textFragmentParam = BookReaderTextFragment.fromUrl(currQueryString, this.book, this.firstIndex);
-  }
-
-  // https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/toString
-  // Note: This method returns the query string without the question mark.
-  let result = newParams.toString();
-  if (textFragmentParam) {
-    if (result) result += '&';
-    result += `text=${textFragmentParam.toUrlString()}`;
-  }
-  if (result) result = '?' + result;
-
-  return result;
+  const result = newParams.toString();
+  return result ? `?${result}` : '';
 };
 
 /**

--- a/src/plugins/plugin.text_selection.js
+++ b/src/plugins/plugin.text_selection.js
@@ -66,8 +66,9 @@ export class TextSelectionPlugin extends BookReaderPlugin {
     this.textSelectionManager.init();
 
     // Init text fragment
-    this.targetTextFragment = BookReaderTextFragment.fromUrl(location.search, this.br.book, this.br.firstIndex);
-    if (this.targetTextFragment) {
+    const textParam = new URLSearchParams(location.search).get('text');
+    if (textParam) {
+      this.targetTextFragment = BookReaderTextFragment.fromString(textParam, this.br.book, this.br.firstIndex);
       const targetTextFragment = this.targetTextFragment;
       this.br.on('textLayerVisible', async (_, {pageContainerEl, textLayer}) => {
         const pageIndex = targetTextFragment.pageIndex;

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -585,7 +585,6 @@ class BRSelectMenu extends LitElement {
    */
   async handleCopyLinkToHighlight(e) {
     e.preventDefault();
-    const currentParams = this.br.readQueryString();
     const currentSelection = /** @type {Selection} */ (window.getSelection());
     const range = currentSelection.getRangeAt(0);
     const textLayer = this.getNodeTextLayer(range.startContainer);
@@ -595,19 +594,18 @@ class BRSelectMenu extends LitElement {
     }
     const textFragment = BookReaderTextFragment.fromSelection(currentSelection, [textLayer]);
 
-    // Note: Have to do a param construction to avoid url-encoding of commas in the text fragment param
-    let linkToHighlightParams = currentParams;
-    if (currentParams.includes('text=')) {
-      linkToHighlightParams = currentParams.replace(/(text=)[\w\W\d%]+/, `text=${textFragment.toUrlString()}`);
-    } else {
-      const sep = linkToHighlightParams ? '&' : '?';
-      linkToHighlightParams += `${sep}text=${textFragment.toUrlString()}`;
-    }
+    const currentParams = new URLSearchParams(this.br.readQueryString());
+    if (currentParams.has('text')) currentParams.delete('text');
+
+    let linkToHighlightParams = currentParams.toString();
+    // Use custom toUrlString, which decodes the delimiters for better readability
+    linkToHighlightParams += (linkToHighlightParams ? '&' : '') + `text=${textFragment.toUrlString()}`;
+
     const currentUrl = window.location;
     const pageNum = textFragment.pageNumber || `n${textFragment.pageIndex}`;
     const adjustedUrlPageNumPath = currentUrl.pathname.replace(/((?:^|[#/])page)\/[^/]+/, `$1/${pageNum}`);
     const hash = currentUrl.hash ? currentUrl.hash.replace(/((?:^|[#/])page)\/[^/]+/, `$1/${pageNum}`) : '';
-    const linkToHighlight = `${currentUrl.origin}${adjustedUrlPageNumPath}${linkToHighlightParams}${hash}`;
+    const linkToHighlight = `${currentUrl.origin}${adjustedUrlPageNumPath}?${linkToHighlightParams}${hash}`;
 
     await navigator.clipboard.writeText(linkToHighlight);
     this.copyLinkOption?.showTemporaryText('Copied!');
@@ -839,12 +837,15 @@ export function getLastMostNode(parent) {
 }
 
 /**
- * Strips the whitespace to normalize text
+ * Normalizes text fragment whitespace and removes special delimiter characters
+ * to allow for reliable url encoding/decoding
  * @param {String} string
  * @returns
  */
-function replaceWhitespace(string) {
-  return string.replace(/\s+/g, " ");
+export function normalizeTextFragment(string) {
+  return string
+    .replace(/(:|-,|,-|,)/g, " ")
+    .replace(/\s+/g, " ");
 }
 
 /**
@@ -944,7 +945,7 @@ export function getBoundaryPointAtIndex(index, nodes, isEnd, { normalize = (s) =
     counted += normalizedData.length;
 
     if (i + 1 < nodes.length) {
-      const nextNormalizedData = replaceWhitespace(nodes[i + 1].textContent);
+      const nextNormalizedData = normalizeTextFragment(nodes[i + 1].textContent);
       // Hyphenated words prove to be an issue since spaces are being inserted between BRlineElements
       // 1st case explicitly check the node class to prevent double counted spaces
       // 2nd case can happen from node traversal when loading from localStorage
@@ -979,7 +980,6 @@ export function renderHighlight(textLayer, textFragment, cssClassName = null) {
   const wholePageRange = new Range();
   wholePageRange.setStart(firstPageNode, 0);
   wholePageRange.setEnd(lastPageNode, lastPageNode.textContent.length);
-  const normalize = replaceWhitespace;
 
   // Retrieve the text nodes and relevant whitespace elements
   // Need to keep the BRlineElement nodes in between to keep the index count consistent, remove first BRlineElement since text starts from the first real text node
@@ -987,10 +987,10 @@ export function renderHighlight(textLayer, textFragment, cssClassName = null) {
   pageWordNodes.splice(0, 1);
 
   const broadRanges = findRangeForRegExp(
-    textFragment.toRegExp({ normalize, context: true }),
+    textFragment.toRegExp({ normalize: normalizeTextFragment, context: true }),
     wholePageRange,
     pageWordNodes,
-    { normalize },
+    { normalize: normalizeTextFragment },
   );
   if (!broadRanges) {
     console.warn("Could not find quote with context in page");
@@ -1006,10 +1006,10 @@ export function renderHighlight(textLayer, textFragment, cssClassName = null) {
 
   // At which point the quote should now be unambiguous!
   const exactRanges = findRangeForRegExp(
-    textFragment.toRegExp({ normalize, context: false }),
+    textFragment.toRegExp({ normalize: normalizeTextFragment, context: false }),
     broadRanges[0],
     broadRangeWordNodes,
-    { normalize },
+    { normalize: normalizeTextFragment },
   );
   if (!exactRanges) {
     throw new Error("Could not find quote in page");
@@ -1222,21 +1222,6 @@ export class BookReaderTextFragment {
     });
   }
 
-  /**
-   * Extract and parse a text fragment from a URL string containing a `text=` parameter.
-   * @param {string} urlString
-   * @param {import('@/src/BookReader/BookModel.js').BookModel} book
-   * @param {number} fallbackPageIndex A fallback page index to use if the text
-   * fragment does not specify a page number or page index.
-   * @returns {BookReaderTextFragment|null}
-   */
-  static fromUrl(urlString, book, fallbackPageIndex) {
-    // Can't parse with eg new URLSearchParams since the text fragment format includes unencoded
-    // commas and colons, so need to do a regex match to extract the text fragment string
-    const textMatch = urlString.match(/[&?#]?text=([^&]*)/);
-    if (!textMatch) return null;
-    return BookReaderTextFragment.fromString(textMatch[1], book, fallbackPageIndex);
-  }
 
   /**
    * Outputs a url-safe string serialization of the text fragment, that's a variation of the standard
@@ -1248,13 +1233,15 @@ export class BookReaderTextFragment {
    */
   toUrlString() {
     // First the page number or index
-    let str = this.pageNumber ? `${encodeURIComponent(this.pageNumber)}:` : `n${this.pageIndex}:`;
+    let str = this.pageNumber ? this.pageNumber : `n${this.pageIndex}`;
+    str += ':';
 
     if (this.prefix) {
-      str += `${encodeURIComponent(this.prefix)}-,`;
+      str += normalizeTextFragment(this.prefix).trim();
+      str += '-,';
     }
 
-    const quote = this.quote?.trim() || null;
+    const quote = this.quote ? normalizeTextFragment(this.quote).trim() : null;
     let shortenedQuoteParts = null;
     if (quote && quote.length > MAX_FULL_QUOTE_URL_CHARS) {
       const words = quote.match(/\S+/g) || [];
@@ -1268,19 +1255,25 @@ export class BookReaderTextFragment {
     }
 
     if (quote && !shortenedQuoteParts) {
-      str += encodeURIComponent(quote);
+      str += quote;
     } else if (shortenedQuoteParts) {
-      str += `${encodeURIComponent(shortenedQuoteParts.quoteStart)},${encodeURIComponent(shortenedQuoteParts.quoteEnd)}`;
+      str += `${shortenedQuoteParts.quoteStart},${shortenedQuoteParts.quoteEnd}`;
     } else if (this.quoteStart && this.quoteEnd) {
-      str += `${encodeURIComponent(this.quoteStart)},${encodeURIComponent(this.quoteEnd)}`;
+      str += `${this.quoteStart},${this.quoteEnd}`;
     } else {
       throw new Error('Text fragment requires either a quote or quoteStart/quoteEnd');
     }
 
     if (this.suffix) {
-      str += `,-${encodeURIComponent(this.suffix)}`;
+      str += ',-';
+      str += normalizeTextFragment(this.suffix).trim();
     }
-    return str;
+
+    return encodeURIComponent(str)
+      // Bring back the delimiters so it's easier to read, but note not necessary.
+      // Note hyphens are not encoded by encodeURIComponent, so no need to replace them
+      .replace(/%2C/g, ',')
+      .replace(/%3A/g, ':');
   }
 
   /**
@@ -1356,11 +1349,11 @@ export class BookReaderTextFragment {
 
     const CONTEXT_WORD_COUNT = 3;
 
-    const preStartText = replaceWhitespace(preStartRange.toString());
+    const preStartText = normalizeTextFragment(preStartRange.toString());
     let prefix = getLastWords(CONTEXT_WORD_COUNT, preStartText);
     let prefixWords = countWords(prefix);
 
-    const postEndText = replaceWhitespace(postEndRange.toString());
+    const postEndText = normalizeTextFragment(postEndRange.toString());
     let suffix = getFirstWords(CONTEXT_WORD_COUNT, postEndText);
     let suffixWords = countWords(suffix);
 
@@ -1377,7 +1370,7 @@ export class BookReaderTextFragment {
     }
 
     // Guarantee that all whitespace is replaced with just one space and that the first/last word of the highlight is not a space
-    const quote = replaceWhitespace(fullQuoteRange.toString()).trim();
+    const quote = normalizeTextFragment(fullQuoteRange.toString()).trim();
     const pageContainerEl = startTextNode.parentElement.closest(".BRpagecontainer");
 
     return new BookReaderTextFragment({

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -871,17 +871,21 @@ export function getLastMostNode(parent) {
 /**
  * Normalizes text fragment whitespace and removes special delimiter characters
  * to allow for reliable url encoding/decoding
+ *
+ * Note: It's very important this *does not* change the length of the string to
+ * ensure matching works smoothly later.
+ *
  * @param {String} string
- * @returns
  */
-export function normalizeTextFragment(string) {
-  let result = string
-    .replace(/(:|-,|,-|,)/g, " ")
-    .replace(/\s+/g, " ");
-  // if the source string didn't have leading whitespace, remove it
-  if (!/^\s/.test(string)) result = result.replace(/^\s/, "");
-  if (!/\s$/.test(string)) result = result.replace(/\s$/, "");
-  return result;
+export function replaceTextFragmentDelimiters(string) {
+  return string.replace(/(:|-,|,-|,|\n)/g, s => s.length === 1 ? ' ' : '  ');
+}
+
+/**
+ * @param {String} s
+ */
+export function collapseWhitespace(s) {
+  return s.replace(/\s+/g, ' ').trim();
 }
 
 /**
@@ -898,7 +902,7 @@ export function findRangeForRegExp(regex, range, textNodes, { normalize = (s) =>
   const startOffset = textNodes[0] === range.startContainer ?
     range.startOffset :
     0;
-  const normalizedWholePageString = normalize(range.toString());
+  const normalizedWholePageString = normalize(textLayerRangeToString(range));
   const normalizedStartOffset = normalize(textNodes[0].textContent.slice(0, startOffset)).length;
   const matchRegex = new RegExp(regex.source, regex.flags.includes('g') ? regex.flags : `${regex.flags}g`);
 
@@ -986,6 +990,23 @@ export function getBoundaryPointAtIndex(index, nodes, isEnd, { normalize = (s) =
 }
 
 /**
+ * @param {Range} range
+ */
+export function textLayerRangeToString(range) {
+  const textNodes = Array.from(genFilter(treeWalkRange(range, 'text'), isBRVisibleTextNode));
+  let result = textNodes.map(node => node.textContent).join('');
+  const firstTextNode = textNodes[0];
+  const lastTextNode = textNodes[textNodes.length - 1];
+  if (range.startContainer === firstTextNode) {
+    result = result.substring(range.startOffset);
+  }
+  if (range.endContainer === lastTextNode) {
+    result = result.substring(0, result.length - (lastTextNode.textContent.length - range.endOffset));
+  }
+  return result;
+}
+
+/**
  * Takes a text quote object and a container element, and wraps the quote
  * within the container element in a span to apply highlight-like styling
  *
@@ -1009,10 +1030,10 @@ export function renderHighlight(textLayer, textFragment, cssClassName = null) {
   const pageWordNodes = Array.from(genFilter(treeWalkRange(wholePageRange, 'text'), isBRVisibleTextNode));
 
   const broadRanges = findRangeForRegExp(
-    textFragment.toRegExp({ normalize: normalizeTextFragment, context: true }),
+    textFragment.toRegExp({ context: true }),
     wholePageRange,
     pageWordNodes,
-    { normalize: normalizeTextFragment },
+    { normalize: replaceTextFragmentDelimiters },
   );
   if (!broadRanges) {
     console.warn("Could not find quote with context in page");
@@ -1024,10 +1045,10 @@ export function renderHighlight(textLayer, textFragment, cssClassName = null) {
   // At which point the quote should now be unambiguous!
   // FIXME: Alas no, it is ambiguous ; need to likely extract prefix and suffix separately?
   const exactRanges = findRangeForRegExp(
-    textFragment.toRegExp({ normalize: normalizeTextFragment, context: false }),
+    textFragment.toRegExp({ context: false }),
     broadRanges[0],
     broadRangeWordNodes,
-    { normalize: normalizeTextFragment },
+    { normalize: replaceTextFragmentDelimiters },
   );
   if (!exactRanges) {
     throw new Error("Could not find quote in page");
@@ -1252,22 +1273,29 @@ export class BookReaderTextFragment {
   /**
    * Outputs a url-safe string serialization of the text fragment, that's a variation of the standard
    * browser TextFragment format to include page information: `pageNumber:prefix-,quote,-suffix`
-  * If quote text is long enough, it is serialized as `quoteStart,quoteEnd`.
-    * Note the ':' and ',' separators must not and are not encoded, but
+   *
+   * If quote text is long enough, it is serialized as `quoteStart,quoteEnd`.
+   * Note the ':' and ',' separators must not and are not encoded, but
    * the pageNumber, prefix, quote/quoteStart/quoteEnd, and suffix text are encoded.
+   *
    * @returns {string}
    */
   toUrlString() {
+    // When constructing to url, we can collapse the whitespace since the corresponding
+    // toRegExp method is resilient to multiple whitespace characters.
+    /** @param {string} s */
+    const normalize = s => collapseWhitespace(replaceTextFragmentDelimiters(s).trim());
+
     // First the page number or index
     let str = this.pageNumber ? this.pageNumber : `n${this.pageIndex}`;
     str += ':';
 
     if (this.prefix) {
-      str += normalizeTextFragment(this.prefix).trim();
+      str += normalize(this.prefix);
       str += '-,';
     }
 
-    const quote = this.quote ? normalizeTextFragment(this.quote).trim() : null;
+    const quote = this.quote ? normalize(this.quote) : null;
     let shortenedQuoteParts = null;
     if (quote && quote.length > MAX_FULL_QUOTE_URL_CHARS) {
       const words = quote.match(/\S+/g) || [];
@@ -1292,7 +1320,7 @@ export class BookReaderTextFragment {
 
     if (this.suffix) {
       str += ',-';
-      str += normalizeTextFragment(this.suffix).trim();
+      str += normalize(this.suffix);
     }
 
     return encodeURIComponent(str)
@@ -1304,10 +1332,10 @@ export class BookReaderTextFragment {
 
   /**
    * Build a regex that matches this quote payload.
-   * @param {{ normalize?: function(string): string, context?: boolean }} [options]
+   * @param {{ context?: boolean }} [options]
    * @returns {RegExp}
    */
-  toRegExp({ normalize = (s) => s, context = false } = {}) {
+  toRegExp({ context = false } = {}) {
     /** @type {[String] | [String, String]} */
     const quotes = this.quote ? [this.quote] : [this.quoteStart, this.quoteEnd];
 
@@ -1316,12 +1344,16 @@ export class BookReaderTextFragment {
       if (this.suffix) quotes[quotes.length - 1] = quotes[quotes.length - 1] + ' ' + this.suffix;
     }
 
+    // Make it resilient to extra whitespace
+    /** @param {String} quote */
+    const quoteToRegExpString = (quote) => RegExp.escape(replaceTextFragmentDelimiters(quote)).replace(/(\\x20)+/g, '\\s+');
+
     if (quotes.length === 1) {
-      return new RegExp(RegExp.escape(normalize(quotes[0])), 'g');
+      return new RegExp(quoteToRegExpString(quotes[0]), 'gi');
     } else {
       return new RegExp(
-        RegExp.escape(normalize(quotes[0])) + '[\\s\\S]*?' + RegExp.escape(normalize(quotes[1])),
-        'g',
+        quoteToRegExpString(quotes[0]) + '[\\s\\S]*?' + quoteToRegExpString(quotes[1]),
+        'gi',
       );
     }
   }
@@ -1375,11 +1407,11 @@ export class BookReaderTextFragment {
 
     const CONTEXT_WORD_COUNT = 3;
 
-    const preStartText = normalizeTextFragment(preStartRange.toString());
+    const preStartText = textLayerRangeToString(preStartRange);
     let prefix = getLastWords(CONTEXT_WORD_COUNT, preStartText);
     let prefixWords = countWords(prefix);
 
-    const postEndText = normalizeTextFragment(postEndRange.toString());
+    const postEndText = textLayerRangeToString(postEndRange);
     let suffix = getFirstWords(CONTEXT_WORD_COUNT, postEndText);
     let suffixWords = countWords(suffix);
 
@@ -1395,8 +1427,7 @@ export class BookReaderTextFragment {
       prefixWords = countWords(prefix);
     }
 
-    // Guarantee that all whitespace is replaced with just one space and that the first/last word of the highlight is not a space
-    const quote = normalizeTextFragment(fullQuoteRange.toString()).trim();
+    const quote = textLayerRangeToString(fullQuoteRange);
     const pageContainerEl = startTextNode.parentElement.closest(".BRpagecontainer");
 
     return new BookReaderTextFragment({

--- a/src/util/TextSelectionManager.js
+++ b/src/util/TextSelectionManager.js
@@ -247,8 +247,8 @@ export class TextSelectionManager {
     // Find the last allowed word in the selection
     const lastAllowedWord = genAt(
       genFilter(
-        walkBetweenNodes(range.startContainer, range.endContainer),
-        (node) => node.classList?.contains(
+        treeWalkRange(range, 'element'),
+        (node) => node.classList.contains(
           this.selectionElement[0].replace(".", ""),
         ),
       ),
@@ -296,26 +296,58 @@ export function* genFilter(iterable, fn) {
 }
 
 /**
+ * @overload
+ * @param {Range} range
+ * @param {'text'} filter
+ * @returns {Generator<Text>}
+ */
+/**
+ * @overload
+ * @param {Range} range
+ * @param {'element'} filter
+ * @returns {Generator<Element>}
+ */
+/**
+ * @overload
+ * @param {Range} range
+ * @param {'text+element'} [filter]
+ * @returns {Generator<Text | Element>}
+ */
+/**
  * Depth traverse the DOM tree starting at `start`, and ending at `end`.
- * @param {Node} start
- * @param {Node} end
+ * @param {Range} range
+ * @param {'text' | 'element' | 'text+element'} [filter]
  * @returns {Generator<Node>}
  */
-export function* walkBetweenNodes(start, end) {
+export function* treeWalkRange(range, filter = 'text+element') {
+  const start = range.startContainer;
+  const end = range.endContainer;
   let done = false;
 
   /**
    * @param {Node} node
    */
+  const passesFilter = node => {
+    return (
+      (filter === 'text' && node.nodeType === Node.TEXT_NODE) ||
+      (filter === 'element' && node.nodeType === Node.ELEMENT_NODE) ||
+      (filter === 'text+element')
+    );
+  };
+
+  /**
+   * @param {Node} node
+   * @returns {Generator<Node>}
+   */
   function* walk(node, {children = true, parents = true, siblings = true} = {}) {
     if (node === end) {
       done = true;
-      yield node;
+      if (passesFilter(node)) yield node;
       return;
     }
 
     // yield self
-    yield node;
+    if (passesFilter(node)) yield node;
 
     // First iterate children (depth-first traversal)
     if (children && node.firstChild) {
@@ -843,9 +875,13 @@ export function getLastMostNode(parent) {
  * @returns
  */
 export function normalizeTextFragment(string) {
-  return string
+  let result = string
     .replace(/(:|-,|,-|,)/g, " ")
     .replace(/\s+/g, " ");
+  // if the source string didn't have leading whitespace, remove it
+  if (!/^\s/.test(string)) result = result.replace(/^\s/, "");
+  if (!/\s$/.test(string)) result = result.replace(/\s$/, "");
+  return result;
 }
 
 /**
@@ -887,8 +923,8 @@ export function findRangeForRegExp(regex, range, textNodes, { normalize = (s) =>
     }
 
     const foundRange = new Range();
-    foundRange.setStart(start.node, 0);
-    foundRange.setEnd(end.node, 1);
+    foundRange.setStart(start.node, start.offset);
+    foundRange.setEnd(end.node, end.offset);
     return foundRange;
   });
 
@@ -898,64 +934,53 @@ export function findRangeForRegExp(regex, range, textNodes, { normalize = (s) =>
 }
 
 /**
- * Uses the index that matches the quote string and normalizes the string contents to find the correct node
+ * Maps an index from "normalized-space" (concatenated and normalized text) to a "node-space" index (node + offset).
  * @param {Number} index
  * @param {Node[]} nodes
  * @param {boolean} isEnd
  * @param {{ normalize?: function(string): string }} [options]
  */
 export function getBoundaryPointAtIndex(index, nodes, isEnd, { normalize = (s) => s } = {}) {
-  let counted = 0;
-  let normalizedData;
-  for (let i = 0; i < nodes.length; i++) {
-    const node = nodes[i];
-    if (node.className === 'BRlineElement') {
-      // Treat the lineElement as a space for now, will check if the previous node was hyphenated or another lineElement later
-      normalizedData = ' ';
-    } else {
-      if (!normalizedData) normalizedData = normalize(node.textContent);
-    }
-    let nodeEnd = counted + normalizedData.length;
-    if (isEnd) nodeEnd += 1;
-    if (nodeEnd > index) {
-      const normalizedOffset = index - counted;
-      let denormalizedOffset = Math.min(index - counted, node.textContent.length);
+  // Rename to have consistent wording
+  const normalizedTargetIndex = index;
+  /** Characters in node-space counted so far */
+  let normalizedI = 0;
 
-      const targetSubstring = isEnd ?
-        normalizedData.substring(0, normalizedOffset) :
-        normalizedData.substring(normalizedOffset);
+  for (const node of nodes) {
+    const nodeText = node.textContent || '';
+    const normalizedText = normalize(nodeText);
+    const nodeNormalizedStart = normalizedI;
+    const nodeNormalizedEnd = nodeNormalizedStart + normalizedText.length + (isEnd ? 1 : 0);
 
-      let candidateSubstring = isEnd ?
-        normalize(node.textContent.substring(0, normalizedOffset)) :
-        normalize(node.textContent.substring(normalizedOffset));
+    if (nodeNormalizedEnd > normalizedTargetIndex) {
+      // We have found the node that contains the normalizedTargetIndex we are looking for!
+      const normalizedOffset = normalizedTargetIndex - nodeNormalizedStart;
 
-      const direction = (isEnd ? -1 : 1) * (targetSubstring.length > candidateSubstring.length ? -1 : 1);
-      while (denormalizedOffset >= 0 &&
-               denormalizedOffset <= node.textContent.length) {
-        if (candidateSubstring.length === targetSubstring.length) {
-          return {node : node, offset: denormalizedOffset};
+      // But the normalized text could be a shorter length than the node text,
+      // so we try to continually increase the nodeOffset
+      let nodeOffset = Math.min(normalizedOffset, nodeText.length);
+
+      const normalizedSubstring = isEnd ?
+        normalizedText.substring(0, normalizedOffset) :
+        normalizedText.substring(normalizedOffset);
+
+      let nodeSubstring = isEnd ?
+        normalize(nodeText.substring(0, normalizedOffset)) :
+        normalize(nodeText.substring(normalizedOffset));
+
+      const direction = (isEnd ? -1 : 1) * (normalizedSubstring.length > nodeSubstring.length ? -1 : 1);
+      while (nodeOffset >= 0 && nodeOffset <= nodeText.length) {
+        if (nodeSubstring.length === normalizedSubstring.length) {
+          return {node, offset: nodeOffset};
         }
-        denormalizedOffset += direction;
+        nodeOffset += direction;
 
-        candidateSubstring = isEnd ?
-          node.textContent.substring(0, denormalizedOffset) :
-          node.textContent.substring(denormalizedOffset);
+        nodeSubstring = isEnd ?
+          normalize(nodeText.substring(0, nodeOffset)) :
+          normalize(nodeText.substring(nodeOffset));
       }
     }
-    counted += normalizedData.length;
-
-    if (i + 1 < nodes.length) {
-      const nextNormalizedData = normalizeTextFragment(nodes[i + 1].textContent);
-      // Hyphenated words prove to be an issue since spaces are being inserted between BRlineElements
-      // 1st case explicitly check the node class to prevent double counted spaces
-      // 2nd case can happen from node traversal when loading from localStorage
-      if (nodes[i - 1]?.classList.contains("BRwordElement--hyphen") && node.className === 'BRlineElement') {
-        counted -= 1;
-      } else if (nodes[i - 1]?.className === 'BRlineElement' && node.className === 'BRlineElement') {
-        counted -= 1;
-      }
-      normalizedData = nextNormalizedData;
-    }
+    normalizedI += normalizedText.length;
   }
   return undefined;
 }
@@ -981,10 +1006,7 @@ export function renderHighlight(textLayer, textFragment, cssClassName = null) {
   wholePageRange.setStart(firstPageNode, 0);
   wholePageRange.setEnd(lastPageNode, lastPageNode.textContent.length);
 
-  // Retrieve the text nodes and relevant whitespace elements
-  // Need to keep the BRlineElement nodes in between to keep the index count consistent, remove first BRlineElement since text starts from the first real text node
-  const pageWordNodes = Array.from(textLayer.querySelectorAll('.BRwordElement, .BRspace, br, .BRlineElement'));
-  pageWordNodes.splice(0, 1);
+  const pageWordNodes = Array.from(genFilter(treeWalkRange(wholePageRange, 'text'), isBRVisibleTextNode));
 
   const broadRanges = findRangeForRegExp(
     textFragment.toRegExp({ normalize: normalizeTextFragment, context: true }),
@@ -997,14 +1019,10 @@ export function renderHighlight(textLayer, textFragment, cssClassName = null) {
     return;
   }
 
-  const broadRangeWordNodes = [];
-  for (const el of walkBetweenNodes(broadRanges[0].startContainer, broadRanges[0].endContainer)) {
-    if (el.classList?.contains('BRwordElement') || el.classList?.contains('BRspace') || el.classList?.contains('BRlineElement')) {
-      broadRangeWordNodes.push(el);
-    }
-  }
+  const broadRangeWordNodes = Array.from(genFilter(treeWalkRange(broadRanges[0], 'text'), isBRVisibleTextNode));
 
   // At which point the quote should now be unambiguous!
+  // FIXME: Alas no, it is ambiguous ; need to likely extract prefix and suffix separately?
   const exactRanges = findRangeForRegExp(
     textFragment.toRegExp({ normalize: normalizeTextFragment, context: false }),
     broadRanges[0],
@@ -1035,6 +1053,14 @@ export function renderHighlight(textLayer, textFragment, cssClassName = null) {
     if (textFragment.uuid) mark.classList.add(textFragment.uuid);
     return mark;
   });
+}
+
+/**
+ * @param {Text} node
+ */
+export function isBRVisibleTextNode(node) {
+  // Exclude the duplicated spaces between words for MS Edge
+  return !node.previousElementSibling?.classList.contains("BRspace");
 }
 
 /**

--- a/tests/jest/util/TextSelectionManager.test.js
+++ b/tests/jest/util/TextSelectionManager.test.js
@@ -7,6 +7,7 @@ import {
   findRangeForRegExp,
   getFirstWords,
   getLastWords,
+  normalizeTextFragment,
   walkBetweenNodes,
 } from '@/src/util/TextSelectionManager.js';
 
@@ -19,12 +20,12 @@ const FAKE_XML_MULT_LINES = `
         <WORD coords="230,2038,320,2002" x-confidence="30">can  </WORD>
         <WORD coords="320,2039,433,2002" x-confidence="28">false </WORD>
         <WORD coords="433,2051,658,2003" x-confidence="29">judgment </WORD>
-        <WORD coords="658,2039,728,2002" x-confidence="30">be </WORD>
+        <WORD coords="658,2039,728,2002" x-confidence="30">be, </WORD>
         <WORD coords="658,2039,728,2002" x-confidence="30">-</WORD>
         <WORD coords="728,2039,939,2001" x-confidence="29"> formed. </WORD>
         <WORD coords="939,2039,1087,2001" x-confidence="29">There </WORD>
         <WORD coords="1087,2039,1187,2002" x-confidence="29">still </WORD>
-        <WORD coords="1187,2038,1370,2003" x-confidence="29">remains </WORD>
+        <WORD coords="1187,2038,1370,2003" x-confidence="29">remains: </WORD>
         <WORD coords="1370,2037,1433,2014" x-confidence="28">an-</WORD>
       </LINE>
       <LINE>
@@ -727,6 +728,32 @@ describe('walkBetweenNodes', () => {
     // Last word should be the end word
     expect(result[result.length - 1].parentElement).toBe(end);
     expect(result[result.length - 1].textContent).toBe('Suppose');
+  });
+});
+
+describe('normalizeTextFragment', () => {
+  test('replaces colon delimiter with space', () => {
+    expect(normalizeTextFragment('page:text')).toBe('page text');
+  });
+
+  test('replaces -,  and ,- delimiters with spaces', () => {
+    expect(normalizeTextFragment('prefix-,quote,-suffix')).toBe('prefix quote suffix');
+  });
+
+  test('replaces standalone comma delimiter with space', () => {
+    expect(normalizeTextFragment('start,end')).toBe('start end');
+  });
+
+  test('collapses multiple whitespace into a single space', () => {
+    expect(normalizeTextFragment('hello   world')).toBe('hello world');
+  });
+
+  test('returns unchanged string when no delimiters present', () => {
+    expect(normalizeTextFragment('plain text here')).toBe('plain text here');
+  });
+
+  test('handles empty string', () => {
+    expect(normalizeTextFragment('')).toBe('');
   });
 });
 

--- a/tests/jest/util/TextSelectionManager.test.js
+++ b/tests/jest/util/TextSelectionManager.test.js
@@ -8,7 +8,11 @@ import {
   getFirstWords,
   getLastWords,
   normalizeTextFragment,
-  walkBetweenNodes,
+  treeWalkRange,
+  genFilter,
+  isBRVisibleTextNode,
+  getFirstMostNode,
+  getLastMostNode,
 } from '@/src/util/TextSelectionManager.js';
 
 // djvu.xml book infos copied from https://ia803103.us.archive.org/14/items/goodytwoshoes00newyiala/goodytwoshoes00newyiala_djvu.xml
@@ -279,7 +283,7 @@ describe("Generic tests", () => {
   });
 });
 
-describe("BookReaderTextFragment.fromSelection tests", () => {
+describe("BookReaderTextFragment.fromSelection", () => {
 
   afterEach(() => {
     sinon.restore();
@@ -356,12 +360,7 @@ describe("BookReaderTextFragment.fromSelection tests", () => {
     expect(backwardTest.toUrlString()).toMatch(forwardTest.toUrlString());
   });
 
-  /** TODO
-   *  BookReaderTextFragment.fromSelection has changed drastically since
-   *  we are no longer using the native browser API for text fragments
-   *  Skipping the tests for now
-   */
-  test.skip("Forward and Backward selection without suffix", async () => {
+  test("Forward and Backward selection without suffix", async () => {
     const $container = $("<div class='BRpagecontainer' data-page-num='12' data-index='15'></div>").appendTo(br.refs.$brContainer);
     sinon.stub(br.plugins.textSelection, "getPageText")
       .returns($(new DOMParser().parseFromString(FAKE_XML_MULT_LINES, "text/xml")));
@@ -382,11 +381,11 @@ describe("BookReaderTextFragment.fromSelection tests", () => {
     backwardRange.collapse(false);
     selection.addRange(backwardRange);
     selection.extend(forwardRange.startContainer, 0);
-    window.getSelection().direction = 'backward';
+    selection.direction = 'backward';
 
     const backwardTest = BookReaderTextFragment.fromSelection(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
 
-    expect(forwardTest.toUrlString()).toMatch("various,lastWord");
+    expect(forwardTest.toUrlString()).toMatch("12:our%20souls%20a%20waxen%20tablet%20of-,various%20qualities%20lastWord");
     expect(backwardTest.toUrlString()).toMatch(forwardTest.toUrlString());
   });
 
@@ -688,20 +687,26 @@ describe("getFirstWords and getLastWords tests", () => {
   });
 });
 
-describe('walkBetweenNodes', () => {
+describe('treeWalkRange', () => {
   const tree = $(FAKE_XML_MULT_LINES);
 
   test('handles empty', () => {
-    const result = Array.from(walkBetweenNodes(tree[0], tree[0]));
+    const r = new Range();
+    r.setStart(tree[0], 0);
+    r.setEnd(tree[0], 0);
+    const result = Array.from(treeWalkRange(r));
     expect(result).toHaveLength(1);
     expect(result[0]).toBe(tree[0]);
   });
 
   test('Words on same line', () => {
     const start = tree.find('WORD')[2];
-    const end = start.nextElementSibling;
+    const end = tree.find('WORD')[3];
+    const r = new Range();
+    r.setStart(start.firstChild, 0);
+    r.setEnd(end.firstChild, 0);
     // Use first child so we hit the text nodes
-    const result = Array.from(walkBetweenNodes(start.firstChild, end.firstChild));
+    const result = Array.from(treeWalkRange(r));
     expect(result).toHaveLength(5);
     expect(result[0].nodeType).toBe(Node.TEXT_NODE);
     expect(result[0].textContent).toBe('false ');
@@ -717,7 +722,10 @@ describe('walkBetweenNodes', () => {
   test('Words on different lines', () => {
     const start = tree.find('WORD')[2];
     const end = tree.find('WORD')[19];
-    const result = Array.from(walkBetweenNodes(start.firstChild, end.firstChild));
+    const r = new Range();
+    r.setStart(start.firstChild, 0);
+    r.setEnd(end.firstChild, 0);
+    const result = Array.from(treeWalkRange(r));
     // Expect two LINES in result
     expect(result.filter(x => x.nodeName == 'LINE')).toHaveLength(2);
     // Expect 18 WORDs in result
@@ -728,6 +736,35 @@ describe('walkBetweenNodes', () => {
     // Last word should be the end word
     expect(result[result.length - 1].parentElement).toBe(end);
     expect(result[result.length - 1].textContent).toBe('Suppose');
+  });
+
+  test('Handles filter=text', () => {
+    const start = tree.find('WORD')[2];
+    const end = tree.find('WORD')[4];
+    const r = new Range();
+    r.setStart(start, 0);
+    r.setEnd(end, 0);
+    const result = Array.from(treeWalkRange(r, 'text'));
+    expect(result).toHaveLength(4);
+    expect(result.map(r => r.nodeType).every(type => type === Node.TEXT_NODE)).toBe(true);
+    expect(result[0].textContent).toBe('false ');
+    expect(result[1].textContent).toMatch(/^\s*$/);
+    expect(result[2].textContent).toBe('judgment ');
+    expect(result[3].textContent).toMatch(/^\s*$/);
+  });
+
+  test('Handles filter=element', () => {
+    const start = tree.find('WORD')[2];
+    const end = tree.find('WORD')[4];
+    const r = new Range();
+    r.setStart(start, 0);
+    r.setEnd(end, 0);
+    const result = Array.from(treeWalkRange(r, 'element'));
+    expect(result).toHaveLength(3);
+    expect(result.map(r => r.nodeType).every(type => type === Node.ELEMENT_NODE)).toBe(true);
+    expect(result[0].textContent).toBe('false ');
+    expect(result[1].textContent).toMatch('judgment ');
+    expect(result[2].textContent).toMatch('be, ');
   });
 });
 
@@ -789,58 +826,26 @@ describe('BookReaderTextFragment.toRegExp and findRangeForRegExp', () => {
       .returns($(new DOMParser().parseFromString(FAKE_DIALOGUE, 'text/xml')));
     await br.plugins.textSelection.createTextLayer({ $container, page: {index: 1, width: 100, height: 100 }});
 
+    const normalize = normalizeTextFragment;
     const textLayer = $container.find('.BRtextLayer')[0];
-    const firstPageNode = textLayer;
-    const lastPageNode = textLayer;
+
+    // Create a range that encompasses the entire text content
+    const firstPageNode = getFirstMostNode(textLayer);
+    const lastPageNode = getLastMostNode(textLayer);
     const wholePageRange = new Range();
     wholePageRange.setStart(firstPageNode, 0);
-    wholePageRange.setEnd(lastPageNode, lastPageNode.childNodes.length);
-    const textNodes = Array.from(textLayer.querySelectorAll('.BRwordElement, .BRspace, br, .BRlineElement'));
-    textNodes.splice(0, 1);
-
-    const quoteStart = new BookReaderTextFragment({
-      prefix: null,
-      quote: '“My own seal.”',
-      quoteStart: null,
-      quoteEnd: null,
-      suffix: null,
-      pageNumber: null,
-      pageIndex: 0,
-    });
-    const quoteEnd = new BookReaderTextFragment({
-      prefix: null,
-      quote: '“My photograph.”',
-      quoteStart: null,
-      quoteEnd: null,
-      suffix: null,
-      pageNumber: null,
-      pageIndex: 0,
-    });
+    wholePageRange.setEnd(lastPageNode, lastPageNode.textContent.length);
+    const textNodes = Array.from(genFilter(treeWalkRange(wholePageRange, 'text'), isBRVisibleTextNode));
+    const tf = BookReaderTextFragment.fromString('“My own seal.”', null, 0);
 
     const range = findRangeForRegExp(
-      quoteStart.toRegExp({ normalize: (s) => s.replace(/\s+/g, ' ') }),
+      tf.toRegExp({ normalize }),
       wholePageRange,
       textNodes,
-      { normalize: (s) => s.replace(/\s+/g, ' ') },
-    );
-    const quoteStartRange = findRangeForRegExp(
-      quoteStart.toRegExp({ normalize: (s) => s.replace(/\s+/g, ' ') }),
-      wholePageRange,
-      textNodes,
-      { normalize: (s) => s.replace(/\s+/g, ' ') },
-    );
-    const quoteEndRange = findRangeForRegExp(
-      quoteEnd.toRegExp({ normalize: (s) => s.replace(/\s+/g, ' ') }),
-      wholePageRange,
-      textNodes,
-      { normalize: (s) => s.replace(/\s+/g, ' ') },
+      { normalize },
     );
 
     expect(range).toBeTruthy();
-    expect(quoteStartRange).toBeTruthy();
-    expect(quoteEndRange).toBeTruthy();
     expect(range[0].toString().replace(/\s+/g, ' ').trim()).toBe('“My own seal.”');
-    expect(quoteStartRange[0].toString().replace(/\s+/g, ' ').trim()).toBe('“My own seal.”');
-    expect(quoteEndRange[0].toString().replace(/\s+/g, ' ').trim()).toBe('“My photograph.”');
   });
 });

--- a/tests/jest/util/TextSelectionManager.test.js
+++ b/tests/jest/util/TextSelectionManager.test.js
@@ -7,7 +7,7 @@ import {
   findRangeForRegExp,
   getFirstWords,
   getLastWords,
-  normalizeTextFragment,
+  replaceTextFragmentDelimiters,
   treeWalkRange,
   genFilter,
   isBRVisibleTextNode,
@@ -15,7 +15,7 @@ import {
   getLastMostNode,
 } from '@/src/util/TextSelectionManager.js';
 
-// djvu.xml book infos copied from https://ia803103.us.archive.org/14/items/goodytwoshoes00newyiala/goodytwoshoes00newyiala_djvu.xml
+// djvu.xml copied from https://ia803103.us.archive.org/14/items/goodytwoshoes00newyiala/goodytwoshoes00newyiala_djvu.xml
 const FAKE_XML_MULT_LINES = `
   <OBJECT data="file://localhost//tmp/derive/goodytwoshoes00newyiala//goodytwoshoes00newyiala.djvu" height="3192" type="image/x.djvu" usemap="goodytwoshoes00newyiala_0001.djvu" width="2454">
     <PARAGRAPH>
@@ -28,7 +28,7 @@ const FAKE_XML_MULT_LINES = `
         <WORD coords="658,2039,728,2002" x-confidence="30">-</WORD>
         <WORD coords="728,2039,939,2001" x-confidence="29"> formed. </WORD>
         <WORD coords="939,2039,1087,2001" x-confidence="29">There </WORD>
-        <WORD coords="1087,2039,1187,2002" x-confidence="29">still </WORD>
+        <WORD coords="1087,2039,1187,2002" x-confidence="29">: </WORD>
         <WORD coords="1187,2038,1370,2003" x-confidence="29">remains: </WORD>
         <WORD coords="1370,2037,1433,2014" x-confidence="28">an-</WORD>
       </LINE>
@@ -403,7 +403,7 @@ describe("BookReaderTextFragment.fromSelection", () => {
     selection.removeAllRanges();
     selection.addRange(startWordRange);
     const startingSpaceTextFragmentUrl = BookReaderTextFragment.fromSelection(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
-    expect(startingSpaceTextFragmentUrl.toUrlString()).toBe(`12:way-,can%20false%20judgment%20be%20-%20formed.,-There%20still%20remains%20another%20mode`);
+    expect(startingSpaceTextFragmentUrl.toUrlString()).toBe(`12:way-,can%20false%20judgment%20be%20-%20formed.,-There%20remains%20another%20mode`);
 
     const endWordRange = document.createRange();
     endWordRange.setStart($container.find(".BRwordElement")[1].firstChild, 0);
@@ -413,7 +413,7 @@ describe("BookReaderTextFragment.fromSelection", () => {
     selection.addRange(endWordRange);
     const endingSpaceTextFragmentUrl = BookReaderTextFragment.fromSelection(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
 
-    expect(endingSpaceTextFragmentUrl.toUrlString()).toBe("12:way-,can%20false%20judgment%20be%20-,-formed.%20There%20still%20remains%20another");
+    expect(endingSpaceTextFragmentUrl.toUrlString()).toBe("12:way-,can%20false%20judgment%20be%20-,-formed.%20There%20remains%20another");
   });
 
   test("Handle range end node not text node", async () => {
@@ -430,7 +430,7 @@ describe("BookReaderTextFragment.fromSelection", () => {
     selection.removeAllRanges();
     selection.addRange(range);
     const startingSpaceTextFragmentUrl = BookReaderTextFragment.fromSelection(selection, Array.from(document.querySelectorAll('.BRtextLayer')));
-    expect(startingSpaceTextFragmentUrl.toUrlString()).toBe("12:-%20formed.%20There-,still%20remains%20an,-other%20mode%20in");
+    expect(startingSpaceTextFragmentUrl.toUrlString()).toBe("12:-%20formed.%20There-,remains%20an,-other%20mode%20in");
   });
 
   test("Quote and comma included in text selection should be URI encoded", async () => {
@@ -768,29 +768,29 @@ describe('treeWalkRange', () => {
   });
 });
 
-describe('normalizeTextFragment', () => {
+describe('replaceTextFragmentDelimiters', () => {
   test('replaces colon delimiter with space', () => {
-    expect(normalizeTextFragment('page:text')).toBe('page text');
+    expect(replaceTextFragmentDelimiters('page:text')).toBe('page text');
   });
 
   test('replaces -,  and ,- delimiters with spaces', () => {
-    expect(normalizeTextFragment('prefix-,quote,-suffix')).toBe('prefix quote suffix');
+    expect(replaceTextFragmentDelimiters('prefix-,quote,-suffix')).toBe('prefix  quote  suffix');
   });
 
   test('replaces standalone comma delimiter with space', () => {
-    expect(normalizeTextFragment('start,end')).toBe('start end');
+    expect(replaceTextFragmentDelimiters('start,end')).toBe('start end');
   });
 
-  test('collapses multiple whitespace into a single space', () => {
-    expect(normalizeTextFragment('hello   world')).toBe('hello world');
+  test('does not collapse multiple whitespace into a single space', () => {
+    expect(replaceTextFragmentDelimiters('hello   world')).toBe('hello   world');
   });
 
   test('returns unchanged string when no delimiters present', () => {
-    expect(normalizeTextFragment('plain text here')).toBe('plain text here');
+    expect(replaceTextFragmentDelimiters('plain text here')).toBe('plain text here');
   });
 
   test('handles empty string', () => {
-    expect(normalizeTextFragment('')).toBe('');
+    expect(replaceTextFragmentDelimiters('')).toBe('');
   });
 });
 
@@ -826,7 +826,7 @@ describe('BookReaderTextFragment.toRegExp and findRangeForRegExp', () => {
       .returns($(new DOMParser().parseFromString(FAKE_DIALOGUE, 'text/xml')));
     await br.plugins.textSelection.createTextLayer({ $container, page: {index: 1, width: 100, height: 100 }});
 
-    const normalize = normalizeTextFragment;
+    const normalize = replaceTextFragmentDelimiters;
     const textLayer = $container.find('.BRtextLayer')[0];
 
     // Create a range that encompasses the entire text content
@@ -839,7 +839,7 @@ describe('BookReaderTextFragment.toRegExp and findRangeForRegExp', () => {
     const tf = BookReaderTextFragment.fromString('“My own seal.”', null, 0);
 
     const range = findRangeForRegExp(
-      tf.toRegExp({ normalize }),
+      tf.toRegExp(),
       wholePageRange,
       textNodes,
       { normalize },


### PR DESCRIPTION
Sharing a "Copy link to highlight" link on eg facebook messenger resulted in the parameters being re-encoded:

Input link: `https://archive.org/details/macklife0000mack/page/246/mode/2up?text=246:to%20some%20extent%20%E2%80%98silly%E2%80%99.-,But%20I%20can,We%E2%80%99re%20all%20%E2%80%98them%E2%80%99.,-Lee%20Mack`

Link in facebooks messenger: `https://archive.org/details/macklife0000mack/page/246/mode/2up?text=246%3Ato%20some%20extent%20%E2%80%98silly%E2%80%99.-%2CBut%20I%20can%2CWe%E2%80%99re%20all%20%E2%80%98them%E2%80%99.%2C-Lee%20Mack`

Note the parameter becomes fully url encoded, with eg `:` being changed to `%3A` , and also `,` being replaced.

This broke the rather brittle custom url encoding the text parameter was using. Switched to a technique where the delimiter characters are removed from the source text, so the entire string can safely be encoded as a whole!

Test here: https://deploy-preview-1562--ia-bookreader.netlify.app/details/theworksofplato01platiala