### PR TITLE
Temporarily restore collapsed "Copy Link to Highlight" button on desktop

### DIFF
--- a/src/css/_TextSelection.scss
+++ b/src/css/_TextSelection.scss
@@ -226,13 +226,31 @@ $select-menu-extended-radius: 10px;
   flex-shrink: 0;
   width: 17px;
   height: 17px;
-  padding: 3px;
+  padding: 2px;
 }
 
 .br-select-menu__label {
   margin-left: 4px;
   font-size: 12px;
   margin-right: 4px;
+}
+
+@media (hover: hover) {
+    .br-select-menu__option {
+        padding: 4px;
+    }
+    .br-select-menu__label {
+        width: 0px;
+        margin: 0;
+        opacity: 0;
+        interpolate-size: allow-keywords;
+        transition: width 0.2s;
+    }
+    .br-select-menu__root:hover .br-select-menu__label {
+        width: auto;
+        margin: 0 4px;
+        opacity: 1;
+    }
 }
 
 .BRtextLayer .BRhighlight {


### PR DESCRIPTION
Addendum to #1564

We will eventually need to remove this animation once we have more options in the context menu, but for now, leave-in since it is a nice experience for the current feature set.