### PR TITLE
Add double-tap-and-drag zoom gesture to 1up/2up modes

### DIFF
--- a/src/BookReader/Mode2UpLit.js
+++ b/src/BookReader/Mode2UpLit.js
@@ -678,11 +678,18 @@ export class Mode2UpLit extends LitElement {
 
     const $page = $(ev.target).closest('.BRpagecontainer');
     if (!$page.length) return;
-    if ($page.data('side') == 'L') {
-      this.br.left();
-    } else if ($page.data('side') == 'R') {
-      this.br.right();
-    }
+    const side = $page.data('side');
+    if (side != 'L' && side != 'R') return;
+
+    // If this tap turns out to be the first of a double-tap(-drag) zoom,
+    // don't flip the page out from under it.
+    this.smoothZoomer.runAfterTapResolved(() => {
+      if (side == 'L') {
+        this.br.left();
+      } else {
+        this.br.right();
+      }
+    });
   }
 }
 

--- a/src/BookReader/Mode2UpLit.js
+++ b/src/BookReader/Mode2UpLit.js
@@ -668,7 +668,7 @@ export class Mode2UpLit extends LitElement {
   /**
    * @param {MouseEvent} ev
    */
-  handlePageClick = (ev) => {
+  handlePageClick = async (ev) => {
     // right click
     if (ev.which == 3 && this.br.protected) {
       return false;
@@ -683,13 +683,13 @@ export class Mode2UpLit extends LitElement {
 
     // If this tap turns out to be the first of a double-tap(-drag) zoom,
     // don't flip the page out from under it.
-    this.smoothZoomer.runAfterTapResolved(() => {
+    if (await this.smoothZoomer.isSingleTap()) {
       if (side == 'L') {
         this.br.left();
       } else {
         this.br.right();
       }
-    });
+    }
   }
 }
 

--- a/src/BookReader/ModeSmoothZoom.js
+++ b/src/BookReader/ModeSmoothZoom.js
@@ -315,11 +315,6 @@ export class ModeSmoothZoom {
     }
     if (!this.activeTouch.isDoubleTapCandidate) return;
 
-    // iOS already uses double-tap-and-drag natively, for text selection --
-    // don't fight it for the zoom gesture. (The disambiguation above, e.g.
-    // not flipping the page on the first tap, still applies either way.)
-    if (isIOS()) return;
-
     // Block this from the first pixel of movement: touchAction should
     // already have stopped the browser from panning natively, but this is a
     // defensive backstop against browsers that don't fully honor that.
@@ -335,11 +330,16 @@ export class ModeSmoothZoom {
     }
 
     // Matches Google Maps/Chrome: drag down to zoom in, drag up to zoom out.
+    // iOS's own double-tap-drag zoom (e.g. Maps, Safari) runs the opposite
+    // way -- drag up to zoom in -- so flip it there to match platform norms.
+    // (Experimental: this competes with iOS's native double-tap-drag text
+    // selection gesture -- trying it out to see if that's worth the tradeoff.)
+    const dyForZoom = isIOS() ? -dy : dy;
     // Reuses pinch-zoom's own scale pipeline (_pinchMove / _drawPinchZoomFrame)
     // by modeling the drag as one finger moving away from a stationary one
     // starting DOUBLE_TAP_DRAG_REFERENCE_PX apart, and feeding the resulting
     // distance ratio in as if it were a pinch gesture's scale.
-    const virtualPinchDistance = Math.max(1, DOUBLE_TAP_DRAG_REFERENCE_PX + dy);
+    const virtualPinchDistance = Math.max(1, DOUBLE_TAP_DRAG_REFERENCE_PX + dyForZoom);
     this._pinchMove({
       scale: virtualPinchDistance / DOUBLE_TAP_DRAG_REFERENCE_PX,
       clientX: this.activeTouch.startX,
@@ -375,13 +375,8 @@ export class ModeSmoothZoom {
 
       // Preemptively block native panning for a possible second tap, since
       // touchAction is read by the browser at the *start* of that touch --
-      // reacting to it once that touch is already moving is too late. Skip
-      // this on iOS: the zoom gesture it would protect is disabled there
-      // anyway (see _handleTapMove), and iOS uses double-tap-drag natively
-      // for text selection -- don't risk interfering with that too.
-      if (!isIOS()) {
-        this.mode.$container.style.touchAction = "none";
-      }
+      // reacting to it once that touch is already moving is too late.
+      this.mode.$container.style.touchAction = "none";
       clearTimeout(this.doubleTapWindowTimer);
       this.doubleTapWindowTimer = setTimeout(this._disarmDoubleTapWindow, remainingWindowMs);
     } else {

--- a/src/BookReader/ModeSmoothZoom.js
+++ b/src/BookReader/ModeSmoothZoom.js
@@ -60,14 +60,12 @@ export class ModeSmoothZoom {
     /** State of the touch currently down, from `down` to `up`. */
     /** @type {{ time: number, startX: number, startY: number, isDoubleTapCandidate: boolean, dragEngaged: boolean, startScale: number }} */
     this.activeTouch = null;
-    /** Non-null when a double-tap-drag scale update has been enqueued/is being processed by the buffer function */
-    this.doubleTapDragFrame = null;
     /** The container's touch-action value outside of the double-tap-drag window (browser-dependent; see attach()). */
     this.baseTouchAction = "pan-x pan-y";
-    /** Timer that reverts touchAction back to baseTouchAction if a second tap never arrives. */
-    this.touchActionRevertTimer = null;
-    /** Timer for an action deferred by runAfterTapResolved(), pending double-tap disambiguation. */
-    this.singleTapActionTimer = null;
+    /** Timer that resolves the double-tap ambiguity if no second tap arrives before it fires. */
+    this.doubleTapWindowTimer = null;
+    /** Resolver for the in-flight isSingleTap() promise, if any. */
+    this._singleTapResolve = null;
 
     /** @type {function(function(): void): any} */
     this.bufferFn = window.requestAnimationFrame.bind(window);
@@ -127,10 +125,9 @@ export class ModeSmoothZoom {
 
   detach() {
     this.detachCtrlZoom();
-    clearTimeout(this.touchActionRevertTimer);
-    this.touchActionRevertTimer = null;
-    clearTimeout(this.singleTapActionTimer);
-    this.singleTapActionTimer = null;
+    clearTimeout(this.doubleTapWindowTimer);
+    this.doubleTapWindowTimer = null;
+    this._resolveSingleTap(false);
 
     // GestureEvents work only on Safari; they interfere with Hammer,
     // so block them.
@@ -161,6 +158,23 @@ export class ModeSmoothZoom {
       await sleep(0); // touches monitor can receive the touch event late
       if (this.touchesMonitor.touches < 2) return;
     }
+    this._startZoomGesture();
+
+    this.interact.gesturable({
+      listeners: {
+        start: this._pinchStart,
+        move: this._pinchMove,
+        end: this._pinchEnd,
+      },
+    });
+  }
+
+  /**
+   * Shared setup for any smooth-zoom gesture -- pinch, or double-tap-drag.
+   * Callers are responsible for their own gesture-start conditions (e.g.
+   * the iOS single-touch check above); this just does the common part.
+   */
+  _startZoomGesture() {
     this.pinching = true;
 
     // Do this in case the pinchend hasn't fired yet.
@@ -170,14 +184,6 @@ export class ModeSmoothZoom {
     this.mode.autoFit = "none";
     this.detachCtrlZoom();
     this.mode.detachScrollListeners?.();
-
-    this.interact.gesturable({
-      listeners: {
-        start: this._pinchStart,
-        move: this._pinchMove,
-        end: this._pinchEnd,
-      },
-    });
   }
 
   /** @param {{ scale: number, clientX: number, clientY: number }}} e */
@@ -265,8 +271,8 @@ export class ModeSmoothZoom {
       return;
     }
     if (e.pointerType !== 'touch') {
+      this._restoreTouchAction();
       this.activeTouch = null;
-      this.pendingTap = null;
       return;
     }
 
@@ -275,15 +281,10 @@ export class ModeSmoothZoom {
       Math.hypot(e.clientX - this.pendingTap.x, e.clientY - this.pendingTap.y) < DOUBLE_TAP_MAX_DISTANCE_PX;
 
     if (isDoubleTapCandidate) {
-      // touchAction was already set to "none" when the first tap ended, so
-      // the browser won't try to natively pan/scroll this touch at all; just
-      // stop the scheduled revert from firing mid-gesture.
-      clearTimeout(this.touchActionRevertTimer);
-      this.touchActionRevertTimer = null;
-      // The first tap turned out to be part of a double-tap: any action
-      // deferred for it (e.g. a page flip) should never run.
-      clearTimeout(this.singleTapActionTimer);
-      this.singleTapActionTimer = null;
+      // touchAction is already "none" from when the first tap ended, so the
+      // browser won't try to natively pan/scroll this touch at all; just
+      // make sure any action deferred for that first tap never runs now.
+      this._consumePendingTap();
     } else {
       this._restoreTouchAction();
     }
@@ -305,7 +306,10 @@ export class ModeSmoothZoom {
   _handleTapMove = (e) => {
     if (!this.activeTouch) return;
     const multiTouch = (e.originalEvent?.touches?.length ?? 1) > 1;
-    if (this.pinching || multiTouch) {
+    // `pinching` is also true once *our own* drag has engaged (it reuses
+    // the pinch pipeline), so only treat it as "a real pinch pre-empted
+    // this" before that point; afterwards, only a second finger can.
+    if (multiTouch || (this.pinching && !this.activeTouch.dragEngaged)) {
       this._cancelDoubleTapDrag();
       return;
     }
@@ -322,29 +326,32 @@ export class ModeSmoothZoom {
     if (!this.activeTouch.dragEngaged) {
       if (Math.hypot(dx, dy) < DOUBLE_TAP_DRAG_ENGAGE_PX) return;
       this.activeTouch.dragEngaged = true;
-      this._doubleTapDragStart(this.activeTouch);
+      this._startZoomGesture();
     }
 
     // Matches Google Maps/Chrome: drag down to zoom in, drag up to zoom out.
-    // Same rate as pinch-zoom: model it as one finger moving away from a
-    // stationary one starting DOUBLE_TAP_DRAG_REFERENCE_PX apart, and scale
-    // by the resulting distance ratio, same as _drawPinchZoomFrame does.
+    // Reuses pinch-zoom's own scale pipeline (_pinchMove / _drawPinchZoomFrame)
+    // by modeling the drag as one finger moving away from a stationary one
+    // starting DOUBLE_TAP_DRAG_REFERENCE_PX apart, and feeding the resulting
+    // distance ratio in as if it were a pinch gesture's scale.
     const virtualPinchDistance = Math.max(1, DOUBLE_TAP_DRAG_REFERENCE_PX + dy);
-    const newScale = this.activeTouch.startScale * virtualPinchDistance / DOUBLE_TAP_DRAG_REFERENCE_PX;
-    this._queueDoubleTapDragScale(newScale);
+    this._pinchMove({
+      scale: virtualPinchDistance / DOUBLE_TAP_DRAG_REFERENCE_PX,
+      clientX: this.activeTouch.startX,
+      clientY: this.activeTouch.startY,
+    });
   }
 
   /**
    * @param {{ clientX: number, clientY: number, timeStamp: number }} e
    */
-  _handleTapUp = (e) => {
+  _handleTapUp = async (e) => {
     if (!this.activeTouch) return;
 
     if (this.activeTouch.dragEngaged) {
-      this._doubleTapDragEnd();
+      await this._pinchEnd();
       this._restoreTouchAction();
       this.activeTouch = null;
-      this.pendingTap = null;
       return;
     }
 
@@ -355,93 +362,78 @@ export class ModeSmoothZoom {
     // Don't let the second tap of a double-tap seed a third; only a lone
     // tap can become the first tap of a new double-tap.
     if (wasTap && !this.activeTouch.isDoubleTapCandidate) {
-      this.pendingTap = { time: e.timeStamp, x: e.clientX, y: e.clientY };
+      // The double-tap window is measured from this tap's *down* (matching
+      // Chrome/Android), not from now -- so only wait out what's left of it.
+      const downTime = this.activeTouch.time;
+      this.pendingTap = { time: downTime, x: e.clientX, y: e.clientY };
+      const remainingWindowMs = Math.max(0, DOUBLE_TAP_TIME_MS - (e.timeStamp - downTime));
+
       // Preemptively block native panning for a possible second tap, since
       // touchAction is read by the browser at the *start* of that touch --
       // reacting to it once that touch is already moving is too late.
       this.mode.$container.style.touchAction = "none";
-      clearTimeout(this.touchActionRevertTimer);
-      this.touchActionRevertTimer = setTimeout(this._disarmDoubleTapWindow, DOUBLE_TAP_TIME_MS);
+      clearTimeout(this.doubleTapWindowTimer);
+      this.doubleTapWindowTimer = setTimeout(this._disarmDoubleTapWindow, remainingWindowMs);
     } else {
-      this.pendingTap = null;
       this._restoreTouchAction();
     }
     this.activeTouch = null;
   }
 
   /**
-   * Runs `fn`, unless the tap that just ended might be the first tap of a
-   * double-tap(-drag) -- in which case `fn` is deferred until we know
-   * whether a second tap follows, and dropped entirely if one does. Lets
-   * callers with their own single-tap actions (e.g. click-to-flip-page)
-   * avoid firing those out from under a gesture that's about to start.
-   * @param {() => void} fn
+   * Resolves once we know whether the tap that just ended was a lone single
+   * tap (true), or turned out to be the first tap of a double-tap(-drag)
+   * zoom (false) -- in which case any single-tap action for it (e.g. a page
+   * flip) should be skipped.
+   * @returns {Promise<boolean>}
    */
-  runAfterTapResolved(fn) {
-    if (!this.pendingTap) {
-      fn();
-      return;
-    }
-    clearTimeout(this.singleTapActionTimer);
-    this.singleTapActionTimer = setTimeout(() => {
-      this.singleTapActionTimer = null;
-      fn();
-    }, DOUBLE_TAP_TIME_MS);
+  isSingleTap() {
+    if (!this.pendingTap) return Promise.resolve(true);
+    return new Promise((resolve) => {
+      this._singleTapResolve = resolve;
+    });
   }
 
-  /** Reverts touchAction if no second tap arrived while it was armed. */
+  /** @param {boolean} isSingle */
+  _resolveSingleTap(isSingle) {
+    const resolve = this._singleTapResolve;
+    this._singleTapResolve = null;
+    resolve?.(isSingle);
+  }
+
+  /** The second tap of a double-tap arrived: it consumes the pending one, whose deferred action must never run. */
+  _consumePendingTap() {
+    clearTimeout(this.doubleTapWindowTimer);
+    this.doubleTapWindowTimer = null;
+    this._resolveSingleTap(false);
+  }
+
+  /** Fires if no second tap arrives before the double-tap window elapses: it really was a lone tap. */
   _disarmDoubleTapWindow = () => {
-    this.touchActionRevertTimer = null;
+    this.doubleTapWindowTimer = null;
     if (!this.activeTouch) {
       this.mode.$container.style.touchAction = this.baseTouchAction;
     }
+    this.pendingTap = null;
+    this._resolveSingleTap(true);
   }
 
+  /** Reverts touchAction to normal and resolves any pending tap as a lone tap, right away. */
   _restoreTouchAction() {
-    clearTimeout(this.touchActionRevertTimer);
-    this.touchActionRevertTimer = null;
+    clearTimeout(this.doubleTapWindowTimer);
+    this.doubleTapWindowTimer = null;
     this.mode.$container.style.touchAction = this.baseTouchAction;
-  }
-
-  /** @param {{ startX: number, startY: number }} touch */
-  _doubleTapDragStart(touch) {
-    this.mode.$visibleWorld.classList.add("BRsmooth-zooming");
-    this.mode.$visibleWorld.style.willChange = "transform";
-    this.mode.autoFit = "none";
-    this.detachCtrlZoom();
-    this.mode.detachScrollListeners?.();
-    this.updateScaleCenter({ clientX: touch.startX, clientY: touch.startY });
-  }
-
-  /** @param {number} newScale */
-  _queueDoubleTapDragScale(newScale) {
-    this.pendingDoubleTapScale = newScale;
-    if (!this.doubleTapDragFrame) {
-      this.doubleTapDragFrame = this.bufferFn(this._applyDoubleTapDragScale);
-    }
-  }
-
-  _applyDoubleTapDragScale = () => {
-    this.doubleTapDragFrame = null;
-    if (!this.activeTouch?.dragEngaged) return;
-    this.mode.scale = this.pendingDoubleTapScale;
-  }
-
-  _doubleTapDragEnd() {
-    this.mode.$visibleWorld.classList.remove("BRsmooth-zooming");
-    this.mode.$visibleWorld.style.willChange = "auto";
-    this.attachCtrlZoom();
-    this.mode.attachScrollListeners?.();
+    this.pendingTap = null;
+    this._resolveSingleTap(true);
   }
 
   /** Aborts an in-progress or candidate double-tap-drag, e.g. when a second finger touches down. */
-  _cancelDoubleTapDrag = () => {
+  _cancelDoubleTapDrag = async () => {
     if (this.activeTouch?.dragEngaged) {
-      this._doubleTapDragEnd();
+      await this._pinchEnd();
     }
     this._restoreTouchAction();
     this.activeTouch = null;
-    this.pendingTap = null;
   }
 
   /** @private */

--- a/src/BookReader/ModeSmoothZoom.js
+++ b/src/BookReader/ModeSmoothZoom.js
@@ -5,6 +5,24 @@ import { sleep } from './utils.js';
 /** @typedef {import('./utils/HTMLDimensionsCacher.js').HTMLDimensionsCacher} HTMLDimensionsCacher */
 
 /**
+ * Max ms between the end of the first tap and the start of the second tap to
+ * count as a double-tap. Matches Android's ViewConfiguration.DOUBLE_TAP_TIMEOUT
+ * and Flutter's kDoubleTapTimeout, both 300ms; iOS doesn't publish a number.
+ */
+const DOUBLE_TAP_TIME_MS = 300;
+/** Max px between the two taps of a double-tap. Matches Flutter's kDoubleTapSlop. */
+const DOUBLE_TAP_MAX_DISTANCE_PX = 100;
+/** Px the second tap needs to move before it's treated as a drag-to-zoom, rather than a stationary double-tap */
+const DOUBLE_TAP_DRAG_ENGAGE_PX = 10;
+/**
+ * Reference "virtual finger spread" for the drag half of the gesture, in px.
+ * Pinch-zoom's scale is exactly currentPinchDistance / startingPinchDistance
+ * (see _drawPinchZoomFrame); modeling the drag as one finger moving away
+ * from a stationary one starting this far apart reproduces that same rate.
+ */
+const DOUBLE_TAP_DRAG_REFERENCE_PX = 200;
+
+/**
  * @typedef {object} SmoothZoomable
  * @property {HTMLElement} $container
  * @property {HTMLElement} $visibleWorld
@@ -35,6 +53,21 @@ export class ModeSmoothZoom {
     /** @type {{ scale: number, clientX: number, clientY: number }}} */
     this.lastEvent = null;
     this.attached = false;
+
+    /** Most recent completed single tap, used to detect the second tap of a double-tap. */
+    /** @type {{ time: number, x: number, y: number }} */
+    this.pendingTap = null;
+    /** State of the touch currently down, from `down` to `up`. */
+    /** @type {{ time: number, startX: number, startY: number, isDoubleTapCandidate: boolean, dragEngaged: boolean, startScale: number }} */
+    this.activeTouch = null;
+    /** Non-null when a double-tap-drag scale update has been enqueued/is being processed by the buffer function */
+    this.doubleTapDragFrame = null;
+    /** The container's touch-action value outside of the double-tap-drag window (browser-dependent; see attach()). */
+    this.baseTouchAction = "pan-x pan-y";
+    /** Timer that reverts touchAction back to baseTouchAction if a second tap never arrives. */
+    this.touchActionRevertTimer = null;
+    /** Timer for an action deferred by runAfterTapResolved(), pending double-tap disambiguation. */
+    this.singleTapActionTimer = null;
 
     /** @type {function(function(): void): any} */
     this.bufferFn = window.requestAnimationFrame.bind(window);
@@ -67,6 +100,11 @@ export class ModeSmoothZoom {
         end: this._pinchEnd,
       },
     });
+
+    // The double-tap-and-drag zoom listeners
+    this.interact.on('down', this._handleTapDown);
+    this.interact.on('move', this._handleTapMove);
+    this.interact.on('up', this._handleTapUp);
     if (isSamsungInternet()) {
       // Samsung internet pinch-zoom will not work unless we disable
       // all touch actions. So use interact.js' built-in drag support
@@ -82,13 +120,17 @@ export class ModeSmoothZoom {
           listeners: { move: this._dragMove },
         });
     }
-
+    this.baseTouchAction = this.mode.$container.style.touchAction;
 
     this.attached = true;
   }
 
   detach() {
     this.detachCtrlZoom();
+    clearTimeout(this.touchActionRevertTimer);
+    this.touchActionRevertTimer = null;
+    clearTimeout(this.singleTapActionTimer);
+    this.singleTapActionTimer = null;
 
     // GestureEvents work only on Safari; they interfere with Hammer,
     // so block them.
@@ -209,6 +251,197 @@ export class ModeSmoothZoom {
     }
     this.mode.$container.scrollTop -= e.dy;
     this.mode.$container.scrollLeft -= e.dx;
+  }
+
+  /**
+   * Tracks the start of every touch, to detect when a touch is the second
+   * tap of a double-tap (the start of a possible double-tap-and-drag zoom).
+   * @param {{ pointerType: string, clientX: number, clientY: number, timeStamp: number, originalEvent: Event }} e
+   */
+  _handleTapDown = (e) => {
+    const multiTouch = (e.originalEvent?.touches?.length ?? 1) > 1;
+    if (this.pinching || multiTouch) {
+      this._cancelDoubleTapDrag();
+      return;
+    }
+    if (e.pointerType !== 'touch') {
+      this.activeTouch = null;
+      this.pendingTap = null;
+      return;
+    }
+
+    const isDoubleTapCandidate = !!this.pendingTap &&
+      (e.timeStamp - this.pendingTap.time) < DOUBLE_TAP_TIME_MS &&
+      Math.hypot(e.clientX - this.pendingTap.x, e.clientY - this.pendingTap.y) < DOUBLE_TAP_MAX_DISTANCE_PX;
+
+    if (isDoubleTapCandidate) {
+      // touchAction was already set to "none" when the first tap ended, so
+      // the browser won't try to natively pan/scroll this touch at all; just
+      // stop the scheduled revert from firing mid-gesture.
+      clearTimeout(this.touchActionRevertTimer);
+      this.touchActionRevertTimer = null;
+      // The first tap turned out to be part of a double-tap: any action
+      // deferred for it (e.g. a page flip) should never run.
+      clearTimeout(this.singleTapActionTimer);
+      this.singleTapActionTimer = null;
+    } else {
+      this._restoreTouchAction();
+    }
+
+    this.activeTouch = {
+      time: e.timeStamp,
+      startX: e.clientX,
+      startY: e.clientY,
+      isDoubleTapCandidate,
+      dragEngaged: false,
+      startScale: this.mode.scale,
+    };
+    this.pendingTap = null;
+  }
+
+  /**
+   * @param {{ clientX: number, clientY: number, originalEvent: Event, preventDefault: function(): void }} e
+   */
+  _handleTapMove = (e) => {
+    if (!this.activeTouch) return;
+    const multiTouch = (e.originalEvent?.touches?.length ?? 1) > 1;
+    if (this.pinching || multiTouch) {
+      this._cancelDoubleTapDrag();
+      return;
+    }
+    if (!this.activeTouch.isDoubleTapCandidate) return;
+
+    // Block this from the first pixel of movement: touchAction should
+    // already have stopped the browser from panning natively, but this is a
+    // defensive backstop against browsers that don't fully honor that.
+    e.preventDefault();
+
+    const dx = e.clientX - this.activeTouch.startX;
+    const dy = e.clientY - this.activeTouch.startY;
+
+    if (!this.activeTouch.dragEngaged) {
+      if (Math.hypot(dx, dy) < DOUBLE_TAP_DRAG_ENGAGE_PX) return;
+      this.activeTouch.dragEngaged = true;
+      this._doubleTapDragStart(this.activeTouch);
+    }
+
+    // Matches Google Maps/Chrome: drag down to zoom in, drag up to zoom out.
+    // Same rate as pinch-zoom: model it as one finger moving away from a
+    // stationary one starting DOUBLE_TAP_DRAG_REFERENCE_PX apart, and scale
+    // by the resulting distance ratio, same as _drawPinchZoomFrame does.
+    const virtualPinchDistance = Math.max(1, DOUBLE_TAP_DRAG_REFERENCE_PX + dy);
+    const newScale = this.activeTouch.startScale * virtualPinchDistance / DOUBLE_TAP_DRAG_REFERENCE_PX;
+    this._queueDoubleTapDragScale(newScale);
+  }
+
+  /**
+   * @param {{ clientX: number, clientY: number, timeStamp: number }} e
+   */
+  _handleTapUp = (e) => {
+    if (!this.activeTouch) return;
+
+    if (this.activeTouch.dragEngaged) {
+      this._doubleTapDragEnd();
+      this._restoreTouchAction();
+      this.activeTouch = null;
+      this.pendingTap = null;
+      return;
+    }
+
+    const dx = e.clientX - this.activeTouch.startX;
+    const dy = e.clientY - this.activeTouch.startY;
+    const wasTap = Math.hypot(dx, dy) < DOUBLE_TAP_DRAG_ENGAGE_PX;
+
+    // Don't let the second tap of a double-tap seed a third; only a lone
+    // tap can become the first tap of a new double-tap.
+    if (wasTap && !this.activeTouch.isDoubleTapCandidate) {
+      this.pendingTap = { time: e.timeStamp, x: e.clientX, y: e.clientY };
+      // Preemptively block native panning for a possible second tap, since
+      // touchAction is read by the browser at the *start* of that touch --
+      // reacting to it once that touch is already moving is too late.
+      this.mode.$container.style.touchAction = "none";
+      clearTimeout(this.touchActionRevertTimer);
+      this.touchActionRevertTimer = setTimeout(this._disarmDoubleTapWindow, DOUBLE_TAP_TIME_MS);
+    } else {
+      this.pendingTap = null;
+      this._restoreTouchAction();
+    }
+    this.activeTouch = null;
+  }
+
+  /**
+   * Runs `fn`, unless the tap that just ended might be the first tap of a
+   * double-tap(-drag) -- in which case `fn` is deferred until we know
+   * whether a second tap follows, and dropped entirely if one does. Lets
+   * callers with their own single-tap actions (e.g. click-to-flip-page)
+   * avoid firing those out from under a gesture that's about to start.
+   * @param {() => void} fn
+   */
+  runAfterTapResolved(fn) {
+    if (!this.pendingTap) {
+      fn();
+      return;
+    }
+    clearTimeout(this.singleTapActionTimer);
+    this.singleTapActionTimer = setTimeout(() => {
+      this.singleTapActionTimer = null;
+      fn();
+    }, DOUBLE_TAP_TIME_MS);
+  }
+
+  /** Reverts touchAction if no second tap arrived while it was armed. */
+  _disarmDoubleTapWindow = () => {
+    this.touchActionRevertTimer = null;
+    if (!this.activeTouch) {
+      this.mode.$container.style.touchAction = this.baseTouchAction;
+    }
+  }
+
+  _restoreTouchAction() {
+    clearTimeout(this.touchActionRevertTimer);
+    this.touchActionRevertTimer = null;
+    this.mode.$container.style.touchAction = this.baseTouchAction;
+  }
+
+  /** @param {{ startX: number, startY: number }} touch */
+  _doubleTapDragStart(touch) {
+    this.mode.$visibleWorld.classList.add("BRsmooth-zooming");
+    this.mode.$visibleWorld.style.willChange = "transform";
+    this.mode.autoFit = "none";
+    this.detachCtrlZoom();
+    this.mode.detachScrollListeners?.();
+    this.updateScaleCenter({ clientX: touch.startX, clientY: touch.startY });
+  }
+
+  /** @param {number} newScale */
+  _queueDoubleTapDragScale(newScale) {
+    this.pendingDoubleTapScale = newScale;
+    if (!this.doubleTapDragFrame) {
+      this.doubleTapDragFrame = this.bufferFn(this._applyDoubleTapDragScale);
+    }
+  }
+
+  _applyDoubleTapDragScale = () => {
+    this.doubleTapDragFrame = null;
+    if (!this.activeTouch?.dragEngaged) return;
+    this.mode.scale = this.pendingDoubleTapScale;
+  }
+
+  _doubleTapDragEnd() {
+    this.mode.$visibleWorld.classList.remove("BRsmooth-zooming");
+    this.mode.$visibleWorld.style.willChange = "auto";
+    this.attachCtrlZoom();
+    this.mode.attachScrollListeners?.();
+  }
+
+  /** Aborts an in-progress or candidate double-tap-drag, e.g. when a second finger touches down. */
+  _cancelDoubleTapDrag = () => {
+    if (this.activeTouch?.dragEngaged) {
+      this._doubleTapDragEnd();
+    }
+    this._restoreTouchAction();
+    this.activeTouch = null;
+    this.pendingTap = null;
   }
 
   /** @private */

--- a/src/BookReader/ModeSmoothZoom.js
+++ b/src/BookReader/ModeSmoothZoom.js
@@ -315,6 +315,11 @@ export class ModeSmoothZoom {
     }
     if (!this.activeTouch.isDoubleTapCandidate) return;
 
+    // iOS already uses double-tap-and-drag natively, for text selection --
+    // don't fight it for the zoom gesture. (The disambiguation above, e.g.
+    // not flipping the page on the first tap, still applies either way.)
+    if (isIOS()) return;
+
     // Block this from the first pixel of movement: touchAction should
     // already have stopped the browser from panning natively, but this is a
     // defensive backstop against browsers that don't fully honor that.
@@ -370,8 +375,13 @@ export class ModeSmoothZoom {
 
       // Preemptively block native panning for a possible second tap, since
       // touchAction is read by the browser at the *start* of that touch --
-      // reacting to it once that touch is already moving is too late.
-      this.mode.$container.style.touchAction = "none";
+      // reacting to it once that touch is already moving is too late. Skip
+      // this on iOS: the zoom gesture it would protect is disabled there
+      // anyway (see _handleTapMove), and iOS uses double-tap-drag natively
+      // for text selection -- don't risk interfering with that too.
+      if (!isIOS()) {
+        this.mode.$container.style.touchAction = "none";
+      }
       clearTimeout(this.doubleTapWindowTimer);
       this.doubleTapWindowTimer = setTimeout(this._disarmDoubleTapWindow, remainingWindowMs);
     } else {

--- a/tests/jest/BookReader/Mode2UpLit.test.js
+++ b/tests/jest/BookReader/Mode2UpLit.test.js
@@ -199,43 +199,58 @@ describe("handlePageClick", () => {
     return { which: 1, target };
   }
 
-  test("routes through smoothZoomer.runAfterTapResolved instead of flipping immediately", () => {
+  test("routes through smoothZoomer.isSingleTap instead of flipping immediately", async () => {
     const br = make_dummy_br({ data: SAMPLE_DATA, left: sinon.spy(), right: sinon.spy() });
     const book = new BookModel(br);
     const mode = new Mode2UpLit(book, br);
-    sinon.stub(mode.smoothZoomer, 'runAfterTapResolved');
+    let resolveIsSingleTap;
+    sinon.stub(mode.smoothZoomer, 'isSingleTap')
+      .returns(new Promise((res) => { resolveIsSingleTap = res; }));
 
-    mode.handlePageClick(pageClickEvent('R'));
+    const clickPromise = mode.handlePageClick(pageClickEvent('R'));
 
-    expect(mode.smoothZoomer.runAfterTapResolved.callCount).toBe(1);
+    expect(mode.smoothZoomer.isSingleTap.callCount).toBe(1);
     expect(br.right.callCount).toBe(0);
 
-    // The deferred callback flips the correct direction once run.
-    mode.smoothZoomer.runAfterTapResolved.firstCall.args[0]();
+    // Only flips once isSingleTap resolves true.
+    resolveIsSingleTap(true);
+    await clickPromise;
     expect(br.right.callCount).toBe(1);
     expect(br.left.callCount).toBe(0);
   });
 
-  test("left side flips left", () => {
+  test("does not flip if isSingleTap resolves false (consumed by a double-tap)", async () => {
     const br = make_dummy_br({ data: SAMPLE_DATA, left: sinon.spy(), right: sinon.spy() });
     const book = new BookModel(br);
     const mode = new Mode2UpLit(book, br);
-    sinon.stub(mode.smoothZoomer, 'runAfterTapResolved').callsFake((fn) => fn());
+    sinon.stub(mode.smoothZoomer, 'isSingleTap').resolves(false);
 
-    mode.handlePageClick(pageClickEvent('L'));
+    await mode.handlePageClick(pageClickEvent('R'));
+
+    expect(br.right.callCount).toBe(0);
+    expect(br.left.callCount).toBe(0);
+  });
+
+  test("left side flips left", async () => {
+    const br = make_dummy_br({ data: SAMPLE_DATA, left: sinon.spy(), right: sinon.spy() });
+    const book = new BookModel(br);
+    const mode = new Mode2UpLit(book, br);
+    sinon.stub(mode.smoothZoomer, 'isSingleTap').resolves(true);
+
+    await mode.handlePageClick(pageClickEvent('L'));
 
     expect(br.left.callCount).toBe(1);
     expect(br.right.callCount).toBe(0);
   });
 
-  test("ignores clicks outside a page container", () => {
+  test("ignores clicks outside a page container", async () => {
     const br = make_dummy_br({ data: SAMPLE_DATA, left: sinon.spy(), right: sinon.spy() });
     const book = new BookModel(br);
     const mode = new Mode2UpLit(book, br);
-    sinon.stub(mode.smoothZoomer, 'runAfterTapResolved');
+    sinon.stub(mode.smoothZoomer, 'isSingleTap');
 
-    mode.handlePageClick({ which: 1, target: document.createElement('div') });
+    await mode.handlePageClick({ which: 1, target: document.createElement('div') });
 
-    expect(mode.smoothZoomer.runAfterTapResolved.callCount).toBe(0);
+    expect(mode.smoothZoomer.isSingleTap.callCount).toBe(0);
   });
 });

--- a/tests/jest/BookReader/Mode2UpLit.test.js
+++ b/tests/jest/BookReader/Mode2UpLit.test.js
@@ -1,4 +1,5 @@
 import sinon from "sinon";
+import "@/src/jquery-wrapper.js";
 import { BookModel } from "@/src/BookReader/BookModel.js";
 import { Mode2UpLit } from "@/src/BookReader/Mode2UpLit.js";
 
@@ -186,5 +187,55 @@ describe("computePositions", () => {
     const mode = new Mode2UpLit(book, br);
 
     expect(mode.computePositions(book.getPage(-1), null)).toEqual(RIGHT_COVER_EXPECTED);
+  });
+});
+
+describe("handlePageClick", () => {
+  /** @param {'L' | 'R'} side */
+  function pageClickEvent(side) {
+    const target = document.createElement('div');
+    target.classList.add('BRpagecontainer');
+    target.setAttribute('data-side', side);
+    return { which: 1, target };
+  }
+
+  test("routes through smoothZoomer.runAfterTapResolved instead of flipping immediately", () => {
+    const br = make_dummy_br({ data: SAMPLE_DATA, left: sinon.spy(), right: sinon.spy() });
+    const book = new BookModel(br);
+    const mode = new Mode2UpLit(book, br);
+    sinon.stub(mode.smoothZoomer, 'runAfterTapResolved');
+
+    mode.handlePageClick(pageClickEvent('R'));
+
+    expect(mode.smoothZoomer.runAfterTapResolved.callCount).toBe(1);
+    expect(br.right.callCount).toBe(0);
+
+    // The deferred callback flips the correct direction once run.
+    mode.smoothZoomer.runAfterTapResolved.firstCall.args[0]();
+    expect(br.right.callCount).toBe(1);
+    expect(br.left.callCount).toBe(0);
+  });
+
+  test("left side flips left", () => {
+    const br = make_dummy_br({ data: SAMPLE_DATA, left: sinon.spy(), right: sinon.spy() });
+    const book = new BookModel(br);
+    const mode = new Mode2UpLit(book, br);
+    sinon.stub(mode.smoothZoomer, 'runAfterTapResolved').callsFake((fn) => fn());
+
+    mode.handlePageClick(pageClickEvent('L'));
+
+    expect(br.left.callCount).toBe(1);
+    expect(br.right.callCount).toBe(0);
+  });
+
+  test("ignores clicks outside a page container", () => {
+    const br = make_dummy_br({ data: SAMPLE_DATA, left: sinon.spy(), right: sinon.spy() });
+    const book = new BookModel(br);
+    const mode = new Mode2UpLit(book, br);
+    sinon.stub(mode.smoothZoomer, 'runAfterTapResolved');
+
+    mode.handlePageClick({ which: 1, target: document.createElement('div') });
+
+    expect(mode.smoothZoomer.runAfterTapResolved.callCount).toBe(0);
   });
 });

--- a/tests/jest/BookReader/ModeSmoothZoom.test.js
+++ b/tests/jest/BookReader/ModeSmoothZoom.test.js
@@ -224,7 +224,11 @@ describe('ModeSmoothZoom', () => {
     });
 
     describe('on iOS', () => {
-      test('the double-tap-drag zoom does not engage at all, since iOS uses that gesture natively for text selection', () => {
+      // Experimental: this competes with iOS's native double-tap-drag text
+      // selection gesture. Enabled (with direction reversed, to match iOS's
+      // own convention) so people can try it out and weigh in on whether
+      // it's worth that tradeoff -- see _handleTapMove.
+      test('drag down zooms out, and drag up zooms in (reversed, matching iOS\'s own gesture)', () => {
         sinon.stub(browserSniffing, 'isIOS').returns(true);
         const mode = dummy_mode();
         const msz = new ModeSmoothZoom(mode);
@@ -233,16 +237,28 @@ describe('ModeSmoothZoom', () => {
         msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
         msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
         msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
-        const move = touchEvent({ clientX: 52, clientY: 90, timeStamp: 120 });
-        msz._handleTapMove(move);
+        // Drag down; on every other platform this zooms in, but on iOS it
+        // should zoom out instead.
+        msz._handleTapMove(touchEvent({ clientX: 52, clientY: 90, timeStamp: 120 }));
 
-        expect(mode.scale).toBe(1);
-        expect(mode.$visibleWorld.classList.contains('BRsmooth-zooming')).toBe(false);
-        // Doesn't fight the native gesture for it, either.
-        expect(move.preventDefault.callCount).toBe(0);
+        expect(mode.scale).toBeLessThan(1);
       });
 
-      test('touchAction is not preemptively locked after a lone tap, since there is no zoom gesture to protect', () => {
+      test('drag up zooms in, on iOS', () => {
+        sinon.stub(browserSniffing, 'isIOS').returns(true);
+        const mode = dummy_mode();
+        const msz = new ModeSmoothZoom(mode);
+        msz.bufferFn = (cb) => cb();
+
+        msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+        msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+        msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
+        msz._handleTapMove(touchEvent({ clientX: 52, clientY: 20, timeStamp: 120 }));
+
+        expect(mode.scale).toBeGreaterThan(1);
+      });
+
+      test('touchAction is preemptively locked to none after a lone tap, same as other platforms', () => {
         sinon.stub(browserSniffing, 'isIOS').returns(true);
         const mode = dummy_mode();
         const msz = new ModeSmoothZoom(mode);
@@ -251,7 +267,7 @@ describe('ModeSmoothZoom', () => {
         msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
         msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
 
-        expect(mode.$container.style.touchAction).not.toBe('none');
+        expect(mode.$container.style.touchAction).toBe('none');
       });
 
       test('a second tap still suppresses the first tap\'s deferred single-tap action (e.g. page flip)', async () => {

--- a/tests/jest/BookReader/ModeSmoothZoom.test.js
+++ b/tests/jest/BookReader/ModeSmoothZoom.test.js
@@ -160,46 +160,76 @@ describe('ModeSmoothZoom', () => {
       };
     }
 
-    test('drag down after a double-tap zooms in (matches Google Maps/Chrome)', () => {
+    test('drag down after a double-tap zooms in (matches Google Maps/Chrome)', async () => {
       const mode = dummy_mode();
       const msz = new ModeSmoothZoom(mode);
+      msz.attach();
       msz.bufferFn = (cb) => cb();
 
       // First tap
       msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
-      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+      await msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
       // Second tap, close in time/space -> double-tap candidate
       msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
       expect(mode.scale).toBe(1);
       // Drag down (increasing clientY) engages the zoom and increases scale
       msz._handleTapMove(touchEvent({ clientX: 52, clientY: 90, timeStamp: 120 }));
       expect(mode.scale).toBeGreaterThan(1);
+      // Reused from pinch-zoom: settles the in-flight frame, same as the
+      // real mode component's updated() lifecycle hook would.
+      msz.pinchMoveFramePromiseRes();
 
-      msz._handleTapUp(touchEvent({ clientX: 52, clientY: 90, timeStamp: 140 }));
+      await msz._handleTapUp(touchEvent({ clientX: 52, clientY: 90, timeStamp: 140 }));
       expect(mode.$visibleWorld.classList.contains('BRsmooth-zooming')).toBe(false);
     });
 
-    test('drag up after a double-tap zooms out (matches Google Maps/Chrome)', () => {
+    test('consecutive move events keep zooming, rather than each one cancelling the last', async () => {
+      // Regression test: engaging the drag reuses pinch-zoom's own `pinching`
+      // flag (per code review), which must not make the *second* move event
+      // mistake the drag it itself started for an external pinch pre-empting it.
+      const mode = dummy_mode();
+      const msz = new ModeSmoothZoom(mode);
+      msz.attach();
+      msz.bufferFn = (cb) => cb();
+
+      msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+      msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
+
+      msz._handleTapMove(touchEvent({ clientX: 52, clientY: 70, timeStamp: 120 }));
+      const scaleAfterFirstMove = mode.scale;
+      expect(mode.$visibleWorld.classList.contains('BRsmooth-zooming')).toBe(true);
+      // Settle the in-flight frame (as the real component's updated() hook
+      // would) so the next move's frame isn't just buffered behind it.
+      msz.pinchMoveFramePromiseRes();
+      await afterEventLoop();
+
+      msz._handleTapMove(touchEvent({ clientX: 52, clientY: 90, timeStamp: 140 }));
+      expect(mode.scale).toBeGreaterThan(scaleAfterFirstMove);
+      expect(mode.$visibleWorld.classList.contains('BRsmooth-zooming')).toBe(true);
+    });
+
+    test('drag up after a double-tap zooms out (matches Google Maps/Chrome)', async () => {
       const mode = dummy_mode();
       const msz = new ModeSmoothZoom(mode);
       msz.bufferFn = (cb) => cb();
 
       msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
-      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+      await msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
       msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
       msz._handleTapMove(touchEvent({ clientX: 52, clientY: 20, timeStamp: 120 }));
 
       expect(mode.scale).toBeLessThan(1);
     });
 
-    test('a lone tap locks touchAction to none, to block native panning if a second tap follows', () => {
+    test('a lone tap locks touchAction to none, to block native panning if a second tap follows', async () => {
       const mode = dummy_mode();
       const msz = new ModeSmoothZoom(mode);
       msz.bufferFn = (cb) => cb();
       expect(mode.$container.style.touchAction).not.toBe('none');
 
       msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
-      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+      await msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
 
       expect(mode.$container.style.touchAction).toBe('none');
     });
@@ -223,19 +253,21 @@ describe('ModeSmoothZoom', () => {
       expect(mode.$visibleWorld.classList.contains('BRsmooth-zooming')).toBe(false);
     });
 
-    test('touchAction is restored once the double-tap-drag ends', () => {
+    test('touchAction is restored once the double-tap-drag ends', async () => {
       const mode = dummy_mode();
       const msz = new ModeSmoothZoom(mode);
+      msz.attach();
       msz.bufferFn = (cb) => cb();
       msz.baseTouchAction = 'pan-x pan-y';
 
       msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
-      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+      await msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
       msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
       msz._handleTapMove(touchEvent({ clientX: 52, clientY: 20, timeStamp: 120 }));
       expect(mode.$container.style.touchAction).toBe('none');
+      msz.pinchMoveFramePromiseRes();
 
-      msz._handleTapUp(touchEvent({ clientX: 52, clientY: 20, timeStamp: 140 }));
+      await msz._handleTapUp(touchEvent({ clientX: 52, clientY: 20, timeStamp: 140 }));
       expect(mode.$container.style.touchAction).toBe('pan-x pan-y');
     });
 
@@ -255,15 +287,34 @@ describe('ModeSmoothZoom', () => {
       jest.useRealTimers();
     });
 
-    test('a stationary second tap does not change scale', () => {
+    test('the double-tap window is measured from the first tap\'s down, not its up', () => {
+      jest.useFakeTimers();
+      const mode = dummy_mode();
+      const msz = new ModeSmoothZoom(mode);
+      msz.bufferFn = (cb) => cb();
+      msz.baseTouchAction = 'pan-x pan-y';
+
+      // Down at t=0, up at t=290 (a slow, deliberate first tap).
+      msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 290 }));
+      expect(mode.$container.style.touchAction).toBe('none');
+
+      // Only 10ms of the 300ms window (measured from the down at t=0) is
+      // left, even though only 10ms have passed since the up at t=290.
+      jest.advanceTimersByTime(15);
+      expect(mode.$container.style.touchAction).toBe('pan-x pan-y');
+      jest.useRealTimers();
+    });
+
+    test('a stationary second tap does not change scale', async () => {
       const mode = dummy_mode();
       const msz = new ModeSmoothZoom(mode);
       msz.bufferFn = (cb) => cb();
 
       msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
-      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+      await msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
       msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
-      msz._handleTapUp(touchEvent({ clientX: 52, clientY: 52, timeStamp: 110 }));
+      await msz._handleTapUp(touchEvent({ clientX: 52, clientY: 52, timeStamp: 110 }));
 
       expect(mode.scale).toBe(1);
     });
@@ -295,20 +346,24 @@ describe('ModeSmoothZoom', () => {
       expect(mode.scale).toBe(1);
     });
 
-    test('a second finger touching down cancels an in-progress double-tap-drag', () => {
+    test('a second finger touching down cancels an in-progress double-tap-drag', async () => {
       const mode = dummy_mode();
       const msz = new ModeSmoothZoom(mode);
+      msz.attach();
       msz.bufferFn = (cb) => cb();
 
       msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
-      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+      await msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
       msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
       msz._handleTapMove(touchEvent({ clientX: 52, clientY: 20, timeStamp: 120 }));
       expect(mode.$visibleWorld.classList.contains('BRsmooth-zooming')).toBe(true);
       const scaleWhenSecondFingerLands = mode.scale;
+      msz.pinchMoveFramePromiseRes();
 
-      // A second finger touches down mid-gesture
+      // A second finger touches down mid-gesture; the resulting cancellation
+      // is fire-and-forget from _handleTapMove, so wait a tick for it.
       msz._handleTapMove(touchEvent({ clientX: 52, clientY: 10, timeStamp: 130, touches: [{}, {}] }));
+      await afterEventLoop();
 
       expect(mode.$visibleWorld.classList.contains('BRsmooth-zooming')).toBe(false);
       expect(mode.scale).toBe(scaleWhenSecondFingerLands);
@@ -328,47 +383,42 @@ describe('ModeSmoothZoom', () => {
       expect(mode.scale).toBe(1);
     });
 
-    describe('runAfterTapResolved', () => {
-      test('runs fn immediately when there is no pending tap (e.g. a mouse click)', () => {
+    describe('isSingleTap', () => {
+      test('resolves true immediately when there is no pending tap (e.g. a mouse click)', async () => {
         const mode = dummy_mode();
         const msz = new ModeSmoothZoom(mode);
-        const fn = sinon.spy();
 
-        msz.runAfterTapResolved(fn);
-
-        expect(fn.callCount).toBe(1);
+        await expect(msz.isSingleTap()).resolves.toBe(true);
       });
 
-      test('defers fn while a lone tap could still become a double-tap, and drops it if one arrives', () => {
-        jest.useFakeTimers();
+      test('resolves false once a second tap arrives before the window elapses', async () => {
         const mode = dummy_mode();
         const msz = new ModeSmoothZoom(mode);
-        const fn = sinon.spy();
+        msz.bufferFn = (cb) => cb();
 
         msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
-        msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
-        msz.runAfterTapResolved(fn);
-        expect(fn.callCount).toBe(0);
+        await msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+        const resultPromise = msz.isSingleTap();
 
-        // A second tap arrives in time -- the deferred action must never fire.
+        // A second tap arrives in time -- this must resolve false.
         msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
-        jest.advanceTimersByTime(1000);
-        expect(fn.callCount).toBe(0);
-        jest.useRealTimers();
+
+        await expect(resultPromise).resolves.toBe(false);
       });
 
-      test('runs the deferred fn if no second tap arrives before the window elapses', () => {
+      test('resolves true if no second tap arrives before the window elapses', async () => {
         jest.useFakeTimers();
         const mode = dummy_mode();
         const msz = new ModeSmoothZoom(mode);
-        const fn = sinon.spy();
+        msz.bufferFn = (cb) => cb();
 
         msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
         msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
-        msz.runAfterTapResolved(fn);
+        const resultPromise = msz.isSingleTap();
 
         jest.advanceTimersByTime(1000);
-        expect(fn.callCount).toBe(1);
+
+        await expect(resultPromise).resolves.toBe(true);
         jest.useRealTimers();
       });
     });

--- a/tests/jest/BookReader/ModeSmoothZoom.test.js
+++ b/tests/jest/BookReader/ModeSmoothZoom.test.js
@@ -1,6 +1,7 @@
 import sinon from 'sinon';
 import interact from 'interactjs';
 import { EventTargetSpy, afterEventLoop } from '../utils.js';
+import * as browserSniffing from '@/src/util/browserSniffing.js';
 import { ModeSmoothZoom, TouchesMonitor } from '@/src/BookReader/ModeSmoothZoom.js';
 /** @typedef {import('@/src/BookReader/ModeSmoothZoom.js').SmoothZoomable} SmoothZoomable */
 
@@ -220,6 +221,53 @@ describe('ModeSmoothZoom', () => {
       msz._handleTapMove(touchEvent({ clientX: 52, clientY: 20, timeStamp: 120 }));
 
       expect(mode.scale).toBeLessThan(1);
+    });
+
+    describe('on iOS', () => {
+      test('the double-tap-drag zoom does not engage at all, since iOS uses that gesture natively for text selection', () => {
+        sinon.stub(browserSniffing, 'isIOS').returns(true);
+        const mode = dummy_mode();
+        const msz = new ModeSmoothZoom(mode);
+        msz.bufferFn = (cb) => cb();
+
+        msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+        msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+        msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
+        const move = touchEvent({ clientX: 52, clientY: 90, timeStamp: 120 });
+        msz._handleTapMove(move);
+
+        expect(mode.scale).toBe(1);
+        expect(mode.$visibleWorld.classList.contains('BRsmooth-zooming')).toBe(false);
+        // Doesn't fight the native gesture for it, either.
+        expect(move.preventDefault.callCount).toBe(0);
+      });
+
+      test('touchAction is not preemptively locked after a lone tap, since there is no zoom gesture to protect', () => {
+        sinon.stub(browserSniffing, 'isIOS').returns(true);
+        const mode = dummy_mode();
+        const msz = new ModeSmoothZoom(mode);
+        msz.bufferFn = (cb) => cb();
+
+        msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+        msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+
+        expect(mode.$container.style.touchAction).not.toBe('none');
+      });
+
+      test('a second tap still suppresses the first tap\'s deferred single-tap action (e.g. page flip)', async () => {
+        sinon.stub(browserSniffing, 'isIOS').returns(true);
+        const mode = dummy_mode();
+        const msz = new ModeSmoothZoom(mode);
+        msz.bufferFn = (cb) => cb();
+
+        msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+        await msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+        const resultPromise = msz.isSingleTap();
+
+        msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
+
+        await expect(resultPromise).resolves.toBe(false);
+      });
     });
 
     test('a lone tap locks touchAction to none, to block native panning if a second tap follows', async () => {

--- a/tests/jest/BookReader/ModeSmoothZoom.test.js
+++ b/tests/jest/BookReader/ModeSmoothZoom.test.js
@@ -147,6 +147,233 @@ describe('ModeSmoothZoom', () => {
     });
   });
 
+  describe("double-tap-and-drag zoom", () => {
+    /** @param {Partial<{clientX: number, clientY: number, timeStamp: number, pointerType: string, touches: any[]}>} overrides */
+    function touchEvent({ clientX = 0, clientY = 0, timeStamp = 0, pointerType = 'touch', touches = [{}] } = {}) {
+      return {
+        clientX,
+        clientY,
+        timeStamp,
+        pointerType,
+        originalEvent: { touches, preventDefault: sinon.spy() },
+        preventDefault: sinon.spy(),
+      };
+    }
+
+    test('drag down after a double-tap zooms in (matches Google Maps/Chrome)', () => {
+      const mode = dummy_mode();
+      const msz = new ModeSmoothZoom(mode);
+      msz.bufferFn = (cb) => cb();
+
+      // First tap
+      msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+      // Second tap, close in time/space -> double-tap candidate
+      msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
+      expect(mode.scale).toBe(1);
+      // Drag down (increasing clientY) engages the zoom and increases scale
+      msz._handleTapMove(touchEvent({ clientX: 52, clientY: 90, timeStamp: 120 }));
+      expect(mode.scale).toBeGreaterThan(1);
+
+      msz._handleTapUp(touchEvent({ clientX: 52, clientY: 90, timeStamp: 140 }));
+      expect(mode.$visibleWorld.classList.contains('BRsmooth-zooming')).toBe(false);
+    });
+
+    test('drag up after a double-tap zooms out (matches Google Maps/Chrome)', () => {
+      const mode = dummy_mode();
+      const msz = new ModeSmoothZoom(mode);
+      msz.bufferFn = (cb) => cb();
+
+      msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+      msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
+      msz._handleTapMove(touchEvent({ clientX: 52, clientY: 20, timeStamp: 120 }));
+
+      expect(mode.scale).toBeLessThan(1);
+    });
+
+    test('a lone tap locks touchAction to none, to block native panning if a second tap follows', () => {
+      const mode = dummy_mode();
+      const msz = new ModeSmoothZoom(mode);
+      msz.bufferFn = (cb) => cb();
+      expect(mode.$container.style.touchAction).not.toBe('none');
+
+      msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+
+      expect(mode.$container.style.touchAction).toBe('none');
+    });
+
+    test('preventDefault is called on the very first pixel of movement, before the drag-engage threshold', () => {
+      const mode = dummy_mode();
+      const msz = new ModeSmoothZoom(mode);
+      msz.bufferFn = (cb) => cb();
+
+      msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+      msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
+
+      // A tiny move, well under DOUBLE_TAP_DRAG_ENGAGE_PX -- the zoom hasn't
+      // engaged yet, but native panning must already be blocked so the
+      // browser can't commit to a scroll before the engage threshold is hit.
+      const tinyMove = touchEvent({ clientX: 52, clientY: 55, timeStamp: 110 });
+      msz._handleTapMove(tinyMove);
+
+      expect(tinyMove.preventDefault.callCount).toBe(1);
+      expect(mode.$visibleWorld.classList.contains('BRsmooth-zooming')).toBe(false);
+    });
+
+    test('touchAction is restored once the double-tap-drag ends', () => {
+      const mode = dummy_mode();
+      const msz = new ModeSmoothZoom(mode);
+      msz.bufferFn = (cb) => cb();
+      msz.baseTouchAction = 'pan-x pan-y';
+
+      msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+      msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
+      msz._handleTapMove(touchEvent({ clientX: 52, clientY: 20, timeStamp: 120 }));
+      expect(mode.$container.style.touchAction).toBe('none');
+
+      msz._handleTapUp(touchEvent({ clientX: 52, clientY: 20, timeStamp: 140 }));
+      expect(mode.$container.style.touchAction).toBe('pan-x pan-y');
+    });
+
+    test('touchAction is restored if a second tap never arrives (candidate window times out)', () => {
+      jest.useFakeTimers();
+      const mode = dummy_mode();
+      const msz = new ModeSmoothZoom(mode);
+      msz.bufferFn = (cb) => cb();
+      msz.baseTouchAction = 'pan-x pan-y';
+
+      msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+      expect(mode.$container.style.touchAction).toBe('none');
+
+      jest.advanceTimersByTime(1000);
+      expect(mode.$container.style.touchAction).toBe('pan-x pan-y');
+      jest.useRealTimers();
+    });
+
+    test('a stationary second tap does not change scale', () => {
+      const mode = dummy_mode();
+      const msz = new ModeSmoothZoom(mode);
+      msz.bufferFn = (cb) => cb();
+
+      msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+      msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
+      msz._handleTapUp(touchEvent({ clientX: 52, clientY: 52, timeStamp: 110 }));
+
+      expect(mode.scale).toBe(1);
+    });
+
+    test('taps far apart in time do not start a double-tap-drag', () => {
+      const mode = dummy_mode();
+      const msz = new ModeSmoothZoom(mode);
+      msz.bufferFn = (cb) => cb();
+
+      msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+      // Second tap arrives after the double-tap window
+      msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 1000 }));
+      msz._handleTapMove(touchEvent({ clientX: 52, clientY: 20, timeStamp: 1020 }));
+
+      expect(mode.scale).toBe(1);
+    });
+
+    test('mouse pointers do not trigger double-tap-drag', () => {
+      const mode = dummy_mode();
+      const msz = new ModeSmoothZoom(mode);
+      msz.bufferFn = (cb) => cb();
+
+      msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0, pointerType: 'mouse', touches: [] }));
+      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10, pointerType: 'mouse', touches: [] }));
+      msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100, pointerType: 'mouse', touches: [] }));
+      msz._handleTapMove(touchEvent({ clientX: 52, clientY: 20, timeStamp: 120, pointerType: 'mouse', touches: [] }));
+
+      expect(mode.scale).toBe(1);
+    });
+
+    test('a second finger touching down cancels an in-progress double-tap-drag', () => {
+      const mode = dummy_mode();
+      const msz = new ModeSmoothZoom(mode);
+      msz.bufferFn = (cb) => cb();
+
+      msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+      msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
+      msz._handleTapMove(touchEvent({ clientX: 52, clientY: 20, timeStamp: 120 }));
+      expect(mode.$visibleWorld.classList.contains('BRsmooth-zooming')).toBe(true);
+      const scaleWhenSecondFingerLands = mode.scale;
+
+      // A second finger touches down mid-gesture
+      msz._handleTapMove(touchEvent({ clientX: 52, clientY: 10, timeStamp: 130, touches: [{}, {}] }));
+
+      expect(mode.$visibleWorld.classList.contains('BRsmooth-zooming')).toBe(false);
+      expect(mode.scale).toBe(scaleWhenSecondFingerLands);
+    });
+
+    test('a double-tap-drag does not start while pinching', () => {
+      const mode = dummy_mode();
+      const msz = new ModeSmoothZoom(mode);
+      msz.bufferFn = (cb) => cb();
+      msz.pinching = true;
+
+      msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+      msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+      msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
+      msz._handleTapMove(touchEvent({ clientX: 52, clientY: 20, timeStamp: 120 }));
+
+      expect(mode.scale).toBe(1);
+    });
+
+    describe('runAfterTapResolved', () => {
+      test('runs fn immediately when there is no pending tap (e.g. a mouse click)', () => {
+        const mode = dummy_mode();
+        const msz = new ModeSmoothZoom(mode);
+        const fn = sinon.spy();
+
+        msz.runAfterTapResolved(fn);
+
+        expect(fn.callCount).toBe(1);
+      });
+
+      test('defers fn while a lone tap could still become a double-tap, and drops it if one arrives', () => {
+        jest.useFakeTimers();
+        const mode = dummy_mode();
+        const msz = new ModeSmoothZoom(mode);
+        const fn = sinon.spy();
+
+        msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+        msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+        msz.runAfterTapResolved(fn);
+        expect(fn.callCount).toBe(0);
+
+        // A second tap arrives in time -- the deferred action must never fire.
+        msz._handleTapDown(touchEvent({ clientX: 52, clientY: 52, timeStamp: 100 }));
+        jest.advanceTimersByTime(1000);
+        expect(fn.callCount).toBe(0);
+        jest.useRealTimers();
+      });
+
+      test('runs the deferred fn if no second tap arrives before the window elapses', () => {
+        jest.useFakeTimers();
+        const mode = dummy_mode();
+        const msz = new ModeSmoothZoom(mode);
+        const fn = sinon.spy();
+
+        msz._handleTapDown(touchEvent({ clientX: 50, clientY: 50, timeStamp: 0 }));
+        msz._handleTapUp(touchEvent({ clientX: 50, clientY: 50, timeStamp: 10 }));
+        msz.runAfterTapResolved(fn);
+
+        jest.advanceTimersByTime(1000);
+        expect(fn.callCount).toBe(1);
+        jest.useRealTimers();
+      });
+    });
+  });
+
   describe("updateViewportOnZoom", () => {
     test("adjusts scroll position when zooming in", () => {
       const mode = dummy_mode();


### PR DESCRIPTION
QA: https://deploy-preview-1591--ia-bookreader.netlify.app/bookreaderdemo/demo-internetarchive?ocaid=theworksofplato01platiala#page/n9/mode/2up

---

Double-tap-and-drag to zoom is a common interaction on mobile devices, allowing an easy one-handed alternative to pinch-zooming. First notably added to Google Maps, it has since become a standard throughout Android, and is now present in Chrome, Firefox, Drive PDF viewer, and now -- BookReader!

Here is how it works:

<img width="200" alt="Double-tap-and-drag to zoom helper graphic from Google Maps" src="https://github.com/user-attachments/assets/ef84b041-59ac-4be6-9b5b-e6a08318ce99" />

([src](https://support.google.com/maps/answer/6396990?hl=en&co=GENIE.Platform%3DAndroid#:~:text=Zoom%20in%20the%20map))

Note: plain double tapping currently does nothing ; this will be a future expansion in #1587 . This is a stepping stone to that feature.

Note: On iOS this doesn't seem to be as prevalent, but I do see it in Apple Maps -- although of course the direction was reversed -- dragging up zoomed in instead of our. I made BR reverse the direction for iOS as a result, but not sure... UPDATE: removed it from iOS ; it seems like iOS has another action for double-tap-drag ; text selection! So just disabled on iOS for now. UPDATE: Turned it on for iOS so folks can try it and we can discuss.