### PR TITLE
Fix `search-provider.test.js` to test constructor

### DIFF
--- a/tests/jest/plugins/search/search-provider.test.js
+++ b/tests/jest/plugins/search/search-provider.test.js
@@ -8,7 +8,7 @@ afterEach(() => {
 });
 
 describe('Search Provider', () => {
-  describe('constructor', () => {
+  test('constructor', () => {
     const provider = new searchProvider({
       onProviderChange: sinon.fake(),
       bookreader: {},


### PR DESCRIPTION
The `search-provider` test accidentally wrapped the constructor test in a `describe` block, which does not fire test expectations correctly. This PR updates the constructor test to use the `test` method instead.

This adds to the total number of tests run, changing it from 8 tests to 9 tests.

# Before

<img width="865" height="564" alt="Screenshot 2026-08-07 at 9 16 32 PM" src="https://github.com/user-attachments/assets/f21e50e4-f173-462f-9954-0df70e0a5148" />

# After

<img width="855" height="631" alt="Screenshot 2026-08-07 at 9 17 01 PM" src="https://github.com/user-attachments/assets/c3513b1e-b504-47d7-b982-4df28c08092b" />
