### PR TITLE
Update jsconfig for new version of typescript

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node16",
     "experimentalDecorators": true,
     "paths": {
       "@/*": ["./*"]


### PR DESCRIPTION
This was causing typehints to fail for imported files.