### PR TITLE
Prevent "scrollIntoView" from causing unexpected body scrolling

### DIFF
--- a/src/BookReader.js
+++ b/src/BookReader.js
@@ -26,6 +26,7 @@ import 'jquery-ui-touch-punch';
 
 import PACKAGE_JSON from '../package.json';
 import * as utils from './BookReader/utils.js';
+import { singleScrollIntoView } from './util/dom.js';
 import { exposeOverrideable } from './BookReader/utils/classes.js';
 import { Navbar } from './BookReader/Navbar/Navbar.js';
 import { DEFAULT_OPTIONS, OptionsParseError } from './BookReader/options.js';
@@ -1032,6 +1033,18 @@ BookReader.prototype.resizeBRcontainer = function(animate) {
       bottom: this.getFooterHeight(),
     });
   }
+};
+
+/**
+ * Scrolls the given element into view within the active mode's scroll container.
+ * @param {Element} el
+ * @param {object} [options]
+ * @param {'auto' | 'smooth'} [options.behavior]
+ * @param {'start' | 'center' | 'end' | 'nearest'} [options.block]
+ * @param {'start' | 'center' | 'end' | 'nearest'} [options.inline]
+ */
+BookReader.prototype.scrollIntoView = function(el, options) {
+  singleScrollIntoView(el, { ...options, scrollContainer: this.activeMode.scrollContainer });
 };
 
 BookReader.prototype.centerPageView = function() {

--- a/src/plugins/plugin.chapters.js
+++ b/src/plugins/plugin.chapters.js
@@ -7,6 +7,7 @@ import '@internetarchive/icon-toc/icon-toc.js';
 import { BookReaderPlugin } from "../BookReaderPlugin.js";
 import { applyVariables } from "../util/strings.js";
 import { promisifyEvent } from "../BookReader/utils.js";
+import { singleScrollIntoView } from "../util/dom.js";
 /** @typedef {import('@/src/BookReader/BookModel.js').PageIndex} PageIndex */
 /** @typedef {import('@/src/BookReader/BookModel.js').PageString} PageString */
 /** @typedef {import('@/src/BookReader/BookModel.js').LeafNum} LeafNum */
@@ -323,10 +324,13 @@ export class BRChaptersPanel extends LitElement {
 
   updated(changedProperties) {
     if (changedProperties.has('currentChapter')) {
-      this.shadowRoot.querySelector('li.current')?.scrollIntoView({
-        block: 'nearest',
-        behavior: 'smooth',
-      });
+      const currentEl = this.shadowRoot.querySelector('li.current');
+      if (currentEl) {
+        singleScrollIntoView(currentEl, {
+          block: 'nearest',
+          behavior: 'smooth',
+        });
+      }
     }
   }
 

--- a/src/plugins/plugin.text_selection.js
+++ b/src/plugins/plugin.text_selection.js
@@ -99,7 +99,7 @@ export class TextSelectionPlugin extends BookReaderPlugin {
           const markEls = renderHighlight(textLayer, targetTextFragment, 'BRhighlight--target-text');
           // Only jump once; presumably on first page load.
           if (!this._jumpedToHighlight) {
-            markEls[0].scrollIntoView({behavior: 'smooth', block: 'center'});
+            this.br.scrollIntoView(markEls[0], {behavior: 'smooth', block: 'center'});
             this._jumpedToHighlight = true;
           }
         }

--- a/src/plugins/search/plugin.search.js
+++ b/src/plugins/search/plugin.search.js
@@ -383,14 +383,8 @@ export class SearchPlugin extends BookReaderPlugin {
     const $boxes = await poll(() => $(`rect.match-index-${match.matchIndex}`), { until: result => result.length > 0 });
     if ($boxes.length) {
       $boxes.css('animation', 'none');
-      $boxes[0].scrollIntoView({
-        // Only vertically center the highlight if we're in 1up or in full screen. In
-        // 2up, if we're not fullscreen, the whole body gets scrolled around to try to
-        // center the highlight 🙄 See:
-        // https://stackoverflow.com/questions/11039885/scrollintoview-causing-the-whole-page-to-move/11041376
-        // Note: nearest doesn't quite work great, because the ReadAloud toolbar is now
-        // full-width, and covers up the last line of the highlight.
-        block: this.br.constMode1up == this.br.mode || this.br.isFullscreenActive ? 'center' : 'nearest',
+      this.br.scrollIntoView($boxes[0], {
+        block: 'center',
         inline: 'center',
         behavior: onNearbyPage ? 'smooth' : 'auto',
       });

--- a/src/plugins/tts/plugin.tts.js
+++ b/src/plugins/tts/plugin.tts.js
@@ -350,14 +350,9 @@ export class TtsPlugin extends BookReaderPlugin {
     // It behaves weird if used in thumb mode
     if (this.br.constModeThumb == this.br.mode) return;
 
-    $(`.pagediv${chunk.leafIndex} .ttsHiliteLayer rect`).last()?.[0]?.scrollIntoView({
-      // Only vertically center the highlight if we're in 1up or in full screen. In
-      // 2up, if we're not fullscreen, the whole body gets scrolled around to try to
-      // center the highlight 🙄 See:
-      // https://stackoverflow.com/questions/11039885/scrollintoview-causing-the-whole-page-to-move/11041376
-      // Note: nearest doesn't quite work great, because the ReadAloud toolbar is now
-      // full-width, and covers up the last line of the highlight.
-      block: this.br.constMode1up == this.br.mode || this.br.isFullscreenActive ? 'center' : 'nearest',
+    const highlightRect = $(`.pagediv${chunk.leafIndex} .ttsHiliteLayer rect`).last()?.[0];
+    this.br.scrollIntoView(highlightRect, {
+      block: 'center',
       inline: 'center',
       behavior: 'smooth',
     });

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -1,0 +1,88 @@
+// @ts-check
+import { clamp } from '../BookReader/utils.js';
+
+/**
+ * Walks up the DOM tree starting at (but not including) the given element,
+ * returning the nearest ancestor that can actually scroll its overflow.
+ * @param {Element} el
+ * @return {Element | null}
+ */
+export function findScrollableAncestor(el) {
+  let current = el.parentElement;
+  while (current) {
+    const style = getComputedStyle(current);
+    const canScrollY = (style.overflowY === 'auto' || style.overflowY === 'scroll') && current.scrollHeight > current.clientHeight;
+    const canScrollX = (style.overflowX === 'auto' || style.overflowX === 'scroll') && current.scrollWidth > current.clientWidth;
+    if (canScrollY || canScrollX) return current;
+    current = current.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Computes the scroll offset for a single axis needed to align an element
+ * within a container, per the same semantics as scrollIntoView's block/inline.
+ * @param {number} elStart
+ * @param {number} elEnd
+ * @param {number} containerStart
+ * @param {number} containerEnd
+ * @param {number} currentScroll
+ * @param {'start' | 'center' | 'end' | 'nearest'} align
+ * @return {number}
+ */
+function computeAxisScroll(elStart, elEnd, containerStart, containerEnd, currentScroll, align) {
+  let delta = 0;
+  switch (align) {
+  case 'start':
+    delta = elStart - containerStart;
+    break;
+  case 'end':
+    delta = elEnd - containerEnd;
+    break;
+  case 'center':
+    delta = (elStart + elEnd) / 2 - (containerStart + containerEnd) / 2;
+    break;
+  case 'nearest':
+  default:
+    if (elStart < containerStart) delta = elStart - containerStart;
+    else if (elEnd > containerEnd) delta = elEnd - containerEnd;
+    break;
+  }
+  return currentScroll + delta;
+}
+
+/**
+ * Scrolls the given element into view within a single scroll container.
+ *
+ * Unlike the native `Element.scrollIntoView`, this never walks up and scrolls
+ * every scrollable ancestor in turn (which can otherwise unexpectedly move
+ * the whole page) — it only ever adjusts the scroll position of one
+ * container: either the one explicitly passed in, or the nearest scrollable
+ * ancestor found via {@link findScrollableAncestor}.
+ * @param {Element} el
+ * @param {object} [options]
+ * @param {'auto' | 'smooth'} [options.behavior]
+ * @param {'start' | 'center' | 'end' | 'nearest'} [options.block]
+ * @param {'start' | 'center' | 'end' | 'nearest'} [options.inline]
+ * @param {Element} [options.scrollContainer] The scrollable element whose
+ *   scroll position should be adjusted. Defaults to `findScrollableAncestor(el)`.
+ */
+export function singleScrollIntoView(el, options) {
+  const { block = 'start', inline = 'nearest', behavior = 'auto', scrollContainer = findScrollableAncestor(el) } = options || {};
+  if (!scrollContainer) {
+    el.scrollIntoView({ block, inline, behavior });
+    return;
+  }
+
+  const containerRect = scrollContainer.getBoundingClientRect();
+  const elRect = el.getBoundingClientRect();
+
+  const top = computeAxisScroll(elRect.top, elRect.bottom, containerRect.top, containerRect.bottom, scrollContainer.scrollTop, block);
+  const left = computeAxisScroll(elRect.left, elRect.right, containerRect.left, containerRect.right, scrollContainer.scrollLeft, inline);
+
+  scrollContainer.scrollTo({
+    top: clamp(top, 0, scrollContainer.scrollHeight - scrollContainer.clientHeight),
+    left: clamp(left, 0, scrollContainer.scrollWidth - scrollContainer.clientWidth),
+    behavior,
+  });
+}

--- a/tests/jest/util/dom.test.js
+++ b/tests/jest/util/dom.test.js
@@ -1,0 +1,94 @@
+import sinon from 'sinon';
+import { findScrollableAncestor, singleScrollIntoView } from '@/src/util/dom.js';
+
+describe('findScrollableAncestor', () => {
+  test('finds the nearest ancestor that actually overflows', () => {
+    const outer = document.createElement('div');
+    const container = document.createElement('div');
+    const inner = document.createElement('div');
+    outer.appendChild(container);
+    container.appendChild(inner);
+
+    container.style.overflowY = 'auto';
+    Object.defineProperty(container, 'scrollHeight', { value: 500, configurable: true });
+    Object.defineProperty(container, 'clientHeight', { value: 100, configurable: true });
+
+    expect(findScrollableAncestor(inner)).toBe(container);
+  });
+
+  test('skips overflow ancestors whose content does not actually overflow', () => {
+    const outer = document.createElement('div');
+    const inner = document.createElement('div');
+    outer.appendChild(inner);
+
+    outer.style.overflowY = 'auto';
+    Object.defineProperty(outer, 'scrollHeight', { value: 100, configurable: true });
+    Object.defineProperty(outer, 'clientHeight', { value: 100, configurable: true });
+
+    expect(findScrollableAncestor(inner)).toBeNull();
+  });
+
+  test('returns null when there is no scrollable ancestor', () => {
+    const outer = document.createElement('div');
+    const inner = document.createElement('div');
+    outer.appendChild(inner);
+
+    expect(findScrollableAncestor(inner)).toBeNull();
+  });
+});
+
+describe('singleScrollIntoView', () => {
+  /** Builds a mock scroll container with controllable rect/scroll dimensions */
+  function mockContainer({ scrollTop = 0, scrollLeft = 0 } = {}) {
+    const container = document.createElement('div');
+    container.getBoundingClientRect = sinon.stub().returns({ top: 0, bottom: 100, left: 0, right: 100 });
+    Object.defineProperty(container, 'scrollTop', { value: scrollTop, configurable: true });
+    Object.defineProperty(container, 'scrollLeft', { value: scrollLeft, configurable: true });
+    Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true });
+    Object.defineProperty(container, 'clientHeight', { value: 100, configurable: true });
+    Object.defineProperty(container, 'scrollWidth', { value: 1000, configurable: true });
+    Object.defineProperty(container, 'clientWidth', { value: 100, configurable: true });
+    container.scrollTo = sinon.stub();
+    return container;
+  }
+
+  test('scrolls the given container to bring a below-the-fold element to the top', () => {
+    const container = mockContainer();
+    const el = document.createElement('div');
+    el.getBoundingClientRect = sinon.stub().returns({ top: 150, bottom: 170, left: 0, right: 20 });
+
+    singleScrollIntoView(el, { block: 'start', scrollContainer: container });
+
+    expect(container.scrollTo.calledOnce).toBe(true);
+    expect(container.scrollTo.firstCall.args[0].top).toBe(150);
+  });
+
+  test('does not move the container when the element is already visible (nearest)', () => {
+    const container = mockContainer({ scrollTop: 50 });
+    const el = document.createElement('div');
+    el.getBoundingClientRect = sinon.stub().returns({ top: 10, bottom: 50, left: 0, right: 20 });
+
+    singleScrollIntoView(el, { block: 'nearest', scrollContainer: container });
+
+    expect(container.scrollTo.firstCall.args[0].top).toBe(50);
+  });
+
+  test('clamps the resulting scroll position to the container bounds', () => {
+    const container = mockContainer();
+    const el = document.createElement('div');
+    el.getBoundingClientRect = sinon.stub().returns({ top: -500, bottom: -480, left: 0, right: 20 });
+
+    singleScrollIntoView(el, { block: 'start', scrollContainer: container });
+
+    expect(container.scrollTo.firstCall.args[0].top).toBe(0);
+  });
+
+  test('falls back to the native scrollIntoView when no scroll container is found', () => {
+    const el = document.createElement('div');
+    const scrollIntoViewStub = el.scrollIntoView = sinon.stub();
+
+    singleScrollIntoView(el, { block: 'center' });
+
+    expect(scrollIntoViewStub.calledOnce).toBe(true);
+  });
+});


### PR DESCRIPTION
The browser native scrollIntoView method recursively moves up the tree an adjusts scrolling of all scroll containers. This creates an unexpected experience in bookreader, which should not cause e.g. the body to scroll. This PR re-implements that method so that we can control it and not cause scrolling past bookreader.